### PR TITLE
Add WindowProperties to App protocol

### DIFF
--- a/Examples/Counter/CounterApp.swift
+++ b/Examples/Counter/CounterApp.swift
@@ -10,7 +10,7 @@ struct CounterApp: App {
     
     let state = CounterState()
     
-    let windowTitle = "CounterApp"
+    let windowProperties = WindowProperties(title: "CounterApp")
     
     var body: some ViewContent {
         HStack {

--- a/Examples/Counter/CounterApp.swift
+++ b/Examples/Counter/CounterApp.swift
@@ -10,6 +10,8 @@ struct CounterApp: App {
     
     let state = CounterState()
     
+    let windowTitle = "CounterApp"
+    
     var body: some ViewContent {
         HStack {
             Button("-") { state.count -= 1 }

--- a/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
+++ b/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
@@ -16,7 +16,7 @@ struct RandomNumberGeneratorApp: App {
     
     var body: some ViewContent {
         VStack {
-            Text("") /// Placeholder until .padding() is available
+            Text("") // Placeholder until .padding() is available
             Text("Random Number: \(state.randomNumber)")
             Button("Generate") {
                 state.randomNumber = Int.random(in: state.minNum...state.maxNum)
@@ -35,7 +35,7 @@ struct RandomNumberGeneratorApp: App {
                 Button("+1") { state.maxNum += 1 }
                 Button("+5") { state.maxNum += 5 }
             }
-            Text("") /// Placeholder until .padding() is available
+            Text("") // Placeholder until .padding() is available
         }
     }
 }

--- a/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
+++ b/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
@@ -10,10 +10,11 @@ class RandomNumberGeneratorState: AppState {
 struct RandomNumberGeneratorApp: App {
     let identifier = "dev.stackotter.RandomNumberGeneratorApp"
     let state = RandomNumberGeneratorState()
+    let windowTitle = "Random Number Generator"
     
     var body: some ViewContent {
         VStack {
-            Text("") // Placeholder until padding is available
+            Text("") /// Placeholder until .padding() is available
             Text("Random Number: \(state.randomNumber)")
             Button("Generate") {
                 state.randomNumber = Int.random(in: state.minNum...state.maxNum)
@@ -32,7 +33,7 @@ struct RandomNumberGeneratorApp: App {
                 Button("+1") { state.maxNum += 1 }
                 Button("+5") { state.maxNum += 5 }
             }
-            Text("") // Placeholder until padding is available
+            Text("") /// Placeholder until .padding() is available
         }
     }
 }

--- a/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
+++ b/Examples/RandomNumberGenerator/RandomNumberGeneratorApp.swift
@@ -9,8 +9,10 @@ class RandomNumberGeneratorState: AppState {
 @main
 struct RandomNumberGeneratorApp: App {
     let identifier = "dev.stackotter.RandomNumberGeneratorApp"
+    
     let state = RandomNumberGeneratorState()
-    let windowTitle = "Random Number Generator"
+    
+    let windowProperties = WindowProperties(title: "Random Number Generator")
     
     var body: some ViewContent {
         VStack {

--- a/Examples/WindowProperties/WindowPropertiesApp.swift
+++ b/Examples/WindowProperties/WindowPropertiesApp.swift
@@ -1,0 +1,31 @@
+import SwiftCrossUI
+
+class WindowPropertiesAppState: AppState {
+    @Observed var count = 0
+}
+
+@main
+struct WindowPropertiesApp: App {
+    let identifier = "dev.stackotter.WindowPropertiesApp"
+    
+    let state = WindowPropertiesAppState()
+    
+    /// This example uses all available window properties to show how a window can be customized.
+    let windowProperties = WindowProperties(title: "WindowPropertiesApp",
+                                            defaultWidth: 500,
+                                            defaultHeight: 650,
+                                            resizable: false)
+    
+    var body: some ViewContent {
+        HStack {
+            VStack {
+                Text("") /// Placeholder until .padding() is available
+                Text("This is a window with a custom size.")
+                Text("This window also can't be resized.")
+                Text("") /// Placeholder until .padding() is available
+                Button("Click") { state.count += 1 }
+                Text("Count: \(state.count)")
+            }
+        }
+    }
+}

--- a/Examples/WindowProperties/WindowPropertiesApp.swift
+++ b/Examples/WindowProperties/WindowPropertiesApp.swift
@@ -11,18 +11,19 @@ struct WindowPropertiesApp: App {
     let state = WindowPropertiesAppState()
     
     /// This example uses all available window properties to show how a window can be customized.
-    let windowProperties = WindowProperties(title: "WindowPropertiesApp",
-                                            defaultWidth: 500,
-                                            defaultHeight: 650,
-                                            resizable: false)
+    let windowProperties = WindowProperties(
+        title: "WindowPropertiesApp",
+        defaultWidth: 500,
+        defaultHeight: 650,
+        resizable: false)
     
     var body: some ViewContent {
         HStack {
             VStack {
-                Text("") /// Placeholder until .padding() is available
+                Text("") // Placeholder until .padding() is available
                 Text("This is a window with a custom size.")
                 Text("This window also can't be resized.")
-                Text("") /// Placeholder until .padding() is available
+                Text("") // Placeholder until .padding() is available
                 Button("Click") { state.count += 1 }
                 Text("Count: \(state.count)")
             }

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,9 @@ let package = Package(
         .executable(
             name: "RandomNumberGeneratorExample",
             targets: ["RandomNumberGeneratorExample"]),
+        .executable(
+            name: "WindowPropertiesExample",
+            targets: ["WindowPropertiesExample"])
     ],
     dependencies: [
         .package(
@@ -42,5 +45,9 @@ let package = Package(
             name: "RandomNumberGeneratorExample",
             dependencies: ["SwiftCrossUI"],
             path: "Examples/RandomNumberGenerator"),
+        .executableTarget(
+            name: "WindowPropertiesExample",
+            dependencies: ["SwiftCrossUI"],
+            path: "Examples/WindowProperties")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ struct CounterApp: App {
     
     let state = CounterState()
     
+    let windowTitle = "CounterApp"
+    
     var body: some ViewContent {
         HStack {
             Button("-") { state.count -= 1 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To see all of the examples, run these commands:
 ```sh
 swift run CounterExample
 swift run RandomNumberGeneratorExample
+swift run WindowPropertiesExample
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ struct CounterApp: App {
     
     let state = CounterState()
     
-    let windowTitle = "CounterApp"
+    let windowProperties = WindowProperties(title: "CounterApp")
     
     var body: some ViewContent {
         HStack {

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -25,8 +25,8 @@ public class WindowProperties {
     public var defaultHeight: Int
     public var resizable: Bool
     
-    /// This custom initalizer is used because the default initializer has the 'internal' protect level and can't be accessed from other files.
-    /// The window's title is the only required value. All other values will use their defaults if not set.
+    /// This custom initalizer is used because the default initializer has the 'internal' protection level and can't be accessed from other files.
+    /// The window's title is the only required value. All other values will use the previously hard-coded values if not set.
     public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil)
     {
         self.title = title

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -27,8 +27,7 @@ public class WindowProperties {
     
     /// This custom initalizer is used because the default initializer has the 'internal' protection level and can't be accessed from other files.
     /// The window's title is the only required value. All other values will use the previously hard-coded values if not set.
-    public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil)
-    {
+    public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil) {
         self.title = title
         self.defaultWidth = defaultWidth ?? 200
         self.defaultHeight = defaultHeight ?? 150

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -10,13 +10,30 @@ public protocol App {
     var state: State { get }
     
     /// The window's properties.
-    var windowTitle: String { get }
+    var windowProperties: WindowProperties { get }
     
     /// The contents of the application's main window.
     @ViewContentBuilder var body: Content { get }
     
     /// Creates the application.
     init()
+}
+
+public class WindowProperties {
+    public var title: String
+    public var defaultWidth: Int
+    public var defaultHeight: Int
+    public var resizable: Bool
+    
+    /// This custom initalizer is used because the default initializer has the 'internal' protect level and can't be accessed from other files.
+    /// The window's title is the only required value. All other values will use their defaults if not set.
+    public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil)
+    {
+        self.title = title
+        self.defaultWidth = defaultWidth ?? 200
+        self.defaultHeight = defaultHeight ?? 150
+        self.resizable = resizable ?? true
+    }
 }
 
 public extension App {

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -9,6 +9,9 @@ public protocol App {
     /// The application's state.
     var state: State { get }
     
+    /// The window's properties.
+    var windowTitle: String { get }
+    
     /// The contents of the application's main window.
     @ViewContentBuilder var body: Content { get }
     

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -19,22 +19,6 @@ public protocol App {
     init()
 }
 
-public class WindowProperties {
-    public var title: String
-    public var defaultWidth: Int
-    public var defaultHeight: Int
-    public var resizable: Bool
-    
-    /// This custom initalizer is used because the default initializer has the 'internal' protection level and can't be accessed from other files.
-    /// The window's title is the only required value. All other values will use the previously hard-coded values if not set.
-    public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil) {
-        self.title = title
-        self.defaultWidth = defaultWidth ?? 200
-        self.defaultHeight = defaultHeight ?? 150
-        self.resizable = resizable ?? true
-    }
-}
-
 public extension App {
     /// Runs the application.
     static func main() {

--- a/Sources/SwiftCrossUI/WindowProperties.swift
+++ b/Sources/SwiftCrossUI/WindowProperties.swift
@@ -1,0 +1,16 @@
+/// The basic properties for a window.
+public struct WindowProperties {
+    public var title: String
+    public var defaultWidth: Int
+    public var defaultHeight: Int
+    public var resizable: Bool
+    
+    /// This custom initalizer is used because the default initializer has the 'internal' protection level and can't be accessed from other files.
+    /// The window's title is the only required value. All other values will use the previously hard-coded values if not set.
+    public init(title: String, defaultWidth: Int? = nil, defaultHeight: Int? = nil, resizable: Bool? = nil) {
+        self.title = title
+        self.defaultWidth = defaultWidth ?? 200
+        self.defaultHeight = defaultHeight ?? 150
+        self.resizable = resizable ?? true
+    }
+}

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -13,8 +13,9 @@ class _App<AppRoot: App> {
             /// The title of the window.
             window.title = self.app.windowProperties.title
             /// The default width and height of the window.
-            window.defaultSize = GtkSize(width: self.app.windowProperties.defaultWidth,
-                                         height: self.app.windowProperties.defaultHeight)
+            window.defaultSize = GtkSize(
+                width: self.app.windowProperties.defaultWidth,
+                height: self.app.windowProperties.defaultHeight)
             /// Whether or not the window's size can be changed.
             window.resizable = self.app.windowProperties.resizable
             

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -10,10 +10,13 @@ class _App<AppRoot: App> {
         let gtkApp = GtkApplication(applicationId: app.identifier)
         
         gtkApp.run { window in
-            window.title = self.app.windowTitle
-            //window.title = "Hello, world!"
-            window.defaultSize = GtkSize(width: 200, height: 150)
-            window.resizable = true
+            /// The title of the window.
+            window.title = self.app.windowProperties.title
+            /// The default width and height of the window.
+            window.defaultSize = GtkSize(width: self.app.windowProperties.defaultWidth,
+                                         height: self.app.windowProperties.defaultHeight)
+            /// Whether or not the window's size can be changed.
+            window.resizable = self.app.windowProperties.resizable
             
             self.viewGraph = ViewGraph(for: self.app)
             

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -10,7 +10,8 @@ class _App<AppRoot: App> {
         let gtkApp = GtkApplication(applicationId: app.identifier)
         
         gtkApp.run { window in
-            window.title = "Hello, world!"
+            window.title = self.app.windowTitle
+            //window.title = "Hello, world!"
             window.defaultSize = GtkSize(width: 200, height: 150)
             window.resizable = true
             


### PR DESCRIPTION
Allows defining window properties from your app.
Currently it has the following properties:

- `title`

- `defaultWidth`

- `defaultHeight`

- `resizable` 

`title` is required, while the other values are optional and default to the previously hard-coded values if not set.
