### PR TITLE
[Feat] range foreach

### DIFF
--- a/Examples/Sources/HoverExample/HoverApp.swift
+++ b/Examples/Sources/HoverExample/HoverApp.swift
@@ -13,9 +13,9 @@ struct HoverExample: App {
         WindowGroup("Hover Example") {
             #hotReloadable {
                 VStack(spacing: 0) {
-                    ForEach([Bool](repeating: false, count: 18)) { _ in
+                    ForEach(1...18) { _ in
                         HStack(spacing: 0) {
-                            ForEach([Bool](repeating: false, count: 30)) { _ in
+                            ForEach(1...30) { _ in
                                 CellView()
                             }
                         }

--- a/Sources/SwiftCrossUI/Views/ForEach.swift
+++ b/Sources/SwiftCrossUI/Views/ForEach.swift
@@ -19,6 +19,8 @@ extension ForEach where Child == [MenuItem] {
 }
 
 extension ForEach where Items == [Int] {
+    /// Creates a view that creates child views on demand based on a given ClosedRange
+    @_disfavoredOverload
     public init(
         _ range: ClosedRange<Int>,
         child: @escaping (Int) -> Child
@@ -27,6 +29,8 @@ extension ForEach where Items == [Int] {
         self.child = child
     }
     
+    /// Creates a view that creates child views on demand based on a given Range
+    @_disfavoredOverload
     public init(
         _ range: Range<Int>,
         child: @escaping (Int) -> Child

--- a/Sources/SwiftCrossUI/Views/ForEach.swift
+++ b/Sources/SwiftCrossUI/Views/ForEach.swift
@@ -18,6 +18,24 @@ extension ForEach where Child == [MenuItem] {
     }
 }
 
+extension ForEach where Items == [Int] {
+    public init(
+        _ range: ClosedRange<Int>,
+        child: @escaping (Int) -> Child
+    ) {
+        self.elements = Array(range)
+        self.child = child
+    }
+    
+    public init(
+        _ range: Range<Int>,
+        child: @escaping (Int) -> Child
+    ) {
+        self.elements = Array(range)
+        self.child = child
+    }
+}
+
 extension ForEach: TypeSafeView, View where Child: View {
     typealias Children = ForEachViewChildren<Items, Child>
 


### PR DESCRIPTION
https://github.com/stackotter/swift-cross-ui/issues/213
Just adds ForEach Initializers accepting Range<Int> or ClosedRange<Int> and updated HoverExample to use the new initializer instead of the old array hack.

I expect it to work seemlessly across all supported platforms, as its just 2 new initializers