### PR TITLE
Fix Mac Catalyst button support (respect interface idiom)

### DIFF
--- a/Sources/UIKitBackend/UIKitBackend.swift
+++ b/Sources/UIKitBackend/UIKitBackend.swift
@@ -48,10 +48,6 @@ public final class UIKitBackend: AppBackend {
 
     public init() {
         self.appDelegateClass = ApplicationDelegate.self
-        print(UIDevice.current.userInterfaceIdiom == .pad)
-        if #available(macCatalyst 14.0, *) {
-            print(UIDevice.current.userInterfaceIdiom == .mac)
-        }
     }
 
     public init(appDelegateClass: ApplicationDelegate.Type) {


### PR DESCRIPTION
UIKitBackend used to render buttons as blue link-style buttons under Mac Catalyst, even when the Mac interface idiom was selected. I've updated the code to respect the system button style and to use the correct foreground colour.