### PR TITLE
Create layout performance benchmarks and DummyBackend

### DIFF
--- a/Benchmarks/LayoutPerformanceBenchmark/GridView.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/GridView.swift
@@ -1,0 +1,66 @@
+import SwiftCrossUI
+
+struct Column: View {
+    var body: some View {
+        HStack {
+            Color.orange.frame(width: 5)
+            Text("Lorem ipsum dolor sit amet.")
+        }
+    }
+}
+
+struct DoubleColumn: View {
+    var body: some View {
+        HStack {
+            Column()
+            Column()
+        }
+    }
+}
+
+struct Row: View {
+    var body: some View {
+        HStack {
+            HStack {
+                DoubleColumn()
+                DoubleColumn()
+                DoubleColumn()
+                DoubleColumn()
+            }
+            HStack {
+                DoubleColumn()
+                DoubleColumn()
+                DoubleColumn()
+                DoubleColumn()
+            }
+        }
+    }
+}
+
+struct DoubleRow: View {
+    var body: some View {
+        VStack {
+            Row()
+            Row()
+        }
+    }
+}
+
+struct GridView: TestCaseView {
+    var body: some View {
+        VStack {
+            VStack {
+                DoubleRow()
+                DoubleRow()
+                DoubleRow()
+                DoubleRow()
+            }
+            VStack {
+                DoubleRow()
+                DoubleRow()
+                DoubleRow()
+                DoubleRow()
+            }
+        }
+    }
+}

--- a/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
@@ -1,0 +1,90 @@
+import Benchmark
+import SwiftCrossUI
+import DummyBackend
+import Foundation
+
+protocol TestCaseView: View {
+    init()
+}
+
+#if BENCHMARK_VIZ
+    import DefaultBackend
+
+    struct VizApp<V: TestCaseView>: App {
+        var body: some Scene {
+            WindowGroup("Benchmark visualisation") {
+                V()
+            }
+        }
+    }
+#endif
+
+@main
+struct Benchmarks {
+    @MainActor
+    static func main() async {
+        let backend = DummyBackend()
+        let defaultEnvironment = EnvironmentValues(backend: backend)
+        let environment = backend.computeRootEnvironment(defaultEnvironment: defaultEnvironment)
+            .with(\.window, backend.createWindow(withDefaultSize: nil))
+
+        @MainActor
+        func makeNode<V: View>(_ view: V) -> ViewGraphNode<V, DummyBackend> {
+            ViewGraphNode(for: view, backend: backend, snapshot: nil, environment: environment)
+        }
+
+        @MainActor
+        func updateNode<V: View>(_ node: ViewGraphNode<V, DummyBackend>, _ size: SIMD2<Int>) {
+            _ = node.update(proposedSize: size, environment: environment, dryRun: true)
+            _ = node.update(proposedSize: size, environment: environment, dryRun: false)
+        }
+
+        #if BENCHMARK_VIZ
+            var benchmarkVisualizations: [(name: String, main: () -> Never)] = []
+        #endif
+
+        @MainActor
+        func benchmarkLayout<V: TestCaseView>(of viewType: V.Type, _ size: SIMD2<Int>, _ label: String) {
+            #if BENCHMARK_VIZ
+                benchmarkVisualizations.append((
+                    label,
+                    {
+                        VizApp<V>.main()
+                        exit(0)
+                    }
+                ))
+            #else
+                let node = makeNode(V())
+                benchmark(label) { @MainActor in
+                    updateNode(node, size)
+                }
+            #endif
+        }
+
+        // Register benchmarks
+        benchmarkLayout(of: GridView.self, SIMD2(800, 800), "grid")
+        benchmarkLayout(of: ScrollableMessageListView.self, SIMD2(800, 800), "message list")
+
+        #if BENCHMARK_VIZ
+            let names = benchmarkVisualizations.map(\.name).joined(separator: " | ")
+            print("Benchmark to viz (\(names)): ", terminator: "")
+            guard let benchmarkName = readLine() else {
+                print("Nothing entered")
+                exit(1)
+            }
+
+            guard
+                let benchmark = benchmarkVisualizations.first(
+                    where: { $0.name == benchmarkName }
+                )
+            else {
+                print("\(benchmarkName) doesn't match any benchmarks")
+                exit(1)
+            }
+
+            benchmark.main()
+        #else
+            await Benchmark.main()
+        #endif
+    }
+}

--- a/Benchmarks/LayoutPerformanceBenchmark/ScrollableMessageListView.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/ScrollableMessageListView.swift
@@ -1,0 +1,99 @@
+import SwiftCrossUI
+
+struct MessageView: View {
+    static let profileSize = 40
+
+    var message: ScrollableMessageListView.Message
+
+    var body: some View {
+        HStack(alignment: .top) {
+            message.author.profileColor
+                .frame(width: Self.profileSize, height: Self.profileSize)
+                .cornerRadius(Self.profileSize / 2)
+
+            VStack(alignment: .leading) {
+                HStack {
+                    Text(message.author.name)
+                        .foregroundColor(message.author.handleColor)
+                        .emphasized()
+
+                    Text(message.time)
+                        .foregroundColor(.gray)
+                }
+
+                Text(message.content)
+            }
+        }
+    }
+}
+
+struct ScrollableMessageListView: TestCaseView {
+    static let authors = [
+        Author(name: "stackotter", handleColor: .blue, profileColor: .pink),
+        Author(name: "gregc", handleColor: .yellow, profileColor: .yellow),
+        Author(name: "bbrk24", handleColor: .purple, profileColor: .green)
+    ]
+
+    static let sentences = [
+        "in the meantime you should be able to disable hot reloading support on linux at line 107 of Package.swift. hot reloading isn't actually supported on linux (it'll tell you that it's unsupported if you try to use hot reloading at runtime), i just left the code enabled to catch cross-platform regressions like this one hahah",
+        "I assume stroke style gets overridden? if so we can make path store stroke style and then StyledShape can store another strokestyle if it wants, and when it produces the path it just overwrites its strokestyle before passing it on or something",
+        "I am hesitant to completely mimic SwiftUI here because you can set stroke style on both Path and Shape, but stroke color only on Shape, so I have no idea what happens if you give them conflicting stroke styles",
+        "I think stroke and fill modifiers on Shape would be a bit nicer. we could get them to return StyledShape or something and then implement the same two modifiers on StyledShape and get StyledShape to store fill and stroke",
+        "Computer Software Is Hard"
+    ]
+
+    static let times = [
+        "8:54am",
+        "9:13am",
+        "10:20pm",
+        "12:01am",
+        "1:00pm"
+    ]
+
+    static let messages = generateMessages(1000)
+
+    struct Author {
+        var name: String
+        var handleColor: Color
+        var profileColor: Color
+
+        static let empty = Self(
+            name: "<no name>",
+            handleColor: .white,
+            profileColor: .white
+        )
+    }
+
+    struct Message {
+        var author: Author
+        var content: String
+        var time: String
+    }
+
+    static func generateMessages(_ count: Int) -> [Message] {
+        var messages: [Message] = []
+        messages.reserveCapacity(count)
+
+        for i in 0..<count {
+            let message = Message(
+                author: authors[i % authors.count],
+                content: sentences[i % sentences.count],
+                time: times[i % times.count]
+            )
+            messages.append(message)
+        }
+        return messages
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                ForEach(Self.messages) { message in
+                    MessageView(message: message)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(20)
+        }
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b87bbc3d0f0110380f592dc86a1c8c65c20f5a326f484bdbe2f6ef5e357840d",
+  "originHash" : "77caf3e84e88f2ff183c89c647d8007a7ba7b50bfb1fb7216b22f7dfda4a2dc0",
   "pins" : [
     {
       "identity" : "jpeg",
@@ -26,6 +26,24 @@
       "state" : {
         "revision" : "5f745a17b9a5c2a4283f17c2cde4517610ab5f99",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
+        "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-benchmark",
+      "state" : {
+        "revision" : "45a7b500c24e7243da7b02e19cf436d0107a0c1b",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,18 @@ switch ProcessInfo.processInfo.environment["SCUI_LIBRARY_TYPE"] {
         }
 }
 
+// When SCUI_BENCHMARK_VIZ is present, we include the DefaultBackend to allow
+// viewing of each benchmark test case with an actual backend.
+let additionalLayoutPerformanceBenchmarkDependencies: [Target.Dependency]
+let layoutPerformanceSwiftSettings: [SwiftSetting]
+if ProcessInfo.processInfo.environment["SCUI_BENCHMARK_VIZ"] == "1" {
+    additionalLayoutPerformanceBenchmarkDependencies = ["DefaultBackend"]
+    layoutPerformanceSwiftSettings = [.define("BENCHMARK_VIZ")]
+} else {
+    additionalLayoutPerformanceBenchmarkDependencies = []
+    layoutPerformanceSwiftSettings = []
+}
+
 let package = Package(
     name: "swift-cross-ui",
     platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .macCatalyst(.v13), .visionOS(.v1)],
@@ -109,6 +121,10 @@ let package = Package(
         .package(
             url: "https://github.com/stackotter/swift-winui",
             revision: "1695ee3ea2b7a249f6504c7f1759e7ec7a38eb86"
+        ),
+        .package(
+            url: "https://github.com/stackotter/swift-benchmark",
+            .upToNextMinor(from: "0.2.0")
         ),
         // .package(
         //     url: "https://github.com/stackotter/TermKit",
@@ -252,6 +268,19 @@ let package = Package(
             name: "WinUIInterop",
             dependencies: []
         ),
+        .target(name: "DummyBackend", dependencies: ["SwiftCrossUI"]),
+
+        .executableTarget(
+            name: "LayoutPerformanceBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "swift-benchmark"),
+                "SwiftCrossUI",
+                "DummyBackend",
+            ] + additionalLayoutPerformanceBenchmarkDependencies,
+            path: "Benchmarks/LayoutPerformanceBenchmark",
+            swiftSettings: layoutPerformanceSwiftSettings
+        ),
+
         // .target(
         //     name: "CursesBackend",
         //     dependencies: ["SwiftCrossUI", "TermKit"]

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -1,0 +1,665 @@
+import SwiftCrossUI
+import Foundation
+
+public final class DummyBackend: AppBackend {
+    public class Window {
+        static let defaultSize = SIMD2<Int>(400, 200)
+
+        public var size: SIMD2<Int>
+        public var minimumSize: SIMD2<Int> = .zero
+        public var title = "Window"
+        public var resizable = true
+        public var content: Widget?
+        public var resizeHandler: ((SIMD2<Int>) -> Void)?
+
+        public init(defaultSize: SIMD2<Int>?) {
+            size = defaultSize ?? Self.defaultSize
+        }
+    }
+
+    public class Widget {
+        public var tag: String?
+        public var cornerRadius = 0
+        public var size = SIMD2<Int>.zero
+        public var naturalSize: SIMD2<Int> {
+            SIMD2<Int>.zero
+        }
+    }
+
+    public class Button: Widget {
+        public var label = ""
+        public var font: Font.Resolved?
+        public var action: (() -> Void)?
+        public var menu: Menu?
+    }
+
+    public class ToggleButton: Widget {
+        public var label = ""
+        public var font: Font.Resolved?
+        public var toggleHandler: ((Bool) -> Void)?
+        public var state = false
+    }
+
+    public class ToggleSwitch: Widget {
+        public var toggleHandler: ((Bool) -> Void)?
+        public var state = false
+
+        override public var naturalSize: SIMD2<Int> {
+            SIMD2(20, 10)
+        }
+    }
+
+    public class Checkbox: Widget {
+        public var toggleHandler: ((Bool) -> Void)?
+        public var state = false
+
+        override public var naturalSize: SIMD2<Int> {
+            SIMD2(10, 10)
+        }
+    }
+
+    public class Slider: Widget {
+        public var value: Double = 0
+        public var minimumValue: Double = 0
+        public var maximumValue: Double = 100
+        public var decimalPlaces = 1
+        public var changeHandler: ((Double) -> Void)?
+        
+        override public var naturalSize: SIMD2<Int> {
+            SIMD2(20, 10)
+        }
+    }
+
+    public class TextField: Widget {
+        public var value = ""
+        public var placeholder = ""
+        public var font: Font.Resolved?
+        public var changeHandler: ((String) -> Void)?
+        public var submitHandler: (() -> Void)?
+    }
+
+    public class TextView: Widget {
+        public var content: String = ""
+        public var font: Font.Resolved?
+        public var color = Color.black
+    }
+
+    public class ImageView: Widget {
+        public var rgbaData: [UInt8] = []
+        public var pixelWidth = 0
+        public var pixelHeight = 0
+    }
+
+    public class Table: Widget {
+        public var rowCount = 0
+        public var columnLabels: [String] = []
+        public var cells: [Widget] = []
+        public var rowHeights: [Int] = []
+    }
+
+    public class Container: Widget {
+        public var children: [(widget: Widget, position: SIMD2<Int>)] = []
+    }
+
+    public class ScrollContainer: Widget {
+        public var child: Widget
+        public var hasVerticalScrollBar = false
+        public var hasHorizontalScrollBar = false
+
+        public init(child: Widget) {
+            self.child = child
+        }
+    }
+
+    public class SelectableListView: Widget {
+        public var items: [Widget] = []
+        public var rowHeights: [Int] = []
+        public var selectionHandler: ((Int) -> Void)?
+        public var selectedIndex: Int?
+    }
+
+    public class Rectangle: Widget {
+        public var color = Color.clear
+    }
+
+    public class SplitView: Widget {
+        public var leadingChild: Widget
+        public var trailingChild: Widget
+
+        public var sidebarResizeHandler: (() -> Void)?
+
+        private var _sidebarWidth = 100
+
+        public var sidebarWidth: Int {
+            get {
+                _sidebarWidth
+            }
+            set {
+                var width = newValue
+                if let minimumSidebarWidth {
+                    width = max(minimumSidebarWidth, width)
+                }
+                if let maximumSidebarWidth {
+                    width = min(maximumSidebarWidth, width)
+                }
+                width = max(0, min(size.x, width))
+                _sidebarWidth = width
+            }
+        }
+
+        public var minimumSidebarWidth: Int? {
+            didSet {
+                if let minimumSidebarWidth {
+                    sidebarWidth = max(minimumSidebarWidth, sidebarWidth)
+                }
+            }
+        }
+
+        public var maximumSidebarWidth: Int? {
+            didSet {
+                if let maximumSidebarWidth {
+                    sidebarWidth = min(maximumSidebarWidth, sidebarWidth)
+                }
+            }
+        }
+
+        override public var size: SIMD2<Int> {
+            didSet {
+                if sidebarWidth > size.x {
+                    sidebarWidth = size.x
+                }
+            }
+        }
+
+        public init(leadingChild: Widget, trailingChild: Widget) {
+            self.leadingChild = leadingChild
+            self.trailingChild = trailingChild
+        }
+    }
+
+    public class Menu {}
+
+    public class Alert {}
+
+    public class Path {}
+
+    public class Sheet {}
+
+    public var defaultTableRowContentHeight = 10
+    public var defaultTableCellVerticalPadding = 10
+    public var defaultPaddingAmount = 10
+    public var scrollBarWidth = 8
+    public var requiresToggleSwitchSpacer = false
+    public var requiresImageUpdateOnScaleFactorChange = false
+    public var menuImplementationStyle = MenuImplementationStyle.dynamicPopover
+    public var deviceClass = DeviceClass.desktop
+    public var canRevealFiles = false
+
+    public init() {}
+
+    public func runMainLoop(_ callback: @escaping @MainActor () -> Void) {
+        callback()
+    }
+
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+        Window(defaultSize: defaultSize)
+    }
+
+    public func setTitle(ofWindow window: Window, to title: String) {
+        window.title = title
+    }
+
+    public func setResizability(ofWindow window: Window, to resizable: Bool) {
+        window.resizable = resizable
+    }
+
+    public func setChild(ofWindow window: Window, to child: Widget) {
+        window.content = child
+    }
+
+    public func size(ofWindow window: Window) -> SIMD2<Int> {
+        window.size
+    }
+
+    public func isWindowProgrammaticallyResizable(_ window: Window) -> Bool {
+        true
+    }
+
+    public func setSize(ofWindow window: Window, to newSize: SIMD2<Int>) {
+        window.size = newSize
+    }
+
+    public func setMinimumSize(ofWindow window: Window, to minimumSize: SIMD2<Int>) {
+        window.minimumSize = minimumSize
+    }
+
+    public func setResizeHandler(ofWindow window: Window, to action: @escaping (SIMD2<Int>) -> Void) {
+        window.resizeHandler = action
+    }
+
+    public func show(window: Window) {}
+
+    public func activate(window: Window) {}
+
+    public func runInMainThread(action: @escaping @MainActor () -> Void) {
+        DispatchQueue.main.async {
+            action()
+        }
+    }
+
+    public func computeRootEnvironment(defaultEnvironment: EnvironmentValues) -> EnvironmentValues {
+        defaultEnvironment
+    }
+
+    public func setRootEnvironmentChangeHandler(to action: @escaping () -> Void) {}
+
+    public func computeWindowEnvironment(window: Window, rootEnvironment: EnvironmentValues) -> EnvironmentValues {
+        rootEnvironment
+    }
+
+    public func setWindowEnvironmentChangeHandler(of window: Window, to action: @escaping () -> Void) {}
+
+    public func show(widget: Widget) {}
+
+    public func tag(widget: Widget, as tag: String) {
+        widget.tag = tag
+    }
+
+    public func createContainer() -> Widget {
+        Container()
+    }
+
+    public func removeAllChildren(of container: Widget) {
+        (container as! Container).children = []
+    }
+
+    public func addChild(_ child: Widget, to container: Widget) {
+        (container as! Container).children.append((child, .zero))
+    }
+
+    public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
+        (container as! Container).children[index].position = position
+    }
+
+    public func removeChild(_ child: Widget, from container: Widget) {
+        let container = container as! Container
+        let index = container.children.firstIndex { (widget, position) in
+            widget === child
+        }
+        if let index {
+            container.children.remove(at: index)
+        }
+    }
+
+    public func createColorableRectangle() -> Widget {
+        Rectangle()
+    }
+
+    public func setColor(ofColorableRectangle widget: Widget, to color: Color) {
+        (widget as! Rectangle).color = color
+    }
+
+    public func setCornerRadius(of widget: Widget, to radius: Int) {
+        widget.cornerRadius = radius
+    }
+
+    public func naturalSize(of widget: Widget) -> SIMD2<Int> {
+        widget.naturalSize
+    }
+
+    public func setSize(of widget: Widget, to size: SIMD2<Int>) {
+        widget.size = size
+    }
+
+    public func createScrollContainer(for child: Widget) -> Widget {
+        ScrollContainer(child: child)
+    }
+
+    public func updateScrollContainer(_ scrollView: Widget, environment: EnvironmentValues) {}
+
+    public func setScrollBarPresence(ofScrollContainer scrollView: Widget, hasVerticalScrollBar: Bool, hasHorizontalScrollBar: Bool) {
+        let scrollContainer = scrollView as! ScrollContainer
+        scrollContainer.hasVerticalScrollBar = hasVerticalScrollBar
+        scrollContainer.hasHorizontalScrollBar = hasHorizontalScrollBar
+    }
+
+    public func createSelectableListView() -> Widget {
+        SelectableListView()
+    }
+
+    public func baseItemPadding(ofSelectableListView listView: Widget) -> EdgeInsets {
+        EdgeInsets(top: 0, bottom: 0, leading: 0, trailing: 0)
+    }
+
+    public func minimumRowSize(ofSelectableListView listView: Widget) -> SIMD2<Int> {
+        .zero
+    }
+
+    public func setItems(ofSelectableListView listView: Widget, to items: [Widget], withRowHeights rowHeights: [Int]) {
+        let selectableListView = listView as! SelectableListView
+        selectableListView.items = items
+        selectableListView.rowHeights = rowHeights
+    }
+
+    public func setSelectionHandler(forSelectableListView listView: Widget, to action: @escaping (Int) -> Void) {
+        (listView as! SelectableListView).selectionHandler = action
+    }
+
+    public func setSelectedItem(ofSelectableListView listView: Widget, toItemAt index: Int?) {
+        (listView as! SelectableListView).selectedIndex = index
+    }
+
+    public func createSplitView(leadingChild: Widget, trailingChild: Widget) -> Widget {
+        SplitView(
+            leadingChild: leadingChild,
+            trailingChild: trailingChild
+        )
+    }
+
+    public func setResizeHandler(ofSplitView splitView: Widget, to action: @escaping () -> Void) {
+        (splitView as! SplitView).sidebarResizeHandler = action
+    }
+
+    public func sidebarWidth(ofSplitView splitView: Widget) -> Int {
+        (splitView as! SplitView).sidebarWidth
+    }
+
+    public func setSidebarWidthBounds(ofSplitView splitView: Widget, minimum minimumWidth: Int, maximum maximumWidth: Int) {
+        let splitView = splitView as! SplitView
+        splitView.minimumSidebarWidth = minimumWidth
+        splitView.maximumSidebarWidth = maximumWidth
+    }
+
+    public func size(of text: String, whenDisplayedIn widget: Widget, proposedFrame: SIMD2<Int>?, environment: EnvironmentValues) -> SIMD2<Int> {
+        let resolvedFont = environment.resolvedFont
+        let lineHeight = Int(resolvedFont.lineHeight)
+        let characterHeight = Int(resolvedFont.pointSize)
+        let characterWidth = characterHeight * 2 / 3
+
+        guard let proposedFrame else {
+            return SIMD2(
+                characterWidth * text.count,
+                lineHeight
+            )
+        }
+
+        let charactersPerLine = max(1, proposedFrame.x / characterWidth)
+        let lineCount = (text.count + charactersPerLine - 1) / charactersPerLine
+        return SIMD2(
+            characterWidth * charactersPerLine,
+            lineHeight * lineCount
+        )
+    }
+
+    public func createTextView() -> Widget {
+        TextView()
+    }
+
+    public func updateTextView(_ textView: Widget, content: String, environment: EnvironmentValues) {
+        let textView = textView as! TextView
+        textView.content = content
+        textView.color = environment.suggestedForegroundColor
+        textView.font = environment.resolvedFont
+    }
+
+    public func createImageView() -> Widget {
+        ImageView()
+    }
+
+    public func updateImageView(_ imageView: Widget, rgbaData: [UInt8], width: Int, height: Int, targetWidth: Int, targetHeight: Int, dataHasChanged: Bool, environment: EnvironmentValues) {
+        let imageView = imageView as! ImageView
+        imageView.rgbaData = rgbaData
+        imageView.pixelWidth = width
+        imageView.pixelHeight = height
+    }
+
+    public func createTable() -> Widget {
+        Table()
+    }
+
+    public func setRowCount(ofTable table: Widget, to rows: Int) {
+        (table as! Table).rowCount = rows
+    }
+
+    public func setColumnLabels(ofTable table: Widget, to labels: [String], environment: EnvironmentValues) {
+        (table as! Table).columnLabels = labels
+    }
+
+    public func setCells(ofTable table: Widget, to cells: [Widget], withRowHeights rowHeights: [Int]) {
+        let table = table as! Table
+        table.cells = cells
+        table.rowHeights = rowHeights
+    }
+
+    public func createButton() -> Widget {
+        Button()
+    }
+
+    public func updateButton(_ button: Widget, label: String, environment: EnvironmentValues, action: @escaping () -> Void) {
+        let button = button as! Button
+        button.label = label
+        button.action = action
+    }
+
+    public func updateButton(_ button: Widget, label: String, menu: Menu, environment: EnvironmentValues) {
+        let button = button as! Button
+        button.label = label
+        button.menu = menu
+        button.font = environment.resolvedFont
+    }
+
+    public func createToggle() -> Widget {
+        ToggleButton()
+    }
+
+    public func updateToggle(_ toggle: Widget, label: String, environment: EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        let toggle = toggle as! ToggleButton
+        toggle.label = label
+        toggle.toggleHandler = onChange
+        toggle.font = environment.resolvedFont
+    }
+
+    public func setState(ofToggle toggle: Widget, to state: Bool) {
+        (toggle as! ToggleButton).state = state
+    }
+
+    public func createSwitch() -> Widget {
+        ToggleSwitch()
+    }
+
+    public func updateSwitch(_ switchWidget: Widget, environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        (switchWidget as! ToggleSwitch).toggleHandler = onChange
+    }
+
+    public func setState(ofSwitch switchWidget: Widget, to state: Bool) {
+        (switchWidget as! ToggleSwitch).state = state
+    }
+
+    public func createCheckbox() -> Widget {
+        Checkbox()
+    }
+
+    public func updateCheckbox(_ checkboxWidget: Widget, environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        (checkboxWidget as! Checkbox).toggleHandler = onChange
+    }
+
+    public func setState(ofCheckbox checkboxWidget: Widget, to state: Bool) {
+        (checkboxWidget as! Checkbox).state = state
+    }
+
+    public func createSlider() -> Widget {
+        Slider()
+    }
+
+    public func updateSlider(_ slider: Widget, minimum: Double, maximum: Double, decimalPlaces: Int, environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (Double) -> Void) {
+        let slider = slider as! Slider
+        slider.minimumValue = minimum
+        slider.maximumValue = maximum
+        slider.decimalPlaces = decimalPlaces
+        slider.changeHandler = onChange
+    }
+
+    public func setValue(ofSlider slider: Widget, to value: Double) {
+        (slider as! Slider).value = value
+    }
+
+    public func createTextField() -> Widget {
+        TextField()
+    }
+
+    public func updateTextField(_ textField: Widget, placeholder: String, environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (String) -> Void, onSubmit: @escaping () -> Void) {
+        let textField = textField as! TextField
+        textField.placeholder = placeholder
+        textField.font = environment.resolvedFont
+        textField.changeHandler = onChange
+        textField.submitHandler = onSubmit
+    }
+
+    public func setContent(ofTextField textField: Widget, to content: String) {
+        (textField as! TextField).value = content
+    }
+
+    public func getContent(ofTextField textField: Widget) -> String {
+        (textField as! TextField).value
+    }
+
+    // public func createTextEditor() -> Widget {
+        
+    // }
+
+    // public func updateTextEditor(_ textEditor: Widget, environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (String) -> Void) {
+        
+    // }
+
+    // public func setContent(ofTextEditor textEditor: Widget, to content: String) {
+        
+    // }
+
+    // public func getContent(ofTextEditor textEditor: Widget) -> String {
+        
+    // }
+
+    // public func createPicker() -> Widget {
+        
+    // }
+
+    // public func updatePicker(_ picker: Widget, options: [String], environment: SwiftCrossUI.EnvironmentValues, onChange: @escaping (Int?) -> Void) {
+        
+    // }
+
+    // public func setSelectedOption(ofPicker picker: Widget, to selectedOption: Int?) {
+        
+    // }
+
+    // public func createProgressSpinner() -> Widget {
+        
+    // }
+
+    // public func createProgressBar() -> Widget {
+        
+    // }
+
+    // public func updateProgressBar(_ widget: Widget, progressFraction: Double?, environment: SwiftCrossUI.EnvironmentValues) {
+        
+    // }
+
+    // public func createPopoverMenu() -> Menu {
+        
+    // }
+
+    // public func updatePopoverMenu(_ menu: Menu, content: SwiftCrossUI.ResolvedMenu, environment: SwiftCrossUI.EnvironmentValues) {
+        
+    // }
+
+    // public func showPopoverMenu(_ menu: Menu, at position: SIMD2<Int>, relativeTo widget: Widget, closeHandler handleClose: @escaping () -> Void) {
+        
+    // }
+
+    // public func createAlert() -> Alert {
+        
+    // }
+
+    // public func updateAlert(_ alert: Alert, title: String, actionLabels: [String], environment: SwiftCrossUI.EnvironmentValues) {
+        
+    // }
+
+    // public func showAlert(_ alert: Alert, window: Window?, responseHandler handleResponse: @escaping (Int) -> Void) {
+        
+    // }
+
+    // public func dismissAlert(_ alert: Alert, window: Window?) {
+        
+    // }
+
+    // public func createSheet(content: Widget) -> Sheet {
+        
+    // }
+
+    // public func updateSheet(_ sheet: Sheet, window: Window, environment: SwiftCrossUI.EnvironmentValues, size: SIMD2<Int>, onDismiss: @escaping () -> Void, cornerRadius: Double?, detents: [SwiftCrossUI.PresentationDetent], dragIndicatorVisibility: SwiftCrossUI.Visibility, backgroundColor: SwiftCrossUI.Color?, interactiveDismissDisabled: Bool) {
+        
+    // }
+
+    // public func presentSheet(_ sheet: Sheet, window: Window, parentSheet: Sheet?) {
+        
+    // }
+
+    // public func dismissSheet(_ sheet: Sheet, window: Window, parentSheet: Sheet?) {
+        
+    // }
+
+    // public func size(ofSheet sheet: Sheet) -> SIMD2<Int> {
+        
+    // }
+
+    // public func showOpenDialog(fileDialogOptions: SwiftCrossUI.FileDialogOptions, openDialogOptions: SwiftCrossUI.OpenDialogOptions, window: Window?, resultHandler handleResult: @escaping (SwiftCrossUI.DialogResult<[URL]>) -> Void) {
+        
+    // }
+
+    // public func showSaveDialog(fileDialogOptions: SwiftCrossUI.FileDialogOptions, saveDialogOptions: SwiftCrossUI.SaveDialogOptions, window: Window?, resultHandler handleResult: @escaping (SwiftCrossUI.DialogResult<URL>) -> Void) {
+        
+    // }
+
+    // public func createTapGestureTarget(wrapping child: Widget, gesture: SwiftCrossUI.TapGesture) -> Widget {
+        
+    // }
+
+    // public func updateTapGestureTarget(_ tapGestureTarget: Widget, gesture: SwiftCrossUI.TapGesture, environment: SwiftCrossUI.EnvironmentValues, action: @escaping () -> Void) {
+        
+    // }
+
+    // public func createHoverTarget(wrapping child: Widget) -> Widget {
+        
+    // }
+
+    // public func updateHoverTarget(_ hoverTarget: Widget, environment: SwiftCrossUI.EnvironmentValues, action: @escaping (Bool) -> Void) {
+        
+    // }
+
+    // public func createPathWidget() -> Widget {
+        
+    // }
+
+    // public func createPath() -> Path {
+        
+    // }
+
+    // public func updatePath(_ path: Path, _ source: SwiftCrossUI.Path, bounds: SwiftCrossUI.Path.Rect, pointsChanged: Bool, environment: SwiftCrossUI.EnvironmentValues) {
+        
+    // }
+
+    // public func renderPath(_ path: Path, container: Widget, strokeColor: SwiftCrossUI.Color, fillColor: SwiftCrossUI.Color, overrideStrokeStyle: SwiftCrossUI.StrokeStyle?) {
+        
+    // }
+
+    // public func createWebView() -> Widget {
+        
+    // }
+
+    // public func updateWebView(_ webView: Widget, environment: SwiftCrossUI.EnvironmentValues, onNavigate: @escaping (URL) -> Void) {
+        
+    // }
+
+    // public func navigateWebView(_ webView: Widget, to url: URL) {
+        
+    // }
+}

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -196,7 +196,7 @@ public struct EnvironmentValues {
     }
 
     /// Creates the default environment.
-    init<Backend: AppBackend>(backend: Backend) {
+    package init<Backend: AppBackend>(backend: Backend) {
         self.backend = backend
 
         onResize = { _ in }


### PR DESCRIPTION
This PR introduces some layout performance benchmarks which I'll be using to measure the performance improvements I make in the coming days.

## Current results

I ran the benchmarks on my M2 MacBook Air with 8gb of RAM.

```console
$ swift run -c release LayoutPerformanceBenchmark --time-unit ms
...
running grid... done! (7234.56 ms)
running message list... done! (2156.93 ms)

name         time        std        iterations
----------------------------------------------
grid         2461.910 ms ±   0.74 %          2
message list 1374.303 ms ±   0.70 %          2
```

## Visualisation

To view the benchmark test cases with your own eyes, build the benchmarks with `SCUI_BENCHMARK_VIZ=1` set in your environment. Then when you run the benchmarks you'll be prompted to enter the name of the benchmark test case that you'd like to view. The benchmark runner will then run the chosen test case using `DefaultBackend`.

On my M2 MacBook Air with 8gb of RAM, `grid` takes around 52 seconds to appear and `message list` takes about 26 seconds to appear.

These times are inflated compared to the actual benchmarks because under the hood SwiftCrossUI lays out the contents of windows multiple times as it decides on the size of the window. That said, a factor of 20 is quite extreme. In addition to updating its content multiple times, WindowGroupNode also uses different sizes in its dry runs vs its actual runs, which would increase the number of cache misses during the actual update run (when compared to our benchmark).