### PR TITLE
Implement TextEditor

### DIFF
--- a/Examples/Sources/NotesExample/ContentView.swift
+++ b/Examples/Sources/NotesExample/ContentView.swift
@@ -34,6 +34,17 @@ struct Note: Codable, Equatable, Identifiable {
 struct ContentView: View {
     let notesFile = URL(fileURLWithPath: "notes.json")
 
+    @Environment(\.colorScheme) var colorScheme
+
+    var textEditorBackground: Color {
+        switch colorScheme {
+            case .light:
+                Color(0.8, 0.8, 0.8)
+            case .dark:
+                Color(0.18, 0.18, 0.18)
+        }
+    }
+
     @State var notes: [Note] = [
         Note(title: "Hello, world!", content: "Welcome SwiftCrossNotes!"),
         Note(
@@ -118,25 +129,22 @@ struct ContentView: View {
                 }
             }
         } detail: {
-            VStack(alignment: .leading) {
-                if let selectedNote = selectedNote {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Title")
-                        TextField("Title", text: selectedNote.title)
-                    }
+            ScrollView {
+                VStack(alignment: .center) {
+                    if let selectedNote = selectedNote {
+                        HStack(spacing: 4) {
+                            Text("Title")
+                            TextField("Title", text: selectedNote.title)
+                        }
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Content")
-                        TextField("Content", text: selectedNote.content)
+                        TextEditor(text: selectedNote.content)
+                            .padding()
+                            .background(textEditorBackground)
+                            .cornerRadius(4)
                     }
-                } else {
-                    Text("Select a note...")
                 }
+                .padding()
             }
-            .frame(maxWidth: 400)
-            .padding(10)
-
-            Spacer()
         }
     }
 }

--- a/Examples/Sources/WebViewExample/WebViewApp.swift
+++ b/Examples/Sources/WebViewExample/WebViewApp.swift
@@ -1,6 +1,6 @@
+import DefaultBackend
 import Foundation
 import SwiftCrossUI
-import DefaultBackend
 
 #if canImport(SwiftBundlerRuntime)
     import SwiftBundlerRuntime
@@ -21,7 +21,7 @@ struct WebViewApp: App {
                         TextField("URL", text: $urlInput)
                         Button("Go") {
                             guard let url = URL(string: urlInput) else {
-                                return // disabled
+                                return  // disabled
                             }
 
                             self.url = url

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ad2ee4a6d8f65103345393a58b1ca6d1f051c2f28bc0f507bd7483047a165b7c",
+  "originHash" : "487507851c568cc8a5257e304806d25a1121e8ee89f781c748bb778ce17a81ba",
   "pins" : [
     {
       "identity" : "jpeg",
@@ -87,7 +87,15 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-uwp",
       "state" : {
-        "revision" : "6e5c0089d599fc47c7f052521e1b546e54c7dc13"
+        "revision" : "c9d3fc079aaaa5113cde9a0132278fb83e808599"
+      }
+    },
+    {
+      "identity" : "swift-webview2core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-webview2core",
+      "state" : {
+        "revision" : "9afd97424f844478914ca4512c8ca0a2d3a2bb67"
       }
     },
     {
@@ -95,7 +103,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-windowsappsdk",
       "state" : {
-        "revision" : "5caed8b4f1b4abc6fc89b8f0a8fa20f3edfab14a"
+        "revision" : "ed938db0b9790b36391dc91b20cee81f2410309f"
       }
     },
     {
@@ -112,7 +120,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-winui",
       "state" : {
-        "revision" : "fad446caf8f40370d82a043ec293646023e07e61"
+        "revision" : "927e2c46430cfb1b6c195590b9e65a30a8fd98a2"
       }
     },
     {

--- a/Sources/Gtk/Generated/Image.swift
+++ b/Sources/Gtk/Generated/Image.swift
@@ -241,6 +241,9 @@ open class Image: Widget {
     /// The symbolic size to display icons at.
     @GObjectProperty(named: "icon-size") public var iconSize: IconSize
 
+    /// The `GdkPaintable` to display.
+    @GObjectProperty(named: "paintable") public var paintable: OpaquePointer?
+
     /// The size in pixels to display icons at.
     ///
     /// If set to a value != -1, this property overrides the

--- a/Sources/Gtk/Generated/Picture.swift
+++ b/Sources/Gtk/Generated/Picture.swift
@@ -170,6 +170,9 @@ open class Picture: Widget {
     /// ratio.
     @GObjectProperty(named: "keep-aspect-ratio") public var keepAspectRatio: Bool
 
+    /// The `GdkPaintable` to be displayed by this `GtkPicture`.
+    @GObjectProperty(named: "paintable") public var paintable: OpaquePointer?
+
     public var notifyAlternativeText: ((Picture, OpaquePointer) -> Void)?
 
     public var notifyCanShrink: ((Picture, OpaquePointer) -> Void)?

--- a/Sources/Gtk/Utility/Pango.swift
+++ b/Sources/Gtk/Utility/Pango.swift
@@ -17,6 +17,8 @@ public class Pango {
     /// acts as a suggested width. The text will attempt to take up less than or equal to the proposed
     /// width but if the text wrapping strategy doesn't allow the text to become as small as required
     /// than it may take up more the proposed width.
+    ///
+    /// Uses the `PANGO_WRAP_WORD_CHAR` text wrapping mode.
     public func getTextSize(
         _ text: String,
         proposedWidth: Double? = nil,

--- a/Sources/Gtk/Utility/TextBuffer.swift
+++ b/Sources/Gtk/Utility/TextBuffer.swift
@@ -1,0 +1,441 @@
+import CGtk
+
+/// Stores text and attributes for display in a `GtkTextView`.
+///
+/// You may wish to begin by reading the
+/// [text widget conceptual overview](section-text-widget.html),
+/// which gives an overview of all the objects and data types
+/// related to the text widget and how they work together.
+///
+/// GtkTextBuffer can support undoing changes to the buffer
+/// content, see [method@Gtk.TextBuffer.set_enable_undo].
+open class TextBuffer: GObject {
+    /// Creates a new text buffer.
+    public convenience init(table: OpaquePointer?) {
+        self.init(
+            gtk_text_buffer_new(table)
+        )
+        // Not a widget so we just register signals at creation.
+        registerSignals()
+    }
+
+    public override func registerSignals() {
+        super.registerSignals()
+
+        // I've commented out all signals we don't use because many of
+        // them are causing crashes on Linux. I believe it's because
+        // The GtkTextTag and GtkTextIter types should be wrapped in pointers
+        // (even though they work both ways on macOS with and without being pointers).
+
+        // let handler0:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextTag, GtkTextIter, GtkTextIter,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextTag, GtkTextIter, GtkTextIter>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "apply-tag", handler: gCallback(handler0)) {
+        //     [weak self] (param0: GtkTextTag, param1: GtkTextIter, param2: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.applyTag?(self, param0, param1, param2)
+        // }
+
+        // addSignal(name: "begin-user-action") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.beginUserAction?(self)
+        // }
+
+        addSignal(name: "changed") { [weak self] () in
+            guard let self = self else { return }
+            self.changed?(self)
+        }
+
+        // let handler3:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, GtkTextIter, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, GtkTextIter>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "delete-range", handler: gCallback(handler3)) {
+        //     [weak self] (param0: GtkTextIter, param1: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.deleteRange?(self, param0, param1)
+        // }
+
+        // addSignal(name: "end-user-action") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.endUserAction?(self)
+        // }
+
+        // let handler5:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, GtkTextChildAnchor, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, GtkTextChildAnchor>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "insert-child-anchor", handler: gCallback(handler5)) {
+        //     [weak self] (param0: GtkTextIter, param1: GtkTextChildAnchor) in
+        //     guard let self = self else { return }
+        //     self.insertChildAnchor?(self, param0, param1)
+        // }
+
+        // let handler6:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, OpaquePointer, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, OpaquePointer>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "insert-paintable", handler: gCallback(handler6)) {
+        //     [weak self] (param0: GtkTextIter, param1: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.insertPaintable?(self, param0, param1)
+        // }
+
+        // let handler7:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, UnsafePointer<CChar>, Int,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextIter, UnsafePointer<CChar>, Int>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "insert-text", handler: gCallback(handler7)) {
+        //     [weak self] (param0: GtkTextIter, param1: UnsafePointer<CChar>, param2: Int) in
+        //     guard let self = self else { return }
+        //     self.insertText?(self, param0, param1, param2)
+        // }
+
+        // let handler8:
+        //     @convention(c) (UnsafeMutableRawPointer, GtkTextMark, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<GtkTextMark>.run(data, value1)
+        //         }
+
+        // addSignal(name: "mark-deleted", handler: gCallback(handler8)) {
+        //     [weak self] (param0: GtkTextMark) in
+        //     guard let self = self else { return }
+        //     self.markDeleted?(self, param0)
+        // }
+
+        // let handler9:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, UnsafeMutablePointer<GtkTextIter>, UnsafeMutablePointer<GtkTextMark>, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<UnsafeMutablePointer<GtkTextIter>, UnsafeMutablePointer<GtkTextMark>>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "mark-set", handler: gCallback(handler9)) {
+        //     [weak self] (param0: UnsafeMutablePointer<GtkTextIter>, param1: UnsafeMutablePointer<GtkTextMark>) in
+        //     guard let self = self else { return }
+        //     self.markSet?(self, param0, param1)
+        // }
+
+        // addSignal(name: "modified-changed") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.modifiedChanged?(self)
+        // }
+
+        // let handler11:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "paste-done", handler: gCallback(handler11)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.pasteDone?(self, param0)
+        // }
+
+        // addSignal(name: "redo") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.redo?(self)
+        // }
+
+        // let handler13:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextTag, GtkTextIter, GtkTextIter,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextTag, GtkTextIter, GtkTextIter>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "remove-tag", handler: gCallback(handler13)) {
+        //     [weak self] (param0: GtkTextTag, param1: GtkTextIter, param2: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.removeTag?(self, param0, param1, param2)
+        // }
+
+        // addSignal(name: "undo") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.undo?(self)
+        // }
+
+        // let handler15:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::can-redo", handler: gCallback(handler15)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyCanRedo?(self, param0)
+        // }
+
+        // let handler16:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::can-undo", handler: gCallback(handler16)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyCanUndo?(self, param0)
+        // }
+
+        // let handler17:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::cursor-position", handler: gCallback(handler17)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyCursorPosition?(self, param0)
+        // }
+
+        // let handler18:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::enable-undo", handler: gCallback(handler18)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyEnableUndo?(self, param0)
+        // }
+
+        // let handler19:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::has-selection", handler: gCallback(handler19)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyHasSelection?(self, param0)
+        // }
+
+        // let handler20:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::tag-table", handler: gCallback(handler20)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyTagTable?(self, param0)
+        // }
+
+        // let handler21:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::text", handler: gCallback(handler21)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyText?(self, param0)
+        // }
+    }
+
+    /// Denotes that the buffer can reapply the last undone action.
+    @GObjectProperty(named: "can-redo") public var canRedo: Bool
+
+    /// Denotes that the buffer can undo the last applied action.
+    @GObjectProperty(named: "can-undo") public var canUndo: Bool
+
+    /// Denotes if support for undoing and redoing changes to the buffer is allowed.
+    @GObjectProperty(named: "enable-undo") public var enableUndo: Bool
+
+    /// Whether the buffer has some text currently selected.
+    @GObjectProperty(named: "has-selection") public var hasSelection: Bool
+
+    /// The text content of the buffer.
+    ///
+    /// Without child widgets and images,
+    /// see [method@Gtk.TextBuffer.get_text] for more information.
+    @GObjectProperty(named: "text") public var text: String
+
+    // /// Emitted to apply a tag to a range of text in a `GtkTextBuffer`.
+    // ///
+    // /// Applying actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @start and @end iters (or has to
+    // /// revalidate them).
+    // ///
+    // /// See also:
+    // /// [method@Gtk.TextBuffer.apply_tag],
+    // /// [method@Gtk.TextBuffer.insert_with_tags],
+    // /// [method@Gtk.TextBuffer.insert_range].
+    // public var applyTag: ((TextBuffer, GtkTextTag, GtkTextIter, GtkTextIter) -> Void)?
+
+    // /// Emitted at the beginning of a single user-visible
+    // /// operation on a `GtkTextBuffer`.
+    // ///
+    // /// See also:
+    // /// [method@Gtk.TextBuffer.begin_user_action],
+    // /// [method@Gtk.TextBuffer.insert_interactive],
+    // /// [method@Gtk.TextBuffer.insert_range_interactive],
+    // /// [method@Gtk.TextBuffer.delete_interactive],
+    // /// [method@Gtk.TextBuffer.backspace],
+    // /// [method@Gtk.TextBuffer.delete_selection].
+    // public var beginUserAction: ((TextBuffer) -> Void)?
+
+    /// Emitted when the content of a `GtkTextBuffer` has changed.
+    public var changed: ((TextBuffer) -> Void)?
+
+    // /// Emitted to delete a range from a `GtkTextBuffer`.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @start and @end iters (or has
+    // /// to revalidate them). The default signal handler revalidates
+    // /// the @start and @end iters to both point to the location
+    // /// where text was deleted. Handlers which run after the default
+    // /// handler (see g_signal_connect_after()) do not have access to
+    // /// the deleted text.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.delete].
+    // public var deleteRange: ((TextBuffer, GtkTextIter, GtkTextIter) -> Void)?
+
+    // /// Emitted at the end of a single user-visible
+    // /// operation on the `GtkTextBuffer`.
+    // ///
+    // /// See also:
+    // /// [method@Gtk.TextBuffer.end_user_action],
+    // /// [method@Gtk.TextBuffer.insert_interactive],
+    // /// [method@Gtk.TextBuffer.insert_range_interactive],
+    // /// [method@Gtk.TextBuffer.delete_interactive],
+    // /// [method@Gtk.TextBuffer.backspace],
+    // /// [method@Gtk.TextBuffer.delete_selection],
+    // /// [method@Gtk.TextBuffer.backspace].
+    // public var endUserAction: ((TextBuffer) -> Void)?
+
+    // /// Emitted to insert a `GtkTextChildAnchor` in a `GtkTextBuffer`.
+    // ///
+    // /// Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @location iter (or has to
+    // /// revalidate it). The default signal handler revalidates
+    // /// it to be placed after the inserted @anchor.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.insert_child_anchor].
+    // public var insertChildAnchor: ((TextBuffer, GtkTextIter, GtkTextChildAnchor) -> Void)?
+
+    // /// Emitted to insert a `GdkPaintable` in a `GtkTextBuffer`.
+    // ///
+    // /// Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @location iter (or has to
+    // /// revalidate it). The default signal handler revalidates
+    // /// it to be placed after the inserted @paintable.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.insert_paintable].
+    // public var insertPaintable: ((TextBuffer, GtkTextIter, OpaquePointer) -> Void)?
+
+    // /// Emitted to insert text in a `GtkTextBuffer`.
+    // ///
+    // /// Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @location iter (or has to
+    // /// revalidate it). The default signal handler revalidates
+    // /// it to point to the end of the inserted text.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.insert],
+    // /// [method@Gtk.TextBuffer.insert_range].
+    // public var insertText: ((TextBuffer, GtkTextIter, UnsafePointer<CChar>, Int) -> Void)?
+
+    // /// Emitted as notification after a `GtkTextMark` is deleted.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.delete_mark].
+    // public var markDeleted: ((TextBuffer, GtkTextMark) -> Void)?
+
+    // /// Emitted as notification after a `GtkTextMark` is set.
+    // ///
+    // /// See also:
+    // /// [method@Gtk.TextBuffer.create_mark],
+    // /// [method@Gtk.TextBuffer.move_mark].
+    // public var markSet: ((TextBuffer, UnsafeMutablePointer<GtkTextIter>, UnsafeMutablePointer<GtkTextMark>) -> Void)?
+
+    // /// Emitted when the modified bit of a `GtkTextBuffer` flips.
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.set_modified].
+    // public var modifiedChanged: ((TextBuffer) -> Void)?
+
+    // /// Emitted after paste operation has been completed.
+    // ///
+    // /// This is useful to properly scroll the view to the end
+    // /// of the pasted text. See [method@Gtk.TextBuffer.paste_clipboard]
+    // /// for more details.
+    // public var pasteDone: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // /// Emitted when a request has been made to redo the
+    // /// previously undone operation.
+    // public var redo: ((TextBuffer) -> Void)?
+
+    // /// Emitted to remove all occurrences of @tag from a range
+    // /// of text in a `GtkTextBuffer`.
+    // ///
+    // /// Removal actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler
+    // /// it must not invalidate the @start and @end iters (or has
+    // /// to revalidate them).
+    // ///
+    // /// See also: [method@Gtk.TextBuffer.remove_tag].
+    // public var removeTag: ((TextBuffer, GtkTextTag, GtkTextIter, GtkTextIter) -> Void)?
+
+    // /// Emitted when a request has been made to undo the
+    // /// previous operation or set of operations that have
+    // /// been grouped together.
+    // public var undo: ((TextBuffer) -> Void)?
+
+    // public var notifyCanRedo: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyCanUndo: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyCursorPosition: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyEnableUndo: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyHasSelection: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyTagTable: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyText: ((TextBuffer, OpaquePointer) -> Void)?
+}

--- a/Sources/Gtk/Widgets/TextView.swift
+++ b/Sources/Gtk/Widgets/TextView.swift
@@ -72,29 +72,23 @@ import CGtk
 ///
 /// `GtkTextView` uses the [enum@Gtk.AccessibleRole.text_box] role.
 open class TextView: Widget, Scrollable {
-    /// Creates a new `GtkTextView`.
-    ///
-    /// If you don’t call [method@Gtk.TextView.set_buffer] before using the
-    /// text view, an empty default buffer will be created for you. Get the
-    /// buffer with [method@Gtk.TextView.get_buffer]. If you want to specify
-    /// your own buffer, consider [ctor@Gtk.TextView.new_with_buffer].
-    public convenience init() {
-        self.init(
-            gtk_text_view_new()
+    /// Create a text view with an empty text buffer.
+    public init() {
+        buffer = TextBuffer(table: nil)
+        super.init(
+            gtk_text_view_new_with_buffer(buffer.gobjectPointer.cast())
         )
     }
 
-    /// Creates a new `GtkTextView` widget displaying the buffer @buffer.
-    ///
-    /// One buffer can be shared among many widgets. @buffer may be %NULL
-    /// to create a default buffer, in which case this function is equivalent
-    /// to [ctor@Gtk.TextView.new]. The text view adds its own reference count
-    /// to the buffer; it does not take over an existing reference.
-    public convenience init(buffer: UnsafeMutablePointer<GtkTextBuffer>!) {
-        self.init(
-            gtk_text_view_new_with_buffer(buffer)
+    /// Create a text view for the given text buffer.
+    public init(buffer: TextBuffer) {
+        self.buffer = buffer
+        super.init(
+            gtk_text_view_new_with_buffer(self.buffer.gobjectPointer.cast())
         )
     }
+
+    open var buffer: TextBuffer
 
     override func didMoveToParent() {
         super.didMoveToParent()

--- a/Sources/Gtk3/Utility/TextBuffer.swift
+++ b/Sources/Gtk3/Utility/TextBuffer.swift
@@ -1,0 +1,388 @@
+import CGtk3
+
+/// You may wish to begin by reading the
+/// [text widget conceptual overview](TextWidget.html)
+/// which gives an overview of all the objects and data
+/// types related to the text widget and how they work together.
+open class TextBuffer: GObject {
+    /// Creates a new text buffer.
+    public convenience init(table: UnsafeMutablePointer<_GtkTextTagTable>?) {
+        self.init(
+            gtk_text_buffer_new(table)
+        )
+        // Not a widget so we just register signals at creation.
+        registerSignals()
+    }
+
+    public override func registerSignals() {
+        super.registerSignals()
+
+        // I've commented out all signals we don't use because many of
+        // them are causing crashes on Linux. I believe it's because
+        // The GtkTextTag and GtkTextIter types should be wrapped in pointers
+        // (even though they work both ways on macOS with and without being pointers).
+
+        // let handler0:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextTag, GtkTextIter, GtkTextIter,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextTag, GtkTextIter, GtkTextIter>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "apply-tag", handler: gCallback(handler0)) {
+        //     [weak self] (param0: GtkTextTag, param1: GtkTextIter, param2: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.applyTag?(self, param0, param1, param2)
+        // }
+
+        // addSignal(name: "begin-user-action") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.beginUserAction?(self)
+        // }
+
+        addSignal(name: "changed") { [weak self] () in
+            guard let self = self else { return }
+            self.changed?(self)
+        }
+
+        // let handler3:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, GtkTextIter, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, GtkTextIter>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "delete-range", handler: gCallback(handler3)) {
+        //     [weak self] (param0: GtkTextIter, param1: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.deleteRange?(self, param0, param1)
+        // }
+
+        // addSignal(name: "end-user-action") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.endUserAction?(self)
+        // }
+
+        // let handler5:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, GtkTextChildAnchor, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, GtkTextChildAnchor>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "insert-child-anchor", handler: gCallback(handler5)) {
+        //     [weak self] (param0: GtkTextIter, param1: GtkTextChildAnchor) in
+        //     guard let self = self else { return }
+        //     self.insertChildAnchor?(self, param0, param1)
+        // }
+
+        // let handler6:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, OpaquePointer, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, OpaquePointer>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "insert-pixbuf", handler: gCallback(handler6)) {
+        //     [weak self] (param0: GtkTextIter, param1: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.insertPixbuf?(self, param0, param1)
+        // }
+
+        // let handler7:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, UnsafePointer<CChar>, Int,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextIter, UnsafePointer<CChar>, Int>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "insert-text", handler: gCallback(handler7)) {
+        //     [weak self] (param0: GtkTextIter, param1: UnsafePointer<CChar>, param2: Int) in
+        //     guard let self = self else { return }
+        //     self.insertText?(self, param0, param1, param2)
+        // }
+
+        // let handler8:
+        //     @convention(c) (UnsafeMutableRawPointer, GtkTextMark, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<GtkTextMark>.run(data, value1)
+        //         }
+
+        // addSignal(name: "mark-deleted", handler: gCallback(handler8)) {
+        //     [weak self] (param0: GtkTextMark) in
+        //     guard let self = self else { return }
+        //     self.markDeleted?(self, param0)
+        // }
+
+        // let handler9:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextIter, GtkTextMark, UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, data in
+        //             SignalBox2<GtkTextIter, GtkTextMark>.run(data, value1, value2)
+        //         }
+
+        // addSignal(name: "mark-set", handler: gCallback(handler9)) {
+        //     [weak self] (param0: GtkTextIter, param1: GtkTextMark) in
+        //     guard let self = self else { return }
+        //     self.markSet?(self, param0, param1)
+        // }
+
+        // addSignal(name: "modified-changed") { [weak self] () in
+        //     guard let self = self else { return }
+        //     self.modifiedChanged?(self)
+        // }
+
+        // let handler11:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "paste-done", handler: gCallback(handler11)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.pasteDone?(self, param0)
+        // }
+
+        // let handler12:
+        //     @convention(c) (
+        //         UnsafeMutableRawPointer, GtkTextTag, GtkTextIter, GtkTextIter,
+        //         UnsafeMutableRawPointer
+        //     ) -> Void =
+        //         { _, value1, value2, value3, data in
+        //             SignalBox3<GtkTextTag, GtkTextIter, GtkTextIter>.run(
+        //                 data, value1, value2, value3)
+        //         }
+
+        // addSignal(name: "remove-tag", handler: gCallback(handler12)) {
+        //     [weak self] (param0: GtkTextTag, param1: GtkTextIter, param2: GtkTextIter) in
+        //     guard let self = self else { return }
+        //     self.removeTag?(self, param0, param1, param2)
+        // }
+
+        // let handler13:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::copy-target-list", handler: gCallback(handler13)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyCopyTargetList?(self, param0)
+        // }
+
+        // let handler14:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::cursor-position", handler: gCallback(handler14)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyCursorPosition?(self, param0)
+        // }
+
+        // let handler15:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::has-selection", handler: gCallback(handler15)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyHasSelection?(self, param0)
+        // }
+
+        // let handler16:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::paste-target-list", handler: gCallback(handler16)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyPasteTargetList?(self, param0)
+        // }
+
+        // let handler17:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::tag-table", handler: gCallback(handler17)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyTagTable?(self, param0)
+        // }
+
+        // let handler18:
+        //     @convention(c) (UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer) -> Void =
+        //         { _, value1, data in
+        //             SignalBox1<OpaquePointer>.run(data, value1)
+        //         }
+
+        // addSignal(name: "notify::text", handler: gCallback(handler18)) {
+        //     [weak self] (param0: OpaquePointer) in
+        //     guard let self = self else { return }
+        //     self.notifyText?(self, param0)
+        // }
+    }
+
+    @GObjectProperty(named: "text") public var text: String
+
+    // /// The ::apply-tag signal is emitted to apply a tag to a
+    // /// range of text in a #GtkTextBuffer.
+    // /// Applying actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler it must not
+    // /// invalidate the @start and @end iters (or has to revalidate them).
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_apply_tag(),
+    // /// gtk_text_buffer_insert_with_tags(),
+    // /// gtk_text_buffer_insert_range().
+    // public var applyTag: ((TextBuffer, GtkTextTag, GtkTextIter, GtkTextIter) -> Void)?
+
+    // /// The ::begin-user-action signal is emitted at the beginning of a single
+    // /// user-visible operation on a #GtkTextBuffer.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_begin_user_action(),
+    // /// gtk_text_buffer_insert_interactive(),
+    // /// gtk_text_buffer_insert_range_interactive(),
+    // /// gtk_text_buffer_delete_interactive(),
+    // /// gtk_text_buffer_backspace(),
+    // /// gtk_text_buffer_delete_selection().
+    // public var beginUserAction: ((TextBuffer) -> Void)?
+
+    /// The ::changed signal is emitted when the content of a #GtkTextBuffer
+    /// has changed.
+    public var changed: ((TextBuffer) -> Void)?
+
+    // /// The ::delete-range signal is emitted to delete a range
+    // /// from a #GtkTextBuffer.
+    // ///
+    // /// Note that if your handler runs before the default handler it must not
+    // /// invalidate the @start and @end iters (or has to revalidate them).
+    // /// The default signal handler revalidates the @start and @end iters to
+    // /// both point to the location where text was deleted. Handlers
+    // /// which run after the default handler (see g_signal_connect_after())
+    // /// do not have access to the deleted text.
+    // ///
+    // /// See also: gtk_text_buffer_delete().
+    // public var deleteRange: ((TextBuffer, GtkTextIter, GtkTextIter) -> Void)?
+
+    // /// The ::end-user-action signal is emitted at the end of a single
+    // /// user-visible operation on the #GtkTextBuffer.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_end_user_action(),
+    // /// gtk_text_buffer_insert_interactive(),
+    // /// gtk_text_buffer_insert_range_interactive(),
+    // /// gtk_text_buffer_delete_interactive(),
+    // /// gtk_text_buffer_backspace(),
+    // /// gtk_text_buffer_delete_selection(),
+    // /// gtk_text_buffer_backspace().
+    // public var endUserAction: ((TextBuffer) -> Void)?
+
+    // /// The ::insert-child-anchor signal is emitted to insert a
+    // /// #GtkTextChildAnchor in a #GtkTextBuffer.
+    // /// Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler it must
+    // /// not invalidate the @location iter (or has to revalidate it).
+    // /// The default signal handler revalidates it to be placed after the
+    // /// inserted @anchor.
+    // ///
+    // /// See also: gtk_text_buffer_insert_child_anchor().
+    // public var insertChildAnchor: ((TextBuffer, GtkTextIter, GtkTextChildAnchor) -> Void)?
+
+    // /// The ::insert-pixbuf signal is emitted to insert a #GdkPixbuf
+    // /// in a #GtkTextBuffer. Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler it must not
+    // /// invalidate the @location iter (or has to revalidate it).
+    // /// The default signal handler revalidates it to be placed after the
+    // /// inserted @pixbuf.
+    // ///
+    // /// See also: gtk_text_buffer_insert_pixbuf().
+    // public var insertPixbuf: ((TextBuffer, GtkTextIter, OpaquePointer) -> Void)?
+
+    // /// The ::insert-text signal is emitted to insert text in a #GtkTextBuffer.
+    // /// Insertion actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler it must not
+    // /// invalidate the @location iter (or has to revalidate it).
+    // /// The default signal handler revalidates it to point to the end of the
+    // /// inserted text.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_insert(),
+    // /// gtk_text_buffer_insert_range().
+    // public var insertText: ((TextBuffer, GtkTextIter, UnsafePointer<CChar>, Int) -> Void)?
+
+    // /// The ::mark-deleted signal is emitted as notification
+    // /// after a #GtkTextMark is deleted.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_delete_mark().
+    // public var markDeleted: ((TextBuffer, GtkTextMark) -> Void)?
+
+    // /// The ::mark-set signal is emitted as notification
+    // /// after a #GtkTextMark is set.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_create_mark(),
+    // /// gtk_text_buffer_move_mark().
+    // public var markSet: ((TextBuffer, GtkTextIter, GtkTextMark) -> Void)?
+
+    // /// The ::modified-changed signal is emitted when the modified bit of a
+    // /// #GtkTextBuffer flips.
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_set_modified().
+    // public var modifiedChanged: ((TextBuffer) -> Void)?
+
+    // /// The paste-done signal is emitted after paste operation has been completed.
+    // /// This is useful to properly scroll the view to the end of the pasted text.
+    // /// See gtk_text_buffer_paste_clipboard() for more details.
+    // public var pasteDone: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // /// The ::remove-tag signal is emitted to remove all occurrences of @tag from
+    // /// a range of text in a #GtkTextBuffer.
+    // /// Removal actually occurs in the default handler.
+    // ///
+    // /// Note that if your handler runs before the default handler it must not
+    // /// invalidate the @start and @end iters (or has to revalidate them).
+    // ///
+    // /// See also:
+    // /// gtk_text_buffer_remove_tag().
+    // public var removeTag: ((TextBuffer, GtkTextTag, GtkTextIter, GtkTextIter) -> Void)?
+
+    // public var notifyCopyTargetList: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyCursorPosition: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyHasSelection: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyPasteTargetList: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyTagTable: ((TextBuffer, OpaquePointer) -> Void)?
+
+    // public var notifyText: ((TextBuffer, OpaquePointer) -> Void)?
+}

--- a/Sources/Gtk3/Widgets/TextView.swift
+++ b/Sources/Gtk3/Widgets/TextView.swift
@@ -28,27 +28,23 @@ import CGtk3
 /// If a context menu is opened, the window node will appear as a subnode
 /// of the main node.
 open class TextView: Container, Scrollable {
-    /// Creates a new #GtkTextView. If you don’t call gtk_text_view_set_buffer()
-    /// before using the text view, an empty default buffer will be created
-    /// for you. Get the buffer with gtk_text_view_get_buffer(). If you want
-    /// to specify your own buffer, consider gtk_text_view_new_with_buffer().
-    public convenience init() {
-        self.init(
-            gtk_text_view_new()
+    /// Create a text view with an empty text buffer.
+    public init() {
+        buffer = TextBuffer(table: nil)
+        super.init(
+            gtk_text_view_new_with_buffer(buffer.gobjectPointer.cast())
         )
     }
 
-    /// Creates a new #GtkTextView widget displaying the buffer
-    /// @buffer. One buffer can be shared among many widgets.
-    /// @buffer may be %NULL to create a default buffer, in which case
-    /// this function is equivalent to gtk_text_view_new(). The
-    /// text view adds its own reference count to the buffer; it does not
-    /// take over an existing reference.
-    public convenience init(buffer: UnsafeMutablePointer<GtkTextBuffer>!) {
-        self.init(
-            gtk_text_view_new_with_buffer(buffer)
+    /// Create a text view for the given text buffer.
+    public init(buffer: TextBuffer) {
+        self.buffer = buffer
+        super.init(
+            gtk_text_view_new_with_buffer(self.buffer.gobjectPointer.cast())
         )
     }
+
+    open var buffer: TextBuffer
 
     override func didMoveToParent() {
         super.didMoveToParent()

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -102,6 +102,10 @@ public final class Gtk3Backend: AppBackend {
                         margin: 0;
                         padding: 0;
                     }
+
+                    textview text {
+                        background: none;
+                    }
                     """
             )
             gtk_style_context_add_provider_for_screen(
@@ -632,11 +636,11 @@ public final class Gtk3Backend: AppBackend {
 
     public func size(
         of text: String,
-        whenDisplayedIn textView: Widget,
+        whenDisplayedIn widget: Widget,
         proposedFrame: SIMD2<Int>?,
         environment: EnvironmentValues
     ) -> SIMD2<Int> {
-        let pango = Pango(for: textView)
+        let pango = Pango(for: widget)
         let (width, height) = pango.getTextSize(
             text,
             proposedWidth: (proposedFrame?.x).map(Double.init),
@@ -893,6 +897,37 @@ public final class Gtk3Backend: AppBackend {
 
     public func getContent(ofTextField textField: Widget) -> String {
         return (textField as! Entry).text
+    }
+
+    public func createTextEditor() -> Widget {
+        let textEditor = Gtk3.TextView()
+        textEditor.wrapMode = .wordCharacter
+        return textEditor
+    }
+
+    public func updateTextEditor(
+        _ textEditor: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (String) -> Void
+    ) {
+        let textEditor = textEditor as! Gtk3.TextView
+        textEditor.buffer.changed = { buffer in
+            onChange(buffer.text)
+        }
+
+        textEditor.css.clear()
+        textEditor.css.set(properties: Self.cssProperties(for: environment, isControl: false))
+        textEditor.css.set(property: CSSProperty(key: "background", value: "none"))
+    }
+
+    public func setContent(ofTextEditor textEditor: Widget, to content: String) {
+        let textEditor = textEditor as! Gtk3.TextView
+        textEditor.buffer.text = content
+    }
+
+    public func getContent(ofTextEditor textEditor: Widget) -> String {
+        let textEditor = textEditor as! Gtk3.TextView
+        return textEditor.buffer.text
     }
 
     // public func createPicker() -> Widget {

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -606,11 +606,11 @@ public final class GtkBackend: AppBackend {
 
     public func size(
         of text: String,
-        whenDisplayedIn textView: Widget,
+        whenDisplayedIn widget: Widget,
         proposedFrame: SIMD2<Int>?,
         environment: EnvironmentValues
     ) -> SIMD2<Int> {
-        let pango = Pango(for: textView)
+        let pango = Pango(for: widget)
         let (width, height) = pango.getTextSize(
             text,
             proposedWidth: (proposedFrame?.x).map(Double.init),
@@ -873,6 +873,37 @@ public final class GtkBackend: AppBackend {
 
     public func getContent(ofTextField textField: Widget) -> String {
         return (textField as! Entry).text
+    }
+
+    public func createTextEditor() -> Widget {
+        let textEditor = Gtk.TextView()
+        textEditor.wrapMode = .wordCharacter
+        return textEditor
+    }
+
+    public func updateTextEditor(
+        _ textEditor: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (String) -> Void
+    ) {
+        let textEditor = textEditor as! Gtk.TextView
+        textEditor.buffer.changed = { buffer in
+            onChange(buffer.text)
+        }
+
+        textEditor.css.clear()
+        textEditor.css.set(properties: Self.cssProperties(for: environment, isControl: false))
+        textEditor.css.set(property: CSSProperty(key: "background", value: "none"))
+    }
+
+    public func setContent(ofTextEditor textEditor: Widget, to content: String) {
+        let textEditor = textEditor as! Gtk.TextView
+        textEditor.buffer.text = content
+    }
+
+    public func getContent(ofTextEditor textEditor: Widget) -> String {
+        let textEditor = textEditor as! Gtk.TextView
+        return textEditor.buffer.text
     }
 
     public func createPicker() -> Widget {

--- a/Sources/GtkCodeGen/GtkCodeGen.swift
+++ b/Sources/GtkCodeGen/GtkCodeGen.swift
@@ -26,6 +26,7 @@ struct GtkCodeGen {
         "GdkPaintable*": "OpaquePointer",
         "GtkSelectionModel*": "OpaquePointer?",
         "GtkListItemFactory*": "OpaquePointer?",
+        "GtkTextTagTable*": "OpaquePointer?",
     ]
 
     /// Problematic signals which are excluded from the generated Swift
@@ -65,6 +66,8 @@ struct GtkCodeGen {
         "Gdk.Event": "GdkEvent",
         "Gdk.EventSequence": "OpaquePointer",
         "Gdk.GLContext": "OpaquePointer",
+        "Gdk.Paintable": "OpaquePointer",
+        "Gdk.Clipboard": "OpaquePointer",
     ]
 
     static let interfaces: [String] = [
@@ -104,7 +107,7 @@ struct GtkCodeGen {
         cGtkImport: String
     ) throws {
         let allowListedClasses = [
-            "Button", "Entry", "Label", "TextView", "Range", "Scale", "Image", "Switch", "Spinner",
+            "Button", "Entry", "Label", "Range", "Scale", "Image", "Switch", "Spinner",
             "ProgressBar", "FileChooserNative", "NativeDialog", "GestureClick", "GestureSingle",
             "Gesture", "EventController", "GestureLongPress", "GLArea", "DrawingArea",
             "CheckButton",

--- a/Sources/SwiftCrossUI/Backend/AppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/AppBackend.swift
@@ -304,25 +304,31 @@ public protocol AppBackend {
 
     // MARK: Passive views
 
-    /// Creates a non-editable text view with optional text wrapping. Predominantly used
-    /// by ``Text``.`
-    func createTextView() -> Widget
-    /// Sets the content and wrapping mode of a non-editable text view.
-    func updateTextView(_ textView: Widget, content: String, environment: EnvironmentValues)
     /// Gets the size that the given text would have if it were layed out attempting to stay
     /// within the proposed frame (most backends only use the proposed width and ignore the
     /// proposed height). The size returned by this function will be upheld by the layout
     /// system; child views always get the final say on their own size, parents just choose how
     /// the children get layed out.
     ///
+    /// The target widget is supplied because some backends (such as Gtk) require a
+    /// reference to the target widget to get a text layout context.
+    ///
     /// If `proposedFrame` isn't supplied, the text should be layed out on a single line
     /// taking up as much width as it needs.
+    ///
+    /// Used by both ``SwiftCrossUI/Text`` and ``SwiftCrossUI/TextEditor``.
     func size(
         of text: String,
-        whenDisplayedIn textView: Widget,
+        whenDisplayedIn widget: Widget,
         proposedFrame: SIMD2<Int>?,
         environment: EnvironmentValues
     ) -> SIMD2<Int>
+
+    /// Creates a non-editable text view with optional text wrapping. Predominantly used
+    /// by ``Text``.`
+    func createTextView() -> Widget
+    /// Sets the content and wrapping mode of a non-editable text view.
+    func updateTextView(_ textView: Widget, content: String, environment: EnvironmentValues)
 
     /// Creates an image view from an image file (specified by path). Predominantly used
     /// by ``Image``.
@@ -467,6 +473,26 @@ public protocol AppBackend {
     func setContent(ofTextField textField: Widget, to content: String)
     /// Gets the value of an editable text field.
     func getContent(ofTextField textField: Widget) -> String
+
+    /// Creates a editable multi-line text editor with a placeholder label and change
+    /// handler. The change handler is called whenever the displayed value changes.
+    /// Predominantly used by ``TextEditor``.
+    func createTextEditor() -> Widget
+    /// Sets the placeholder label and change handler of a editable multi-line text editor.
+    /// The new change handler replaces any existing change handlers, and is called
+    /// whenever the displayed value changes.
+    ///
+    /// The backend shouldn't wait until the user finishes typing to call the change
+    /// handler; it should allow live access to the value.
+    func updateTextEditor(
+        _ textEditor: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (String) -> Void
+    )
+    /// Sets the value of an editable multi-line text editor.
+    func setContent(ofTextEditor textEditor: Widget, to content: String)
+    /// Gets the value of an editable multi-line text editor.
+    func getContent(ofTextEditor textEditor: Widget) -> String
 
     /// Creates a picker for selecting from a finite set of options (e.g. a radio button group,
     /// a drop-down, a picker wheel). Predominantly used by ``Picker``. The change handler is
@@ -757,6 +783,15 @@ extension AppBackend {
 
     // MARK: Passive views
 
+    public func size(
+        of text: String,
+        whenDisplayedIn widget: Widget,
+        proposedFrame: SIMD2<Int>?,
+        environment: EnvironmentValues
+    ) -> SIMD2<Int> {
+        todo()
+    }
+
     public func createTextView(content: String, shouldWrap: Bool) -> Widget {
         todo()
     }
@@ -765,14 +800,6 @@ extension AppBackend {
         content: String,
         environment: EnvironmentValues
     ) {
-        todo()
-    }
-    public func size(
-        of text: String,
-        whenDisplayedIn textView: Widget,
-        proposedFrame: SIMD2<Int>?,
-        environment: EnvironmentValues
-    ) -> SIMD2<Int> {
         todo()
     }
 
@@ -912,6 +939,23 @@ extension AppBackend {
         todo()
     }
     public func getContent(ofTextField textField: Widget) -> String {
+        todo()
+    }
+
+    public func createTextEditor() -> Widget {
+        todo()
+    }
+    public func updateTextEditor(
+        _ textEditor: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (String) -> Void
+    ) {
+        todo()
+    }
+    public func setContent(ofTextEditor textEditor: Widget, to content: String) {
+        todo()
+    }
+    public func getContent(ofTextEditor textEditor: Widget) -> String {
         todo()
     }
 

--- a/Sources/SwiftCrossUI/State/ObservableObject.swift
+++ b/Sources/SwiftCrossUI/State/ObservableObject.swift
@@ -43,7 +43,7 @@
 ///
 /// struct CounterView: View {
 ///     @State var state = CounterState()
-/// 
+///
 ///     var body: some View {
 ///         HStack {
 ///             Button("-") {

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/BackgroundModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/BackgroundModifier.swift
@@ -75,7 +75,18 @@ struct BackgroundModifier<Background: View, Foreground: View>: TypeSafeView {
         return ViewUpdateResult(
             size: ViewSize(
                 size: frameSize,
-                idealSize: foregroundSize.idealSize,
+                idealSize: SIMD2(
+                    max(foregroundSize.idealSize.x, backgroundSize.minimumWidth),
+                    max(foregroundSize.idealSize.y, backgroundSize.minimumHeight)
+                ),
+                idealWidthForProposedHeight: max(
+                    foregroundSize.idealWidthForProposedHeight,
+                    backgroundSize.minimumWidth
+                ),
+                idealHeightForProposedWidth: max(
+                    foregroundSize.idealHeightForProposedWidth,
+                    backgroundSize.minimumHeight
+                ),
                 minimumWidth: max(backgroundSize.minimumWidth, foregroundSize.minimumWidth),
                 minimumHeight: max(backgroundSize.minimumHeight, foregroundSize.minimumHeight),
                 maximumWidth: min(backgroundSize.maximumWidth, foregroundSize.maximumWidth),

--- a/Sources/SwiftCrossUI/Views/ScrollView.swift
+++ b/Sources/SwiftCrossUI/Views/ScrollView.swift
@@ -64,7 +64,6 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
             axes.contains(.horizontal) && contentSize.idealWidthForProposedHeight > proposedSize.x
         let hasVerticalScrollBar =
             axes.contains(.vertical) && contentSize.idealHeightForProposedWidth > proposedSize.y
-        print(contentSize.idealHeightForProposedWidth)
 
         let verticalScrollBarWidth = hasVerticalScrollBar ? scrollBarWidth : 0
         let horizontalScrollBarHeight = hasHorizontalScrollBar ? scrollBarWidth : 0
@@ -77,14 +76,20 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
             scrollViewWidth = max(proposedSize.x, verticalScrollBarWidth)
             minimumWidth = verticalScrollBarWidth
         } else {
-            scrollViewWidth = contentSize.size.x + verticalScrollBarWidth
+            scrollViewWidth = min(
+                contentSize.size.x + verticalScrollBarWidth,
+                max(proposedSize.x, contentSize.minimumWidth + verticalScrollBarWidth)
+            )
             minimumWidth = contentSize.minimumWidth + verticalScrollBarWidth
         }
         if axes.contains(.vertical) {
             scrollViewHeight = max(proposedSize.y, horizontalScrollBarHeight)
             minimumHeight = horizontalScrollBarHeight
         } else {
-            scrollViewHeight = contentSize.size.y + horizontalScrollBarHeight
+            scrollViewHeight = min(
+                contentSize.size.y + horizontalScrollBarHeight,
+                max(proposedSize.y, contentSize.minimumHeight + horizontalScrollBarHeight)
+            )
             minimumHeight = contentSize.minimumHeight + horizontalScrollBarHeight
         }
 
@@ -141,8 +146,6 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
         } else {
             finalResult = childResult
         }
-
-        print(finalResult.size)
 
         return ViewUpdateResult(
             size: ViewSize(

--- a/Sources/SwiftCrossUI/Views/ScrollView.swift
+++ b/Sources/SwiftCrossUI/Views/ScrollView.swift
@@ -61,9 +61,10 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
         let scrollBarWidth = backend.scrollBarWidth
 
         let hasHorizontalScrollBar =
-            axes.contains(.horizontal) && contentSize.idealSize.x > proposedSize.x
+            axes.contains(.horizontal) && contentSize.idealWidthForProposedHeight > proposedSize.x
         let hasVerticalScrollBar =
-            axes.contains(.vertical) && contentSize.idealSize.y > proposedSize.y
+            axes.contains(.vertical) && contentSize.idealHeightForProposedWidth > proposedSize.y
+        print(contentSize.idealHeightForProposedWidth)
 
         let verticalScrollBarWidth = hasVerticalScrollBar ? scrollBarWidth : 0
         let horizontalScrollBarHeight = hasHorizontalScrollBar ? scrollBarWidth : 0
@@ -94,12 +95,17 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
 
         let finalResult: ViewUpdateResult
         if !dryRun {
+            // TODO: scroll bar presence shouldn't affect whether we use current
+            //   or ideal size. Only the presence of the given axis in the user's
+            //   list of scroll axes should affect that.
             let proposedContentSize = SIMD2(
                 hasHorizontalScrollBar
-                    ? contentSize.idealSize.x
+                    ? (hasVerticalScrollBar
+                        ? contentSize.idealSize.x : contentSize.idealWidthForProposedHeight)
                     : min(contentSize.size.x, proposedSize.x - verticalScrollBarWidth),
                 hasVerticalScrollBar
-                    ? contentSize.idealSize.y
+                    ? (hasHorizontalScrollBar
+                        ? contentSize.idealSize.y : contentSize.idealHeightForProposedWidth)
                     : min(contentSize.size.y, proposedSize.y - horizontalScrollBarHeight)
             )
 
@@ -135,6 +141,8 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
         } else {
             finalResult = childResult
         }
+
+        print(finalResult.size)
 
         return ViewUpdateResult(
             size: ViewSize(

--- a/Sources/SwiftCrossUI/Views/TextEditor.swift
+++ b/Sources/SwiftCrossUI/Views/TextEditor.swift
@@ -1,0 +1,60 @@
+/// A control for editing multiline text.
+public struct TextEditor: ElementaryView {
+    @Binding var text: String
+
+    public init(text: Binding<String>) {
+        _text = text
+    }
+
+    func asWidget<Backend: AppBackend>(backend: Backend) -> Backend.Widget {
+        backend.createTextEditor()
+    }
+
+    func update<Backend: AppBackend>(
+        _ widget: Backend.Widget,
+        proposedSize: SIMD2<Int>,
+        environment: EnvironmentValues,
+        backend: Backend,
+        dryRun: Bool
+    ) -> ViewUpdateResult {
+        // Avoid evaluating the binding multiple times
+        let content = text
+
+        if !dryRun {
+            backend.updateTextEditor(widget, environment: environment) { newValue in
+                self.text = newValue
+            }
+            if content != backend.getContent(ofTextEditor: widget) {
+                backend.setContent(ofTextEditor: widget, to: content)
+            }
+        }
+
+        let idealHeight = backend.size(
+            of: content,
+            whenDisplayedIn: widget,
+            proposedFrame: SIMD2(proposedSize.x, 1),
+            environment: environment
+        ).y
+        let size = SIMD2(
+            proposedSize.x,
+            max(proposedSize.y, idealHeight)
+        )
+
+        if !dryRun {
+            backend.setSize(of: widget, to: size)
+        }
+
+        return ViewUpdateResult.leafView(
+            size: ViewSize(
+                size: size,
+                idealSize: SIMD2(10, 10),
+                idealWidthForProposedHeight: 10,
+                idealHeightForProposedWidth: idealHeight,
+                minimumWidth: 0,
+                minimumHeight: idealHeight,
+                maximumWidth: nil,
+                maximumHeight: nil
+            )
+        )
+    }
+}

--- a/Sources/UIKitBackend/UIKitBackend+Passive.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Passive.swift
@@ -50,7 +50,7 @@ extension UIKitBackend {
 
     public func size(
         of text: String,
-        whenDisplayedIn textView: Widget,
+        whenDisplayedIn widget: Widget,
         proposedFrame: SIMD2<Int>?,
         environment: EnvironmentValues
     ) -> SIMD2<Int> {

--- a/Sources/UIKitBackend/UIKitBackend+WebView.swift
+++ b/Sources/UIKitBackend/UIKitBackend+WebView.swift
@@ -1,5 +1,5 @@
-import WebKit
 import SwiftCrossUI
+import WebKit
 
 extension UIKitBackend {
     public func createWebView() -> Widget {


### PR DESCRIPTION
This PR introduces a `TextEditor` control for editing multi-line text. For now it's borderless (i.e. has all platform-specific 'text field' looking styles disabled) to allow for it to be used in the widest variety of use cases.

The text editor background in the NotesExample app (see screenshots below) was added using the `background` modifier and doesn't come with the text editor (unstyled by default).

## Other changes

- Added default Edit menu items to AppKitBackend's default menu to enable keyboard shortcuts such as `cmd+a`, `cmd+c`, `cmd+v` etc to be used in text inputs.
- Fixed `background` modifier's propagation of `idealHeightForWidth` and `idealWidthForHeight` (previously just set to the child view's `idealSize.x` and `idealSize.y`)
- Fixed `ScrollView`'s sizing behaviour (to a certain extent; just enough to fix `NotesExample`)

## Known issues

- GtkBackend and Gtk3Backend overestimate the required height of text editors by about half a pixel per line of text (or less) on macOS (but work fine on Linux).

## Future directions

- A `textEditorStyle` modifier to allow platform-specific decorations to be enabled (so that text editors can fit in with text fields for form-like use cases)

## Screenshots

### AppKit

<img width="400" alt="Screenshot 2025-06-22 at 1 15 27 pm" src="https://github.com/user-attachments/assets/4af920b5-b3af-4cf5-8df7-47872178c338" />

### WinUI

<img width="400" src="https://github.com/user-attachments/assets/91c5c688-3993-4636-862f-8ce9c8b2424c" />

### Gtk 4

<img width="400" src="https://github.com/user-attachments/assets/3a4c86f9-98f1-4f48-a76e-c62661ca3d69" />

### Gtk 3

The missing border radius is a known issue for Gtk3Backend.

<img width="400" src="https://github.com/user-attachments/assets/d295f071-7709-4c39-9434-a44c1b3e23a4" />

### UIKit

<img width="400" src="https://github.com/user-attachments/assets/8bfc27f7-eaa4-4a09-810a-78bae3f6d94d" />