### PR TITLE
UIKitBackend: Fix text rendering (set NSTextContainer.lineFragmentPadding to 0)

### DIFF
--- a/Examples/Sources/CounterExample/CounterApp.swift
+++ b/Examples/Sources/CounterExample/CounterApp.swift
@@ -18,6 +18,11 @@ struct CounterApp: App {
                         count -= 1
                     }
                     Text("Count: \(count)")
+                        .overlay {
+                            GeometryReader { proxy in
+                                Color.blue.opacity(0.5)
+                            }
+                        }
                     Button("+") {
                         count += 1
                     }

--- a/Sources/UIKitBackend/UIKitBackend+Passive.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Passive.swift
@@ -131,6 +131,7 @@ final class CustomTextView: UIView {
 
         textContainer = NSTextContainer(size: frame.size)
         textContainer.lineBreakMode = .byTruncatingTail
+        textContainer.lineFragmentPadding = 0
         layoutManager.addTextContainer(textContainer)
 
         super.init(frame: frame)


### PR DESCRIPTION
#278 broke UIKitBackend's Text implementation when switching from UILabel to a custom text rendering UIView implementation. It didn't override its NSTextContainer's lineFragmentPadding, so the text content got rendered with a horizontal offset and ended up clipping even when there was available space.