### PR TITLE
Fix basic AppKitBackend layout test in CI

### DIFF
--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -40,6 +40,7 @@ jobs:
       run: swift test --test-product swift-cross-uiPackageTests
     - name: Upload snapshot
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: snapshot
         path: snapshot.tiff

--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -38,3 +38,8 @@ jobs:
         swift build --target GtkExample
     - name: Test
       run: swift test --test-product swift-cross-uiPackageTests
+    - name: Upload snapshot
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapshot
+        path: snapshot.tiff

--- a/.github/workflows/swift-macos.yml
+++ b/.github/workflows/swift-macos.yml
@@ -38,9 +38,3 @@ jobs:
         swift build --target GtkExample
     - name: Test
       run: swift test --test-product swift-cross-uiPackageTests
-    - name: Upload snapshot
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: snapshot
-        path: snapshot.tiff

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -1402,6 +1402,16 @@ class NSSplitViewResizingDelegate: NSObject, NSSplitViewDelegate {
 public class NSCustomWindow: NSWindow {
     var resizeDelegate = ResizeDelegate()
 
+    /// Allows the backing scale factor to be overridden. Useful for keeping
+    /// UI tests consistent across devices.
+    ///
+    /// Idea from https://github.com/pointfreeco/swift-snapshot-testing/pull/533
+    public var backingScaleFactorOverride: CGFloat?
+
+    public override var backingScaleFactor: CGFloat {
+        backingScaleFactorOverride ?? super.backingScaleFactor
+    }
+
     class ResizeDelegate: NSObject, NSWindowDelegate {
         var resizeHandler: ((SIMD2<Int>) -> Void)?
 

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -68,6 +68,12 @@ final class SwiftCrossUITests: XCTestCase {
         func testBasicLayout() throws {
             let backend = AppKitBackend()
             let window = backend.createWindow(withDefaultSize: SIMD2(200, 200))
+
+            // Idea taken from https://github.com/pointfreeco/swift-snapshot-testing/pull/533
+            // and implemented in AppKitBackend.
+            window.backingScaleFactorOverride = 1
+            window.colorSpace = .genericRGB
+
             let environment = EnvironmentValues(backend: backend)
                 .with(\.window, window)
             let viewGraph = ViewGraph(
@@ -86,11 +92,9 @@ final class SwiftCrossUITests: XCTestCase {
             backend.setSize(of: view, to: result.size.size)
             backend.setSize(ofWindow: window, to: result.size.size)
 
-            try Self.snapshotView(view).write(to: URL(fileURLWithPath: "snapshot.tiff"))
-
             XCTAssertEqual(
                 result.size,
-                ViewSize(fixedSize: SIMD2(94, 95)),
+                ViewSize(fixedSize: SIMD2(88, 95)),
                 "View update result mismatch"
             )
 

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -86,6 +86,8 @@ final class SwiftCrossUITests: XCTestCase {
             backend.setSize(of: view, to: result.size.size)
             backend.setSize(ofWindow: window, to: result.size.size)
 
+            try Self.snapshotView(view).write(to: URL(fileURLWithPath: "snapshot.tiff"))
+
             XCTAssertEqual(
                 result.size,
                 ViewSize(fixedSize: SIMD2(94, 95)),
@@ -96,7 +98,6 @@ final class SwiftCrossUITests: XCTestCase {
                 result.preferences.onOpenURL == nil,
                 "onOpenURL not nil"
             )
-
         }
 
         static func snapshotView(_ view: NSView) throws -> Data {


### PR DESCRIPTION
After debugging the CI, I discovered that the CI renders at 1x scale instead of 2x scale (retina). This causes the text to get kerned differently and ends up changing the layout in ways that can't be adjusted for by just dividing by two.

This PR is based off ideas from https://github.com/pointfreeco/swift-snapshot-testing/pull/533

The fix was to override the `backingScaleFactor` of `NSWindow` to `1.0` from a subclass. I also overrode the color space while I was at it just in case.