### PR TITLE
Add `environment(_:_:)` and `transformEnvironment(_:transform:)` to `Scene`

### DIFF
--- a/Sources/SwiftCrossUI/Scenes/Modifiers/SceneEnvironmentModifier.swift
+++ b/Sources/SwiftCrossUI/Scenes/Modifiers/SceneEnvironmentModifier.swift
@@ -1,0 +1,84 @@
+extension Scene {
+    /// Modifies the scene's environment.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the environment value to update.
+    ///   - newValue: The new value.
+    public func environment<T>(
+        _ keyPath: WritableKeyPath<EnvironmentValues, T>,
+        _ newValue: T
+    ) -> some Scene {
+        SceneEnvironmentModifier(self) { environment in
+            environment.with(keyPath, newValue)
+        }
+    }
+
+    /// Modifies the scene's environment.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path to the environment value to update.
+    ///   - transform: A closure that transforms the environment at `keyPath`.
+    public func transformEnvironment<T>(
+        _ keyPath: WritableKeyPath<EnvironmentValues, T>,
+        transform: @escaping (inout T) -> Void
+    ) -> some Scene {
+        SceneEnvironmentModifier(self) { environment in
+            var value = environment[keyPath: keyPath]
+            transform(&value)
+            return environment.with(keyPath, value)
+        }
+    }
+}
+
+struct SceneEnvironmentModifier<Content: Scene>: Scene {
+    typealias Node = SceneEnvironmentModifierNode<Content>
+
+    var content: Content
+    var modification: (EnvironmentValues) -> EnvironmentValues
+
+    var commands: Commands { content.commands }
+
+    init(
+        _ content: Content,
+        modification: @escaping (EnvironmentValues) -> EnvironmentValues
+    ) {
+        self.content = content
+        self.modification = modification
+    }
+}
+
+final class SceneEnvironmentModifierNode<Content: Scene>: SceneGraphNode {
+    typealias NodeScene = SceneEnvironmentModifier<Content>
+
+    var modification: (EnvironmentValues) -> EnvironmentValues
+    var contentNode: Content.Node
+
+    init<Backend: AppBackend>(
+        from scene: NodeScene,
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        self.modification = scene.modification
+        contentNode = Content.Node(
+            from: scene.content,
+            backend: backend,
+            environment: modification(environment)
+        )
+    }
+
+    func update<Backend: AppBackend>(
+        _ newScene: NodeScene?,
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        if let newScene {
+            self.modification = newScene.modification
+        }
+
+        contentNode.update(
+            newScene?.content,
+            backend: backend,
+            environment: modification(environment)
+        )
+    }
+}


### PR DESCRIPTION
`environment(_:_:)` on `Scene` behaves almost identically to the corresponding modifier on `View`, setting the given environment value for all views in the scene. `transformEnvironment(_:transform:)` is similar, but allows the caller to perform arbitrary operations on the environment value rather than being limited to overwriting it entirely. (Both APIs have equivalents in SwiftUI.)