### PR TITLE
Fix deprecation warning in GreetingGeneratorExample

### DIFF
--- a/Examples/Sources/GreetingGeneratorExample/GreetingGeneratorApp.swift
+++ b/Examples/Sources/GreetingGeneratorExample/GreetingGeneratorApp.swift
@@ -15,7 +15,7 @@ struct GreetingGeneratorApp: App {
         WindowGroup("Greeting Generator") {
             #hotReloadable {
                 VStack {
-                    TextField("Name", $name)
+                    TextField("Name", text: $name)
                     HStack {
                         Button("Generate") {
                             greetings.append("Hello, \(name)!")


### PR DESCRIPTION
```swift
macro expansion #hotReloadable:3:21: warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
`- /home/****/swift-cross-ui/Examples/Sources/GreetingGeneratorExample/GreetingGeneratorApp.swift:47:14: note: expanded code originates here
45 |                 }
46 |                 .padding(10)
47 |             }
   +--- macro expansion #hotReloadable ---------------------------------
   | 1 | SwiftCrossUI.HotReloadableView {
   | 2 |                 VStack {
   | 3 |                     TextField("Name", $name)
   |   |                     |- warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
   |   |                     `- note: use 'TextField.init(_:text:)' instead
   | 4 |                     HStack {
   | 5 |                         Button("Generate") {
   +--------------------------------------------------------------------
48 |         }
49 |     }

/home/*****swift-cross-ui/Examples/Sources/GreetingGeneratorExample/GreetingGeneratorApp.swift:18:21: warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
16 |             #hotReloadable {
17 |                 VStack {
18 |                     TextField("Name", $name)
   |                     |- warning: 'init(_:_:)' is deprecated: Use TextField(_:text:) instead
   |                     `- note: use 'TextField.init(_:text:)' instead
19 |                     HStack {
20 |                         Button("Generate") {
```
