### PR TITLE
Fix build errors when running examples using WinUIBackend

### DIFF
--- a/Examples/Sources/SelectedBackend/SelectedBackend.swift
+++ b/Examples/Sources/SelectedBackend/SelectedBackend.swift
@@ -13,6 +13,9 @@
 #elseif canImport(LVGLBackend)
     import LVGLBackend
     public typealias SelectedBackend = LVGLBackend
+#elseif canImport(WinUIBackend)
+    import WinUIBackend
+    public typealias SelectedBackend = WinUIBackend
 #else
     #error("Unknown backend selected")
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ var swift510Products: [Product] = []
         .target(
             name: "WinUIBackend",
             dependencies: [
+                "SwiftCrossUI",
                 .product(name: "WinUI", package: "swift-winui"),
                 .product(name: "WinAppSDK", package: "swift-windowsappsdk"),
                 .product(name: "WindowsFoundation", package: "swift-windowsfoundation"),

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -20,6 +20,10 @@ class WinRTApplication: SwiftApplication {
     }
 }
 
+extension App {
+    public typealias Backend = WinUIBackend
+}
+
 public struct WinUIBackend: AppBackend {
     public typealias Window = WinUI.Window
     public typealias Widget = WinUI.FrameworkElement


### PR DESCRIPTION
Example apps that didn't specify the `Backend` typealias were failing under `WinUIBackend` because it didn't have a default value.

See https://github.com/stackotter/swift-cross-ui/commit/26627bdd148ea53e4dab70af823fff577836c409 which removed need for explicit backend typealias in all backends except for `WinUIBackend`