### PR TITLE
Update example running instructions in readme and docs (with Vitor Silveira)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ import SwiftCrossUI
 import DefaultBackend
 
 @main
-struct CounterApp: App {
+struct YourApp: App {
     @State var count = 0
 
     var body: some Scene {
-        WindowGroup("CounterApp") {
+        WindowGroup("YourApp") {
             HStack {
                 Button("-") { count -= 1 }
                 Text("Count: \(count)")
@@ -80,50 +80,34 @@ struct CounterApp: App {
     }
 }
 ```
+Figure 2: *Sources/YourApp/YourApp.swift*
 
-Clone the SwiftCrossUI repository to test out this example and others. Running the examples requires an installation of [Swift Bundler](https://github.com/stackotter/swift-bundler), which provides consistent behavior across platforms and enables running on iOS and tvOS simulators and devices.
+## More examples
 
-To install Swift Bundler, you can follow [its official installation instructions](https://github.com/stackotter/swift-bundler?tab=readme-ov-file#installation-). Swift Bundler is typically installed using [Mint](https://github.com/yonaskolb/Mint?tab=readme-ov-file#installing), a Swift package manager that lets you easily install and run CLI tools distributed as Swift packages.
+The SwiftCrossUI repository contains the above example and many more. The documentation hosts [a detailed list of all examples](https://stackotter.github.io/swift-cross-ui/documentation/swiftcrossui/examples).
 
-If you don't have Mint installed, you can install it with [Homebrew](https://brew.sh/):
+Running the examples requires [Swift Bundler](https://github.com/stackotter/swift-bundler), which provides consistent behavior across platforms and enables running on iOS/tvOS devices and simulators.
 
-```sh
-brew install mint
-```
-
-Then use Mint to install Swift Bundler:
-
-```sh
-mint install stackotter/swift-bundler@main
-```
-
-Once installed, clone the project and run the example:
+To install Swift Bundler, follow [its official installation instructions](https://github.com/stackotter/swift-bundler?tab=readme-ov-file#installation-).
 
 ```sh
 git clone https://github.com/stackotter/swift-cross-ui
 cd swift-cross-ui/Examples
-swift bundler run CounterExample
+
+# Run on host machine
+swift-bundler run CounterExample
+# Run on a connected device with "iPhone" in its name (macOS only)
+swift-bundler run CounterExample --device iPhone
+# Run on a simulator with "iPhone 16" in its name (macOS only)
+swift-bundler run CounterExample --simulator "iPhone 16"
 ```
 
-You can also run on iOS and tvOS:
+These examples may also be run using SwiftPM. However, resources may not be loaded as expected, and features such as deep linking may not work. You also won't be able to run the examples on iOS or tvOS using this method.
 
 ```sh
-# On a connected device with "iPhone" in its name (macOS only)
-swift bundler run CounterExample device iPhone
-
-# On a simulator with "iPhone 16" in its name (macOS only)
-swift bundler run CounterExample simulator "iPhone 16"
-```
-
-These examples may also be run on your host machine without Swift Bundler by using SwiftPM:
-
-```sh
+# Non-recommended method
 swift run CounterExample
 ```
-
-However, resources may not be loaded as expected, and features like deep linking may not work. This method also does not support running on iOS or tvOS.
-
-The documentation contains [a detailed list of all examples](https://stackotter.github.io/swift-cross-ui/documentation/swiftcrossui/examples)
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To dive right in with SwiftCrossUI, check out [the SwiftCrossUI quick start guid
 
 ## Overview
 
-- [Overview](#overview)
 - [Community](#community)
 - [Supporting SwiftCrossUI](#supporting-swiftcrossui)
 - [Documentation](#documentation)

--- a/README.md
+++ b/README.md
@@ -81,23 +81,47 @@ struct CounterApp: App {
 }
 ```
 
-Clone the SwiftCrossUI repository to test out this example, and many more;
+Clone the SwiftCrossUI repository to test out this example and others. Running the examples requires an installation of [Swift Bundler](https://github.com/stackotter/swift-bundler), which provides consistent behavior across platforms and enables running on iOS and tvOS simulators and devices.
 
-```sh
-git clone https://github.com/stackotter/swift-cross-ui
-cd swift-cross-ui/Examples
-swift run CounterExample
-```
+To install Swift Bundler, you can follow [its official installation instructions](https://github.com/stackotter/swift-bundler?tab=readme-ov-file#installation-). Swift Bundler is typically installed using [Mint](https://github.com/yonaskolb/Mint?tab=readme-ov-file#installing), a Swift package manager that lets you easily install and run CLI tools distributed as Swift packages.
 
-The examples are written as Swift packages, which means you can't run them on iOS directly without creating an Xcode project. By using tools like [`mint`](https://github.com/yonaskolb/Mint) and [`swift-bundler`](https://github.com/stackotter/swift-bundler), running these apps on the iOS Simulator becomes much easier.
+If you don't have Mint installed, you can install it with [Homebrew](https://brew.sh/):
 
 ```sh
 brew install mint
+```
+
+Then use Mint to install Swift Bundler:
+
+```sh
 mint install stackotter/swift-bundler@main
+```
+
+Once installed, clone the project and run the example:
+
+```sh
 git clone https://github.com/stackotter/swift-cross-ui
 cd swift-cross-ui/Examples
-swift bundler run CounterExample --simulator "iPhone"
+swift bundler run CounterExample
 ```
+
+You can also run on iOS and tvOS:
+
+```sh
+# On a connected device with "iPhone" in its name (macOS only)
+swift bundler run CounterExample device iPhone
+
+# On a simulator with "iPhone 16" in its name (macOS only)
+swift bundler run CounterExample simulator "iPhone 16"
+```
+
+These examples may also be run on your host machine without Swift Bundler by using SwiftPM:
+
+```sh
+swift run CounterExample
+```
+
+However, resources may not be loaded as expected, and features like deep linking may not work. This method also does not support running on iOS or tvOS.
 
 The documentation contains [a detailed list of all examples](https://stackotter.github.io/swift-cross-ui/documentation/swiftcrossui/examples)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To dive right in with SwiftCrossUI, check out [the SwiftCrossUI quick start guid
 
 ## Overview
 
+- [Overview](#overview)
 - [Community](#community)
 - [Supporting SwiftCrossUI](#supporting-swiftcrossui)
 - [Documentation](#documentation)
@@ -87,6 +88,16 @@ Clone the SwiftCrossUI repository to test out this example, and many more;
 git clone https://github.com/stackotter/swift-cross-ui
 cd swift-cross-ui/Examples
 swift run CounterExample
+```
+
+The examples are written as Swift packages, which means you can't run them on iOS directly without creating an Xcode project. By using tools like [`mint`](https://github.com/yonaskolb/Mint) and [`swift-bundler`](https://github.com/stackotter/swift-bundler), running these apps on the iOS Simulator becomes much easier.
+
+```sh
+brew install mint
+mint install stackotter/swift-bundler@main
+git clone https://github.com/stackotter/swift-cross-ui
+cd swift-cross-ui/Examples
+swift bundler run CounterExample --simulator "iPhone"
 ```
 
 The documentation contains [a detailed list of all examples](https://stackotter.github.io/swift-cross-ui/documentation/swiftcrossui/examples)

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Examples.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Examples.md
@@ -9,22 +9,45 @@ A few examples are included with SwiftCrossUI to demonstrate some of its basic f
 - `CounterExample`, a simple app with buttons to increase and decrease a count.
 - `RandomNumberGeneratorExample`, a simple app to generate random numbers between a minimum and maximum.
 - `WindowingExample`, a simple app showcasing how ``WindowGroup`` is used to make multi-window apps and
-  control the properties of each window.
+  control the properties of each window. It also demonstrates the use of modals
+  such as alerts and file pickers.
 - `GreetingGeneratorExample`, a simple app demonstrating dynamic state and the ``ForEach`` view.
 - `NavigationExample`, an app showcasing ``NavigationStack`` and related concepts.
-- `SplitExample`, an app showcasing sidebar-based navigation with multiple levels.
+- `SplitExample`, an app showcasing ``NavigationSplitView``-based hierarchical navigation.
 - `StressTestExample`, an app used to test view update performance.
 - `SpreadsheetExample`, an app showcasing tables.
 - `ControlsExample`, an app showcasing the various types of controls available.
+- `NotesExample`, an app showcasing multi-line text editing and a more realistic usage of SwiftCrossUI.
+- `PathsExample`, an app showcasing the use of ``Path`` to draw various shapes.
+- `WebViewExample`, an app showcasing the use of ``WebView`` to display websites. Only works on Apple platforms so far.
 
-To run an example, either select the example under schemes at the top of the window (in Xcode), or run it from the command line like so:
+## Running examples
 
-```
-swift run ExampleToRun
+Running the examples requires [Swift Bundler](https://github.com/stackotter/swift-bundler), which provides consistent behavior across platforms and enables running SwiftPM-based apps on iOS/tvOS devices and simulators.
+
+To install Swift Bundler, follow [its official installation instructions](https://github.com/stackotter/swift-bundler?tab=readme-ov-file#installation-).
+
+```sh
+git clone https://github.com/stackotter/swift-cross-ui
+cd swift-cross-ui/Examples
+
+# Run on host machine
+swift-bundler run CounterExample
+# Run on a connected device with "iPhone" in its name (macOS only)
+swift-bundler run CounterExample --device iPhone
+# Run on a simulator with "iPhone 16" in its name (macOS only)
+swift-bundler run CounterExample --simulator "iPhone 16"
 ```
 
 If you want to try out an example with a backend other than the default, you can do that too;
 
+```sh
+SCUI_DEFAULT_BACKEND=Gtk3Backend swift-bundler run ExampleToRun
 ```
-SCUI_DEFAULT_BACKEND=QtBackend swift run ExampleToRun
+
+These examples may also be run using SwiftPM. However, resources may not be loaded as expected, and features such as deep linking may not work. You also won't be able to run the examples on iOS or tvOS using this method.
+
+```sh
+# Non-recommended method
+swift run CounterExample
 ```


### PR DESCRIPTION
This PR follows on from Vitor Silveira's PR #195 to address issue #194. I've moved the example running instructions to their own subheading, and compressed them down about to keep the README skimmable (with links out to more detailed instructions. I've also updated the list of examples in the documentation while I was at it and copied across the running instruction changes (cause the docs had outdated instructions as well).