### PR TITLE
Use modern Swift on latest Windows CI

### DIFF
--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -58,6 +58,6 @@ jobs:
     - name: Build SwiftCrossUI
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/${{ steps.triplet.outputs.lowercase }}/lib/pkgconfig
-      run: swift build -v
+      run: swift build --target SwiftCrossUI -v
     - name: Build WinUIBackend
       run: swift build --target WinUIBackend

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -22,7 +22,7 @@ jobs:
       uses: seanmiddleditch/gha-setup-vsdevenv@v5
 
     - name: Setup
-      uses: compnerd/gha-setup-swift@v0.2.3
+      uses: compnerd/gha-setup-swift@v0.3.0
       with:
         branch: swift-5.10-release
         tag: 5.10-RELEASE

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   build-windows:
-    runs-on: windows-2019 # Windows SDK lower than 10.0.26100 is needed until https://github.com/swiftlang/swift/pull/79751 released!
+    runs-on: windows-latest
 
     steps:
     - name: Setup VS Dev Environment
@@ -24,8 +24,8 @@ jobs:
     - name: Setup
       uses: compnerd/gha-setup-swift@v0.3.0
       with:
-        branch: swift-5.10-release
-        tag: 5.10-RELEASE
+        branch: swift-6.1-release
+        tag: 6.1-RELEASE
 
     - name: Compute vcpkg Triplet
       id: triplet

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -58,7 +58,6 @@ jobs:
     - name: Build SwiftCrossUI
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/${{ steps.triplet.outputs.lowercase }}/lib/pkgconfig
-    # Requires 6.0, and 6.0 is broken in CI for now.
-    # - name: Build WinUIBackend
-    #   run: swift build --target WinUIBackend
       run: swift build -v
+    - name: Build WinUIBackend
+      run: swift build --target WinUIBackend

--- a/.github/workflows/swift-windows.yml
+++ b/.github/workflows/swift-windows.yml
@@ -58,8 +58,7 @@ jobs:
     - name: Build SwiftCrossUI
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/${{ steps.triplet.outputs.lowercase }}/lib/pkgconfig
-      # Only build the library target to work around apple/swift-package-manager#6644
-      run: swift build --target SwiftCrossUI -v
     # Requires 6.0, and 6.0 is broken in CI for now.
     # - name: Build WinUIBackend
     #   run: swift build --target WinUIBackend
+      run: swift build -v


### PR DESCRIPTION
Took a good minute to build from scratch on my fork, but it's working fine now with the latest commit:
https://github.com/DivineDominion/swift-cross-ui/actions
