### PR TITLE
More native UIKit features

### DIFF
--- a/Sources/UIKitBackend/UIKitBackend.swift
+++ b/Sources/UIKitBackend/UIKitBackend.swift
@@ -20,6 +20,13 @@ public final class UIKitBackend: AppBackend {
     public let defaultTableCellVerticalPadding = -1
 
     var onTraitCollectionChange: (() -> Void)?
+
+    private let appDelegateClass: ApplicationDelegate.Type
+
+    public init(appDelegateClass: ApplicationDelegate.Type = ApplicationDelegate.self) {
+        self.appDelegateClass = appDelegateClass
+    }
+
     public func runMainLoop(
         _ callback: @escaping () -> Void
     ) {
@@ -31,7 +38,7 @@ public final class UIKitBackend: AppBackend {
             CommandLine.argc,
             CommandLine.unsafeArgv,
             NSStringFromClass(UIApplication.self),
-            NSStringFromClass(ApplicationDelegate.self)
+            NSStringFromClass(appDelegateClass)
         )
     }
 
@@ -97,8 +104,33 @@ extension App {
     }
 }
 
-class ApplicationDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow? {
+/// The root class for application delegates of SwiftCrossUI apps.
+///
+/// In order to use a custom application delegate, pass your class to ``UIKitBackend/init(appDelegateClass:)``:
+///
+/// ```swift
+/// import SwiftCrossUI
+/// import UIKitBackend
+///
+/// class MyAppDelegate: ApplicationDelegate {
+///     // UIApplicationDelegate methods here
+/// }
+///
+/// @main
+/// struct SwiftCrossUI_TestApp: App {
+///     var backend: UIKitBackend {
+///         UIKitBackend(appDelegateClass: MyAppDelegate.self)
+///     }
+///
+///     var body: some Scene {
+///         WindowGroup {
+///             // View code here
+///         }
+///     }
+/// }
+/// ```
+open class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    public var window: UIWindow? {
         get {
             UIKitBackend.mainWindow
         }
@@ -107,7 +139,16 @@ class ApplicationDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {
+    public required override init() {
+        super.init()
+    }
+
+    /// Tells the delegate that the app has become active.
+    ///
+    /// - Important: If you override this method in a subclass, you must call
+    /// `super.applicationDidBecomeActive(application)` as the first step of your
+    /// implementation.
+    open func applicationDidBecomeActive(_ application: UIApplication) {
         UIKitBackend.onBecomeActive?()
 
         // We only want to notify the first time. Otherwise the app's view
@@ -116,7 +157,14 @@ class ApplicationDelegate: UIResponder, UIApplicationDelegate {
         UIKitBackend.onBecomeActive = nil
     }
 
-    func application(
+    /// Tells the delegate that the launch process is almost done and the app is almost ready
+    /// to run.
+    ///
+    /// If you override this method in a subclass, you should call
+    /// `super.application(application, didFinishLaunchingWithOptions: launchOptions)`
+    /// at some point in your implementation. You do not necessarily have to return the same
+    /// value as this `super` call.
+    open func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
@@ -129,7 +177,13 @@ class ApplicationDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func application(
+    /// Asks the delegate to open a resource specified by a URL, and provides a dictionary of launch options.
+    ///
+    /// If you override this method in a subclass, you should call
+    /// `super.application(app, open: url, options: options` at some point in your
+    /// implementation. You do not necessarily have to return the same value as this `super`
+    /// call.
+    open func application(
         _ app: UIApplication,
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]

--- a/Sources/UIKitBackend/UIViewRepresentable.swift
+++ b/Sources/UIKitBackend/UIViewRepresentable.swift
@@ -1,0 +1,195 @@
+import SwiftCrossUI
+import UIKit
+
+public struct UIViewRepresentableContext<Coordinator> {
+    public let coordinator: Coordinator
+    public internal(set) var environment: EnvironmentValues
+}
+
+public protocol UIViewRepresentable: View
+where Content == Never {
+    associatedtype UIViewType: UIView
+    associatedtype Coordinator = Void
+
+    /// Create the initial UIView instance.
+    func makeUIView(context: UIViewRepresentableContext<Coordinator>) -> UIViewType
+
+    /// Update the view with new values.
+    /// - Parameters:
+    ///   - uiView: The view to update.
+    ///   - context: The context, including the coordinator and potentially new environment
+    ///   values.
+    /// - Note: This may be called even when `context` has not changed.
+    func updateUIView(_ uiView: UIViewType, context: UIViewRepresentableContext<Coordinator>)
+
+    /// Make the coordinator for this view.
+    ///
+    /// The coordinator is used when the view needs to communicate changes to the rest of
+    /// the view hierarchy (i.e. through bindings), and is often the view's delegate.
+    func makeCoordinator() -> Coordinator
+
+    /// Compute the view's preferred size.
+    /// - Parameters:
+    ///   - proposal: The proposed frame for the view to render in.
+    ///   - uiVIew: The view being queried for its preferred size.
+    ///   - context: The context, including the coordinator and environment values.
+    /// - Returns: The preferred size for the view, ideally one that fits within `proposal`,
+    /// or `nil` to use a default size for this view.
+    func sizeThatFits(
+        _ proposal: CGSize, uiView: UIViewType, context: UIViewRepresentableContext<Coordinator>
+    ) -> CGSize?
+
+    /// Called to clean up the view when it's removed.
+    /// - Parameters:
+    ///   - uiVIew: The view being queried for its preferred size.
+    ///   - coordinator: The coordinator.
+    ///
+    /// The default implementation does nothing.
+    static func dismantleUIView(_ uiView: UIViewType, coordinator: Coordinator)
+}
+
+extension UIViewRepresentable {
+    public static func dismantleUIView(_: UIViewType, coordinator _: Coordinator) {
+        // no-op
+    }
+
+    public func sizeThatFits(
+        _ proposal: CGSize, uiView: UIViewType, context _: UIViewRepresentableContext<Coordinator>
+    ) -> CGSize? {
+        // For many growable views, such as WKWebView, sizeThatFits just returns the current
+        // size -- which is 0 x 0 on first render. So, check if the view can grow to fill
+        // the available space first.
+        let intrinsicContentSize = uiView.intrinsicContentSize
+        if intrinsicContentSize.width < 0.0 || intrinsicContentSize.height < 0.0 {
+            return nil
+        }
+        return uiView.sizeThatFits(proposal)
+    }
+}
+
+extension View
+where Self: UIViewRepresentable {
+    public var body: Never {
+        preconditionFailure("This should never be called")
+    }
+
+    public func children<Backend: AppBackend>(
+        backend _: Backend,
+        snapshots _: [ViewGraphSnapshotter.NodeSnapshot]?,
+        environment _: EnvironmentValues
+    ) -> any ViewGraphNodeChildren {
+        EmptyViewChildren()
+    }
+
+    public func layoutableChildren<Backend: AppBackend>(
+        backend _: Backend,
+        children _: any ViewGraphNodeChildren
+    ) -> [LayoutSystem.LayoutableChild] {
+        []
+    }
+
+    public func asWidget<Backend: AppBackend>(
+        _: any ViewGraphNodeChildren,
+        backend _: Backend
+    ) -> Backend.Widget {
+        if let widget = RepresentingWidget(representable: self) as? Backend.Widget {
+            return widget
+        } else {
+            fatalError("UIViewRepresentable requested by \(Backend.self)")
+        }
+    }
+
+    public func update<Backend: AppBackend>(
+        _ widget: Backend.Widget,
+        children _: any ViewGraphNodeChildren,
+        proposedSize: SIMD2<Int>,
+        environment: EnvironmentValues,
+        backend _: Backend,
+        dryRun: Bool
+    ) -> ViewUpdateResult {
+        let representingWidget = widget as! RepresentingWidget<Self>
+        representingWidget.updateContext(environment: environment)
+
+        let preferredSize =
+            representingWidget.representable.sizeThatFits(
+                CGSize(width: proposedSize.x, height: proposedSize.y),
+                uiView: representingWidget.subview,
+                context: representingWidget.context!
+            ) ?? representingWidget.subview.intrinsicContentSize
+
+        let roundedSize = SIMD2(
+            Int(preferredSize.width.rounded(.awayFromZero)),
+            Int(preferredSize.height.rounded(.awayFromZero)))
+
+        // Not only does -1 x -1 mean "grow to fill", UIKit allows you to return -1 for only one axis!
+        let size = ViewSize(
+            size: SIMD2(
+                roundedSize.x < 0 ? proposedSize.x : min(proposedSize.x, roundedSize.x),
+                roundedSize.y < 0 ? proposedSize.y : min(proposedSize.y, roundedSize.y)
+            ),
+            idealSize: SIMD2(
+                roundedSize.x < 0 ? proposedSize.x : roundedSize.x,
+                roundedSize.y < 0 ? proposedSize.y : roundedSize.y
+            ),
+            minimumWidth: roundedSize.x > proposedSize.x ? roundedSize.x : 0,
+            minimumHeight: roundedSize.y > proposedSize.y ? roundedSize.y : 0,
+            maximumWidth: nil,
+            maximumHeight: nil
+        )
+
+        if !dryRun {
+            representingWidget.width = size.size.x
+            representingWidget.height = size.size.y
+        }
+
+        return ViewUpdateResult.leafView(size: size)
+    }
+}
+
+extension UIViewRepresentable
+where Coordinator == Void {
+    public func makeCoordinator() {
+        return ()
+    }
+}
+
+final class RepresentingWidget<Representable: UIViewRepresentable>: BaseWidget {
+    var representable: Representable
+    var context: UIViewRepresentableContext<Representable.Coordinator>?
+
+    lazy var subview: Representable.UIViewType = {
+        let view = representable.makeUIView(context: context!)
+
+        self.addSubview(view)
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
+
+        return view
+    }()
+
+    func updateContext(environment: EnvironmentValues) {
+        if context == nil {
+            context = .init(coordinator: representable.makeCoordinator(), environment: environment)
+        } else {
+            context!.environment = environment
+            representable.updateUIView(subview, context: context!)
+        }
+    }
+
+    init(representable: Representable) {
+        self.representable = representable
+        super.init()
+    }
+
+    deinit {
+        if let context {
+            Representable.dismantleUIView(subview, coordinator: context.coordinator)
+        }
+    }
+}


### PR DESCRIPTION
Including custom application delegates and `UIViewRepresentable`. The context type is different from SwiftUI but the `UIViewRepresentable` protocol is otherwise the same.

I'm really unsure about the size calculation code so I would appreciate guidance on that.