### PR TITLE
AppKitBackend: Respect environment font when updating text fields

### DIFF
--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -676,6 +676,7 @@ public final class AppKitBackend: AppBackend {
         textField.isEnabled = environment.isEnabled
         textField.placeholderString = placeholder
         textField.appearance = environment.colorScheme.nsAppearance
+        textField.font = Self.font(for: environment)
         textField.onEdit = { textField in
             onChange(textField.stringValue)
         }


### PR DESCRIPTION
This PR makes the following code work as you'd expect (i.e. it will create a TextField with 20pt text);

```swift
TextField("Username", text: $username)
    .font(.system(size: 20))
```

GtkBackend already behaves this way.