### PR TITLE
Fix deprecation warning in WindowingApp example

### DIFF
--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -76,7 +76,7 @@ struct WindowingApp: App {
                 VStack {
                     HStack {
                         Text("Window title:")
-                        TextField("My window", $title)
+                        TextField("My window", text: $title)
                     }
 
                     Button(resizable ? "Disable resizing" : "Enable resizing") {


### PR DESCRIPTION
```swift
macro expansion #hotReloadable:5:25: warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
`- /home/*****/swift-cross-ui/Examples/Sources/WindowingExample/WindowingApp.swift:97:14: note: expanded code originates here
 95 |                 }
 96 |                 .padding(20)
 97 |             }
    +--- macro expansion #hotReloadable --------------------------------
    | 3 |                     HStack {
    | 4 |                         Text("Window title:")
    | 5 |                         TextField("My window", $title)
    |   |                         |- warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
    |   |                         `- note: use 'TextField.init(_:text:)' instead
    | 6 |                     }
    | 7 | 
    +-------------------------------------------------------------------
 98 |         }
 99 |         .defaultSize(width: 500, height: 500)
```