### PR TITLE
GtkBackend,Gtk3Backend: Implement main run loop tickler (fixes #140)

### DIFF
--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -87,7 +87,9 @@ public final class Gtk3Backend: AppBackend {
                 guint(GTK_STYLE_PROVIDER_PRIORITY_APPLICATION)
             )
 
-            Self.mainRunLoopTicklingLoop()
+            #if !os(macOS)
+                Self.mainRunLoopTicklingLoop()
+            #endif
         }
     }
 

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -63,6 +63,20 @@ public final class GtkBackend: AppBackend {
         gtkApp.run { window in
             self.precreatedWindow = window
             callback()
+
+            Self.mainRunLoopTicklingLoop()
+        }
+    }
+
+    private static func mainRunLoopTicklingLoop(nextDelayMilliseconds: Int? = nil) {
+        Self.runInMainThread(afterMilliseconds: nextDelayMilliseconds ?? 50) {
+            let nextDate = RunLoop.main.limitDate(forMode: .default)
+            // This isn't expected to be nil, but if it is we can just loop
+            // again quickly with the default delay.
+            let nextDelay = nextDate.map {
+                return max(min(Int($0.timeIntervalSinceNow * 1000), 50), 0)
+            }
+            mainRunLoopTicklingLoop(nextDelayMilliseconds: nextDelay)
         }
     }
 
@@ -286,6 +300,28 @@ public final class GtkBackend: AppBackend {
                     .takeUnretainedValue()
                 action.action()
 
+                return 0
+            },
+            Unmanaged<ThreadActionContext>.passRetained(action).toOpaque(),
+            { _ in }
+        )
+    }
+
+    private static func runInMainThread(afterMilliseconds delay: Int, action: @escaping () -> Void) {
+        let action = ThreadActionContext(action: action)
+        g_timeout_add_full(
+            0,
+            guint(max(delay, 0)),
+            { context in
+                guard let context = context else {
+                    fatalError("Gtk action callback called without context")
+                }
+
+                let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
+                    .takeUnretainedValue()
+                action.action()
+
+                // Cancel the recurring timeout after one iteration
                 return 0
             },
             Unmanaged<ThreadActionContext>.passRetained(action).toOpaque(),

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -64,7 +64,9 @@ public final class GtkBackend: AppBackend {
             self.precreatedWindow = window
             callback()
 
-            Self.mainRunLoopTicklingLoop()
+            #if !os(macOS)
+                Self.mainRunLoopTicklingLoop()
+            #endif
         }
     }
 


### PR DESCRIPTION
Implements a 'main run loop tickler' that periodically services the main run loop. Enables the use of `@MainActor` and `DispatchQueue.main` under Gtk on non-Apple platforms (gtk already services the main run loop on macOS).