### PR TITLE
[WinUIBackend] Prevent crash: remove empty paths

### DIFF
--- a/Examples/Sources/PathsExample/PathsApp.swift
+++ b/Examples/Sources/PathsExample/PathsApp.swift
@@ -37,6 +37,35 @@ struct ArcShape: StyledShape {
     }
 }
 
+struct TestCurveShape: StyledShape {
+    var strokeColor: Color? = Color.purple
+    let fillColor: Color? = nil
+    let strokeStyle: StrokeStyle? = StrokeStyle(width: 3.0, cap: .round)
+
+    func path(in bounds: Path.Rect) -> Path {
+        Path()
+            .move(to: SIMD2(x: bounds.x + 1.5, y: bounds.y + 1.5))
+            .addCubicCurve(
+                control1: SIMD2(x: bounds.maxX, y: bounds.center.y),
+                control2: SIMD2(x: bounds.x, y: bounds.center.y),
+                to: SIMD2(x: bounds.maxX - 1.5, y: bounds.maxY - 1.5)
+            )
+            .addSubpath(
+                RoundedRectangle(cornerRadius: 12.0)
+                    .path(
+                        in: Path.Rect(
+                            x: bounds.x + (1.0 - 0.5.squareRoot()) * bounds.width / 2.0,
+                            y: bounds.y + (1.0 - 0.5.squareRoot()) * bounds.height / 2.0,
+                            width: bounds.width * 0.5.squareRoot(),
+                            height: bounds.height * 0.5.squareRoot()
+                        )
+                    )
+                    .applyTransform(.rotation(degrees: 60.0, center: bounds.center))
+            )
+            .applyTransform(.rotation(degrees: -15.0, center: bounds.center))
+    }
+}
+
 @main
 struct PathsApp: App {
     var body: some Scene {
@@ -114,8 +143,7 @@ struct PathsApp: App {
                 }
                 .padding()
 
-                Ellipse()
-                    .fill(.blue)
+                TestCurveShape()
                     .padding()
             }
         }

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -1515,6 +1515,16 @@ public final class WinUIBackend: AppBackend {
                     geometry.append(subGeo)
             }
         }
+
+        // Cleanup: remove empty paths
+        // Having empty paths in the geometry group causes rendering it to silently crash
+        for i in (0..<geometry.size).reversed() {
+            if let pathGeo = geometry.getAt(i) as? PathGeometry,
+                pathGeo.figures.size == 0
+            {
+                geometry.removeAt(i)
+            }
+        }
     }
 
     public func renderPath(


### PR DESCRIPTION
After applying a transform, I appended an empty path to the geometry group, so that future lines and Bézier curves would go in that (untransformed) path. However, if you don't have any lines or curves after the transform, that path stays empty, and WinUI really doesn't like rendering empty paths. This PR adds a cleanup pass to remove any empty paths, and adds a custom curve to the PathsExample that previously would have triggered this crash.