### PR TITLE
ForEach rework

### DIFF
--- a/Sources/Gtk/Widgets/Box.swift
+++ b/Sources/Gtk/Widgets/Box.swift
@@ -4,7 +4,7 @@
 
 import CGtk
 
-open class Box: Widget {
+open class Box: Widget, Orientable {
     var widgets: [Widget] = []
 
     public init(orientation: Orientation, spacing: Int) {

--- a/Sources/Gtk/Widgets/Grid.swift
+++ b/Sources/Gtk/Widgets/Grid.swift
@@ -12,7 +12,7 @@ import CGtk
 /// `attach(nextTo:sibling:side:width:height:)`. The behaviour of Grid when several children occupy
 /// the same grid cell is undefined. Grid can be used like a Box by just using `add(_:)`, which will
 /// place children next to each other in the direction determined by the "orientation" property.
-public class Grid: Widget {
+public class Grid: Widget, Orientable {
     var widgets: [Widget] = []
 
     override init() {

--- a/Sources/Gtk/Widgets/Orientable.swift
+++ b/Sources/Gtk/Widgets/Orientable.swift
@@ -1,0 +1,17 @@
+import CGtk
+
+public protocol Orientable: AnyObject {
+    var opaquePointer: OpaquePointer? { get }
+    var orientation: Orientation { get set }
+}
+
+extension Orientable {
+    public var orientation: Orientation {
+        get {
+            gtk_orientable_get_orientation(opaquePointer).toOrientation()
+        }
+        set {
+            gtk_orientable_set_orientation(opaquePointer, newValue.toGtkOrientation())
+        }
+    }
+}

--- a/Sources/Gtk/Widgets/SingleChildBox.swift
+++ b/Sources/Gtk/Widgets/SingleChildBox.swift
@@ -1,0 +1,40 @@
+import CGtk
+
+/// Helper Box that uses GtkBox under the hood but only allows one child. It returns its parents orientation.
+open class SingleChildBox: Widget, Orientable {
+    var child: Widget?
+
+    public override init() {
+        super.init()
+        widgetPointer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0)
+    }
+
+    /// This gets and sets the orientation of the parentWidget
+    ///
+    /// Some parents are not Orientable (ScrollableWindow, Window, Viewport, Stack) in which case this does nothing.
+    public var orientation: Orientation {
+        get {
+            (parentWidget as? Orientable)?.orientation ?? .vertical
+        }
+        set {
+            (parentWidget as? Orientable)?.orientation = newValue
+        }
+    }
+
+    /// This removes the previous child if it existed and shows the new child
+    ///
+    /// - Parameter newChild: The child to show, use `nil` to remove previous child
+    public func setOnlyChild(_ newChild: Widget?) {
+        if let child {
+            gtk_box_remove(castedPointer(), child.widgetPointer)
+            child.parentWidget = nil
+            self.child = nil
+        }
+
+        if let newChild {
+            self.child = newChild
+            newChild.parentWidget = self
+            gtk_box_append(castedPointer(), newChild.widgetPointer)
+        }
+    }
+}

--- a/Sources/SwiftCrossUI/Gtk/Gtk.swift
+++ b/Sources/SwiftCrossUI/Gtk/Gtk.swift
@@ -2,6 +2,8 @@ import Gtk
 
 public typealias GtkApplication = Gtk.Application
 public typealias GtkBox = Gtk.Box
+public typealias GtkSingleChildBox = Gtk.SingleChildBox
+public typealias GtkOrientable = Gtk.Orientable
 public typealias GtkSize = Gtk.Size
 public typealias GtkWidget = Gtk.Widget
 public typealias GtkButton = Gtk.Button

--- a/Sources/SwiftCrossUI/Views/EitherView.swift
+++ b/Sources/SwiftCrossUI/Views/EitherView.swift
@@ -78,16 +78,15 @@ public struct EitherView<A: View, B: View>: View {
         body = EitherViewContent(b)
     }
 
-    public func asWidget(_ children: EitherViewChildren<A, B>) -> GtkBox {
-        let box = GtkBox(orientation: .vertical, spacing: 0)
-        box.add(children.widgets[0])
+    public func asWidget(_ children: EitherViewChildren<A, B>) -> GtkSingleChildBox {
+        let box = GtkSingleChildBox()
+        box.setOnlyChild(children.widgets[0])
         return box
     }
 
-    public func update(_ widget: GtkBox, children: EitherViewChildren<A, B>) {
+    public func update(_ widget: GtkSingleChildBox, children: EitherViewChildren<A, B>) {
         if children.storage.hasSwitchedCase {
-            widget.removeAll()
-            widget.add(children.widgets[0])
+            widget.setOnlyChild(children.widgets[0])
         }
     }
 }

--- a/Sources/SwiftCrossUI/Views/ForEach.swift
+++ b/Sources/SwiftCrossUI/Views/ForEach.swift
@@ -24,6 +24,10 @@ where Items.Index == Int {
     }
 
     public func update(with content: Content) {
+        if let parent = storage.container.parentWidget as? GtkOrientable {
+            storage.container.orientation = parent.orientation
+        }
+
         for (i, node) in storage.nodes.enumerated() {
             guard i < content.elements.count else {
                 break

--- a/Sources/SwiftCrossUI/Views/ForegroundColorView.swift
+++ b/Sources/SwiftCrossUI/Views/ForegroundColorView.swift
@@ -10,18 +10,14 @@ public struct ForegroundColorView<Child: View>: View {
         self.color = color
     }
 
-    public func asWidget(_ children: ViewGraphNodeChildren1<Child>) -> GtkBox {
-        let box = GtkBox(orientation: .vertical, spacing: 0)
-        for widget in children.widgets {
-            box.add(widget)
-        }
-
+    public func asWidget(_ children: ViewGraphNodeChildren1<Child>) -> GtkSingleChildBox {
+        let box = GtkSingleChildBox()
+        box.setOnlyChild(children.child0.widget)
         box.setForegroundColor(color: color.gtkColor)
-
         return box
     }
 
-    public func update(_ widget: GtkBox, children: ViewGraphNodeChildren1<Child>) {
+    public func update(_ widget: GtkSingleChildBox, children: ViewGraphNodeChildren1<Child>) {
         widget.setForegroundColor(color: color.gtkColor)
     }
 }

--- a/Sources/SwiftCrossUI/Views/OptionalView.swift
+++ b/Sources/SwiftCrossUI/Views/OptionalView.swift
@@ -10,8 +10,7 @@ public struct OptionalViewChildren<V: View>: ViewGraphNodeChildren {
     let storage: Storage
 
     public var widgets: [GtkWidget] {
-        let arr = [storage.view?.widget].compactMap { $0 }
-        return arr
+        return [storage.view?.widget].compactMap { $0 }
     }
 
     public init(from content: Content) {
@@ -54,20 +53,15 @@ public struct OptionalView<V: View>: View {
         body = OptionalViewContent(view)
     }
 
-    public func asWidget(_ children: OptionalViewChildren<V>) -> GtkBox {
-        let box = GtkBox(orientation: .vertical, spacing: 0)
-        for widget in children.widgets {
-            box.add(widget)
-        }
+    public func asWidget(_ children: OptionalViewChildren<V>) -> GtkSingleChildBox {
+        let box = GtkSingleChildBox()
+        box.setOnlyChild(children.widgets.first)
         return box
     }
 
-    public func update(_ widget: GtkBox, children: OptionalViewChildren<V>) {
+    public func update(_ widget: GtkSingleChildBox, children: OptionalViewChildren<V>) {
         if children.storage.hasToggled {
-            widget.removeAll()
-            for child in children.widgets {
-                widget.add(child)
-            }
+            widget.setOnlyChild(children.widgets.first)
         }
     }
 }

--- a/Sources/SwiftCrossUI/Views/PaddingView.swift
+++ b/Sources/SwiftCrossUI/Views/PaddingView.swift
@@ -1,17 +1,15 @@
-public struct PaddingView<Content: ViewContent>: View {
-    public var body: Content
+public struct PaddingView<Child: View>: View {
+    public var body: ViewContent1<Child>
     public var padding: Padding
 
-    init(_ content: Content, _ padding: Padding) {
-        body = content
+    init(_ content: Child, _ padding: Padding) {
+        body = ViewContent1(content)
         self.padding = padding
     }
 
-    public func asWidget(_ children: Content.Children) -> GtkBox {
-        let box = GtkBox(orientation: .vertical, spacing: 0)
-        for widget in children.widgets {
-            box.add(widget)
-        }
+    public func asWidget(_ children: ViewGraphNodeChildren1<Child>) -> GtkSingleChildBox {
+        let box = GtkSingleChildBox()
+        box.setOnlyChild(children.child0.widget)
 
         box.topMargin = padding.top
         box.bottomMargin = padding.bottom
@@ -19,5 +17,12 @@ public struct PaddingView<Content: ViewContent>: View {
         box.rightMargin = padding.right
 
         return box
+    }
+
+    public func update(_ box: GtkSingleChildBox, children: ViewGraphNodeChildren1<Child>) {
+        box.topMargin = padding.top
+        box.bottomMargin = padding.bottom
+        box.leftMargin = padding.left
+        box.rightMargin = padding.right
     }
 }


### PR DESCRIPTION
Reworked Box usage across modifiers so ForEach can retrieve the correct orientation for its context.

Previously the following would create vertical items in swift-cross-ui while in SwiftUI it generates the views inside ForEach horizontally. 

```swift
HStack {
  ForEach(...) {
    ...
  }
}
```

This PR aligns our ForEach with Apples SwiftUI behaviour. From here on out if you want to wrap content (eg ModifierView) without caring about orientation, use `GtkSingleChildBox`.