### PR TITLE
Update WinUIBackend dependency wording for clarity

### DIFF
--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/WinUIBackend.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/WinUIBackend.md
@@ -8,7 +8,7 @@ WinUIBackend supports both ARM64 and x64 Windows 10/11 computers. It is the reco
 
 ## System dependencies
 
-Before you can use WinUIBackend you must install two dependencies; the former is only required at compile time while the later is only required at runtime.
+Before you can use WinUIBackend you must install two dependencies; the former is only required at compile time while the later is only required at runtime. If you're developing an app, you need both.
 
 1. Install Windows SDK 10.0.17736;
    ```sh


### PR DESCRIPTION
A user of SwiftCrossUI found the wording of the docs to be a bit ambiguous about which dependencies are required as a developer. I agree that it'd be reasonable to assume that you could get away with only installing the SDK, so I've added an extra sentence to make things a bit more clear.