### PR TITLE
Make all products/targets visible to consumers.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "Qlift",
-        "repositoryURL": "https://github.com/Longhanks/qlift",
-        "state": {
-          "branch": null,
-          "revision": "ddab1f1ecc113ad4f8e05d2999c2734cdf706210",
-          "version": null
-        }
-      },
-      {
         "package": "swift-collections",
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
+          "revision": "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+          "version": "1.1.0"
         }
       },
       {


### PR DESCRIPTION
**The Problem**

> error: target `GtkBackend` does not exist in package `swift-cross-ui`.

The way to prevent this error from happening is for _consuming users_ to implement something like the following to reference **swift-cross-ui** in their own **Package.swift** manifests in a way that doesn't break a user's existing **SwiftPM** package:

```swift
public static func pkgDeps() -> [Package.Dependency]
{
  #if os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD) || os(Windows) || os(Cygwin)
    [
      .package(url: "https://github.com/stackotter/swift-cross-ui", revision: "dd09e61")
    ]
  #else
    []
  #endif
}

public static func backend() -> [Target.Dependency]
{
  #if os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD) || os(Windows) || os(Cygwin)
    [
      .product(name: "SwiftCrossUI", package: "swift-cross-ui", condition: .when(platforms: [.linux, .windows])),
      .product(name: "GtkBackend", package: "swift-cross-ui", condition: .when(platforms: [.linux, .windows])),
    ]
  #else
    []
  #endif
}
```

**The Solution**

* This revision attempts to make it easier for consuming packages which rely on **swift-cross-ui** as a package dependency to conditionally apply targets based on the OS platform, without having to preprocess the various backends in their own Package.swift manifest files, the preprocessing workaround is exampled above.

**Use Case**

Now in my own **SwiftPM** project I can do the following without inducing the error noted above:

```swift
  // maintaining the "standard" method of adding SwiftPM dependencies
  // to an existing SwiftPM project is what is demonstrated here.

  ...
  dependencies: [
    .package(url: "https://github.com/furby-tm/swift-cross-ui", revision: "a26353e")
  ],
  targets: [
    .executableTarget(
      name: "MyReallyEpicCrossPlatformApp",
      dependencies: [
        .product(name: "SwiftCrossUI", package: "swift-cross-ui", condition: .when(platforms: [.linux, .windows])),
        .product(name: "GtkBackend", package: "swift-cross-ui", condition: .when(platforms: [.linux, .windows])),
      ]
    ),
  ]
```

**Potential Drawback**

You will now have to preprocess all backend-dependent Swift code in **swift-cross-ui** if you wish to be able to build the _whole package_ (`swift build`) (now that specifying a _specific target_ is a prerequisite (`swift build --target GtkBackend`)) like the following:
```swift
// for any file that uses anything from 'Gtk'.
#if canImport(Gtk)
  import Gtk

  // many lines of swift code.
  // many lines of swift code.
  // many lines of swift code.
  // many lines of swift code.
#endif /* canImport(Gtk) */
```

However, it appears that supporting `swift build` to "target" the whole package was not something that was working anyway from the latest **SPI** [build results](https://swiftpackageindex.com/builds/00C4697B-3832-4803-BC4C-BDB953B7327A), so this drawback seems unsubstantial.