### PR TITLE
Add new examples to documentation and categorize pages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,42 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AsyncExtensions",
-        "repositoryURL": "https://github.com/lhoward/AsyncExtensions",
-        "state": {
-          "branch": "linux",
-          "revision": "2218eaa30dbdb39b063e92644fc28ed22e2cb942",
-          "version": null
-        }
-      },
-      {
-        "package": "LVGL",
-        "repositoryURL": "https://github.com/PADL/LVGLSwift",
-        "state": {
-          "branch": null,
-          "revision": "19c19a942153b50d61486faf1d0d45daf79e7be5",
-          "version": null
-        }
-      },
-      {
-        "package": "Qlift",
-        "repositoryURL": "https://github.com/Longhanks/qlift",
-        "state": {
-          "branch": null,
-          "revision": "ddab1f1ecc113ad4f8e05d2999c2734cdf706210",
-          "version": null
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-          "version": "1.0.5"
-        }
-      },
-      {
         "package": "SwiftDocCPlugin",
         "repositoryURL": "https://github.com/apple/swift-docc-plugin",
         "state": {

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ import PackageDescription
 let package = Package(
   name: "Example",
   dependencies: [
-    .package(url: "https://github.com/stackotter/swift-cross-ui", .branch("main"))
+    .package(url: "https://github.com/stackotter/swift-cross-ui", branch: "main")
   ],
   targets: [
     .executableTarget(

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sed -i '' 's/-I..includedir.//g' $(brew --prefix)/Library/Homebrew/os/mac/pkgcon
 
 ### Linux: Installing Gtk 4 and Clang
 
-Install Gtk 4 and Clang using apt or the package manager of your choice. On most GNOME-based systems, Gtk should already be installed (although you should verify that it's Gtk 3).
+Install Gtk 4 and Clang using apt or the package manager of your choice. On most GNOME-based systems, Gtk should already be installed (although you should verify that it's Gtk 4).
 
 ```sh
 sudo apt install libgtk-4-dev clang

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Basic Usage.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Basic Usage.md
@@ -27,6 +27,7 @@ If you're on a Debian or Ubuntu-based Linux distro, you can use the following co
 ```
 sudo apt install libgtk-4-dev clang
 ```
+
 For Fedora:
 ```
 sudo dnf install gtk4-devel clang

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Basic Usage.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Basic Usage.md
@@ -27,6 +27,10 @@ If you're on a Debian or Ubuntu-based Linux distro, you can use the following co
 ```
 sudo apt install libgtk-4-dev clang
 ```
+For Fedora:
+```
+sudo dnf install gtk4-devel clang
+```
 
 If your distro uses a different package manager, the package names will likely be similar.
 
@@ -34,7 +38,7 @@ If your distro uses a different package manager, the package names will likely b
 
 To add SwiftCrossUI to your project, add the following dependency to your `Package.swift` file.
 ```swift
-.package(url: "https://github.com/stackotter/swift-cross-ui", .branch("main"))
+.package(url: "https://github.com/stackotter/swift-cross-ui", branch: "main")
 ```
 
 Here's an example package file that uses SwiftCrossUI.
@@ -44,7 +48,7 @@ import PackageDescription
 let package = Package(
   name: "Example",
   dependencies: [
-    .package(url: "https://github.com/stackotter/swift-cross-ui", .branch("main"))
+    .package(url: "https://github.com/stackotter/swift-cross-ui", branch: "main")
   ],
   targets: [
     .executableTarget(

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Examples.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Examples.md
@@ -12,6 +12,10 @@ A few examples are included with SwiftCrossUI to demonstrate some of it's basic 
 - `GreetingGeneratorExample`, a simple app demonstrating dynamic state and the ``ForEach`` view.
 - `FileViewerExample`, an app showcasing integration with the system's file chooser.
 - `NavigationExample`, an app showcasing ``NavigationStack`` and related concepts.
+- `SplitExample`, an app showcasing sidebar-based navigation with multiple levels.
+- `StressTestExample`, an app used to test view update performance.
+- `SpreadsheetExample`, an app showcasing tables.
+- `ControlsExample`, an app showcasing the various types of controls available.
 
 To run an example, either select the example under schemes at the top of the window (in Xcode), or run one of the following commands (if using a terminal):
 ```
@@ -21,4 +25,8 @@ swift run WindowPropertiesExample
 swift run GreetingGeneratorExample
 swift run FileViewerExample
 swift run NavigationExample
+swift run SpitExample
+swift run StressTestExample
+swift run SpreadsheetExample
+swift run ControlsExample
 ```

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
@@ -15,7 +15,7 @@ SwiftCrossUI implements a simple API similar but not identical to SwiftUI, allow
 
 ### App Structure
 
-The top level of your app
+The top level of your app.
 
 - ``App``
 - ``SceneBuilder``
@@ -23,9 +23,10 @@ The top level of your app
 
 ### Views
 
-SwiftCrossUI has a wide variety of views available that you can combine to create complex UIs.
+The wide variety of views available that you can combine to create complex UIs.
 
 - ``Button``
+- ``CellPosition``
 - ``Color``
 - ``ForEach``
 - ``HStack``
@@ -44,9 +45,12 @@ SwiftCrossUI has a wide variety of views available that you can combine to creat
 - ``TextField``
 - ``Toggle``
 - ``View``
+- ``ViewContent``
 - ``VStack``
 
 ### States
+
+Objects that are read from and/or written to as part of your app.
 
 - ``AppState``
 - ``Binding``
@@ -61,7 +65,14 @@ SwiftCrossUI has a wide variety of views available that you can combine to creat
 
 ### Implementation Details
 
+The detailed components that are part of the low level of SwiftCrossUI.
+
 - ``AnyViewGraphNode``
+- ``EitherView``
+- ``EmptyView``
+- ``EmptyViewGraphNodeChildren``
+- ``OptionalView``
+- ``TableBuilder``
 - ``ViewGraph``
 - ``ViewGraphNode``
 - ``ViewGraphNodeChildren``

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
@@ -4,7 +4,7 @@ Create cross-platform desktop apps for macOS, Linux and Windows.
 
 ## Overview
 
-SwiftCrossUI implements a simple API similar but not identical to SwiftUI, allowing you to use the basic concepts of SwiftUI to create a cross-platofrm desktop app. SwiftCrossUI runs on SwiftGTK, a Swift wrapper for GTK+.
+SwiftCrossUI implements a simple API similar but not identical to SwiftUI, allowing you to use the basic concepts of SwiftUI to create a cross-platofrm desktop app. SwiftCrossUI is designed to be flexible and can work with different backends, but has a focus on using GTK+ through SwiftGTK.
 
 ## Topics
 

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
@@ -12,3 +12,56 @@ SwiftCrossUI implements a simple API similar but not identical to SwiftUI, allow
 
 - <doc:Basic-Usage>
 - <doc:Examples>
+
+### App Structure
+
+The top level of your app
+
+- ``App``
+- ``SceneBuilder``
+- ``ViewBuilder``
+
+### Views
+
+SwiftCrossUI has a wide variety of views available that you can combine to create complex UIs.
+
+- ``Button``
+- ``Color``
+- ``ForEach``
+- ``HStack``
+- ``Image``
+- ``NavigationLink``
+- ``NavigationPath``
+- ``NavigationSplitView``
+- ``NavigationStack``
+- ``Picker``
+- ``ScrollView``
+- ``Slider``
+- ``Spacer``
+- ``Table``
+- ``TableColumn``
+- ``Text``
+- ``TextField``
+- ``Toggle``
+- ``View``
+- ``VStack``
+
+### States
+
+- ``AppState``
+- ``Binding``
+- ``Cancellable``
+- ``EmptyAppState``
+- ``EmptyState``
+- ``EmptyViewState``
+- ``Observable``
+- ``Observed``
+- ``Publisher``
+- ``ViewState``
+
+### Implementation Details
+
+- ``AnyViewGraphNode``
+- ``ViewGraph``
+- ``ViewGraphNode``
+- ``ViewGraphNodeChildren``


### PR DESCRIPTION
Added the following examples to `Examples.md` and wrote a short description for each:
- SpitExample
- StressTestExample
- SpreadsheetExample
- ControlsExample

Categorized documentation pages. Currently using the categories `App Structure` (Apple's name for that category), `Views`, `States`, and `Implementation Details`. Descriptions for most of those categories are missing at the moment.

Some small changes to the overview of SwiftCrossUI and the README were also made, namely changing the formatting of the package import because its changed slightly since they were written, and touching up some wording here and there.