### PR TITLE
Added AlertAction public initializer

### DIFF
--- a/Sources/SwiftCrossUI/Modifiers/AlertAction.swift
+++ b/Sources/SwiftCrossUI/Modifiers/AlertAction.swift
@@ -9,4 +9,11 @@ public struct AlertAction {
 
     public var label: String
     public var action: () -> Void
+
+    public init(
+        label: String, 
+        action: @escaping () -> Void) {
+        self.label = label
+        self.action = action
+    }
 }


### PR DESCRIPTION
Added `public` `AlertAction` initializer.
I don't know if there was a specific reason behind it, but the `AlertAction` initializer was missing there was only a default `.ok`.