### PR TITLE
Get rid of "apple" vs "swiftlang" package resolution warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "55a84247053982279804c20f6120f043f327ebac8c19e5ce749978c828726b2e",
+  "originHash" : "43ca7a91f2d39258c4f0e5b38b0266ccb3d8f34249b6f5babf0cdb298c962064",
   "pins" : [
     {
       "identity" : "jpeg",
@@ -40,7 +40,7 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
         "version" : "1.4.3"
@@ -76,7 +76,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -82,11 +82,11 @@ let package = Package(
             from: "0.17.1"
         ),
         .package(
-            url: "https://github.com/apple/swift-docc-plugin",
+            url: "https://github.com/swiftlang/swift-docc-plugin",
             from: "1.0.0"
         ),
         .package(
-            url: "https://github.com/apple/swift-syntax.git",
+            url: "https://github.com/swiftlang/swift-syntax.git",
             from: "600.0.0"
         ),
         .package(


### PR DESCRIPTION
change "apple" dependencies to "swiftlang" to get rid of these warnings

`warning: 'swift-cross-ui': 'swift-cross-ui' dependency on 'https://github.com/apple/swift-syntax.git' conflicts with dependency on 'https://github.com/swiftlang/swift-syntax.git' which has the same identity 'swift-syntax'. this will be escalated to an error in future versions of SwiftPM.`