### PR TITLE
Set translatesAutoresizingMaskIntoConstraints to false

### DIFF
--- a/Sources/UIKitBackend/UIViewControllerRepresentable.swift
+++ b/Sources/UIKitBackend/UIViewControllerRepresentable.swift
@@ -169,7 +169,6 @@ final class ControllerRepresentingWidget<
         view.addSubview(subcontroller.view)
         addChild(subcontroller)
 
-        view.translatesAutoresizingMaskIntoConstraints = false
         subcontroller.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             subcontroller.view.topAnchor.constraint(equalTo: view.topAnchor),

--- a/Sources/UIKitBackend/Widget.swift
+++ b/Sources/UIKitBackend/Widget.swift
@@ -284,6 +284,11 @@ class BaseControllerWidget: UIViewController, WidgetProtocolHelpers {
         }
         view.removeFromSuperview()
     }
+
+    override func viewDidLoad() {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        super.viewDidLoad()
+    }
 }
 
 class WrapperWidget<View: UIView>: BaseViewWidget {


### PR DESCRIPTION
Fixes #333, at least mostly. (The other part is that the initial render is wrong. Triggering a relayout, such as by rotating the device, fixes it.)