### PR TITLE
Fix onDisappear modifier (fixes #230)

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/Lifecycle/OnDisappearModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Lifecycle/OnDisappearModifier.swift
@@ -10,7 +10,7 @@ extension View {
     }
 }
 
-struct OnDisappearModifier<Content: View>: View {
+struct OnDisappearModifier<Content: View>: TypeSafeView {
     var body: TupleView1<Content>
     var action: @Sendable @MainActor () -> Void
 


### PR DESCRIPTION
`OnDisappearModifier` implemented the methods required by `TypeSafeView`, but conformed to `View`, so the custom method implementations were completely ignored. Easy fix once I figured out the issue.