### PR TITLE
Optimize ForEach updates (fixes #331 and #300)

### DIFF
--- a/Examples/Sources/ForEachExample/ForEachApp.swift
+++ b/Examples/Sources/ForEachExample/ForEachApp.swift
@@ -42,23 +42,24 @@ struct ForEachApp: App {
                     .padding(10)
 
                     ScrollView {
-                        ForEach(Array(items.enumerated()), id: \.element.id) { (index, item) in
-                            ItemRow(
-                                item: item,
-                                isFirst: index == 0,
-                                isLast: index == items.count - 1
-                            ) {
-                                items.remove(at: index)
-                            } moveUp: {
-                                guard index != items.startIndex else { return }
-                                items.swapAt(index, index - 1)
-                            } moveDown: {
-                                guard index != items.endIndex else { return }
-                                items.swapAt(index, index + 1)
+                        VStack(alignment: .trailing) {
+                            ForEach(Array(items.enumerated()), id: \.element.id) { (index, item) in
+                                ItemRow(
+                                    item: $items[index],
+                                    isFirst: index == 0,
+                                    isLast: index == items.count - 1
+                                ) {
+                                    items.remove(at: index)
+                                } moveUp: {
+                                    guard index != items.startIndex else { return }
+                                    items.swapAt(index, index - 1)
+                                } moveDown: {
+                                    guard index != items.endIndex else { return }
+                                    items.swapAt(index, index + 1)
+                                }
                             }
                         }
-                        .frame(maxWidth: .infinity)
-                    }
+                    }.padding()
                 }
             }
         }
@@ -67,7 +68,11 @@ struct ForEachApp: App {
 }
 
 struct ItemRow: View {
-    var item: Item
+    @Binding var item: Item
+
+    @State var isEditing = false
+    @State var value = ""
+
     let isFirst: Bool
     let isLast: Bool
     var remove: () -> Void
@@ -76,7 +81,26 @@ struct ItemRow: View {
 
     var body: some View {
         HStack {
-            Text(item.value)
+            if isEditing {
+                TextField("Value", text: $value)
+                    .frame(width: 100)
+                Spacer()
+                Button("Save") {
+                    item.value = value
+                    isEditing = false
+                }
+                Button("Cancel") {
+                    isEditing = false
+                }
+            } else {
+                Text(item.value)
+                    .frame(width: 100, alignment: .leading)
+                Spacer()
+                Button("Edit") {
+                    isEditing = true
+                    value = item.value
+                }
+            }
             Button("Delete") { remove() }
             Button("⌃") { moveUp() }
                 .disabled(isFirst)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ddeec630632b0145da44c9ac6a3914e4fe12d2fdc9527164d01281076d0c497e",
+  "originHash" : "d67afda47318a1da55f159038bea8c95778993612dfd2e6dc54b4c35e9f98151",
   "pins" : [
     {
       "identity" : "jpeg",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "45a7b500c24e7243da7b02e19cf436d0107a0c1b",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -123,10 +123,6 @@ let package = Package(
             revision: "1695ee3ea2b7a249f6504c7f1759e7ec7a38eb86"
         ),
         .package(
-            url: "https://github.com/apple/swift-collections.git",
-            .upToNextMinor(from: "1.2.1")
-        ),
-        .package(
             url: "https://github.com/stackotter/swift-benchmark",
             .upToNextMinor(from: "0.2.0")
         ),
@@ -154,7 +150,6 @@ let package = Package(
                 "HotReloadingMacrosPlugin",
                 .product(name: "ImageFormats", package: "swift-image-formats"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "OrderedCollections", package: "swift-collections"),
             ],
             exclude: [
                 "Builders/ViewBuilder.swift.gyb",

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -395,53 +395,46 @@ public final class AppKitBackend: AppBackend {
 
     public func show(widget: Widget) {}
 
-    class NSContainerView: NSView {
-        var children: [NSView] = []
-
-        override func addSubview(_ view: NSView) {
-            children.append(view)
-            super.addSubview(view)
-        }
-
-        func removeSubview(_ view: NSView) {
-            children.removeAll { other in
-                view === other
-            }
-            view.removeFromSuperview()
-        }
-
-        func removeAllSubviews() {
-            for child in children {
-                child.removeFromSuperview()
-            }
-            children = []
-        }
-    }
-
     public func createContainer() -> Widget {
-        let container = NSContainerView()
+        let container = NSView()
         container.translatesAutoresizingMaskIntoConstraints = false
         return container
     }
 
     public func removeAllChildren(of container: Widget) {
-        let container = container as! NSContainerView
-        container.removeAllSubviews()
+        container.subviews = []
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
-        container.addSubview(child)
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
+        container.subviews.insert(child, at: index)
         child.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
-        let container = container as! NSContainerView
-        guard container.children.indices.contains(index) else {
-            logger.warning("attempted to set position of non-existent container child")
-            return
-        }
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: NSView) {
+        assert(
+            container.subviews.indices.contains(firstIndex)
+            && container.subviews.indices.contains(secondIndex),
+            """
+            attempted to swap container child out of bounds; container count \
+            = \(container.subviews.count); firstIndex = \(firstIndex); \
+            secondIndex = \(secondIndex)
+            """
+        )
 
-        let child = container.children[index]
+        container.subviews.swapAt(firstIndex, secondIndex)
+    }
+
+    public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
+        assert(
+            container.subviews.indices.contains(index),
+            """
+            attempted to set position of non-existent container child; container \
+            count = \(container.subviews.count); index = \(index); position = \
+            \(position)
+            """
+        )
+
+        let child = container.subviews[index]
 
         var foundConstraint = false
         for constraint in container.constraints {
@@ -480,9 +473,8 @@ public final class AppKitBackend: AppBackend {
         }
     }
 
-    public func removeChild(_ child: Widget, from container: Widget) {
-        let container = container as! NSContainerView
-        container.removeSubview(child)
+    public func remove(childAt index: Int, from container: Widget) {
+        container.subviews.remove(at: index)
     }
 
     public func createColorableRectangle() -> Widget {

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -337,22 +337,21 @@ public final class DummyBackend: AppBackend {
         (container as! Container).children = []
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
-        (container as! Container).children.append((child, .zero))
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
+        (container as! Container).children.insert((child, .zero), at: index)
+    }
+
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
+        (container as! Container).children.swapAt(firstIndex, secondIndex)
     }
 
     public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
         (container as! Container).children[index].position = position
     }
 
-    public func removeChild(_ child: Widget, from container: Widget) {
+    public func remove(childAt index: Int, from container: Widget) {
         let container = container as! Container
-        let index = container.children.firstIndex { (widget, position) in
-            widget === child
-        }
-        if let index {
-            container.children.remove(at: index)
-        }
+        container.children.remove(at: index)
     }
 
     public func createColorableRectangle() -> Widget {

--- a/Sources/Gtk/Widgets/Fixed.swift
+++ b/Sources/Gtk/Widgets/Fixed.swift
@@ -51,6 +51,12 @@ open class Fixed: Widget {
         child.parentWidget = self
     }
 
+    public func put(_ child: Widget, index: Int, x: Double, y: Double) {
+        gtk_fixed_put(castedPointer(), child.widgetPointer, x, y)
+        children.insert(child, at: index)
+        child.parentWidget = self
+    }
+
     public func move(_ child: Widget, x: Double, y: Double) {
         gtk_fixed_move(castedPointer(), child.widgetPointer, x, y)
     }

--- a/Sources/Gtk3/Widgets/Fixed.swift
+++ b/Sources/Gtk3/Widgets/Fixed.swift
@@ -51,6 +51,12 @@ open class Fixed: Widget {
         child.parentWidget = self
     }
 
+    public func put(_ child: Widget, index: Int, x: Int, y: Int) {
+        gtk_fixed_put(castedPointer(), child.widgetPointer, gint(x), gint(y))
+        children.insert(child, at: index)
+        child.parentWidget = self
+    }
+
     public func move(_ child: Widget, x: Int, y: Int) {
         gtk_fixed_move(castedPointer(), child.widgetPointer, gint(x), gint(y))
     }

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -459,9 +459,9 @@ public final class Gtk3Backend: AppBackend {
         container.removeAllChildren()
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
         let container = container as! Fixed
-        container.put(child, x: 0, y: 0)
+        container.put(child, index: index, x: 0, y: 0)
     }
 
     public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
@@ -469,9 +469,20 @@ public final class Gtk3Backend: AppBackend {
         container.move(container.children[index], x: position.x, y: position.y)
     }
 
-    public func removeChild(_ child: Widget, from container: Widget) {
+    public func remove(childAt index: Int, from container: Widget) {
         let container = container as! Fixed
+        let child = container.children[index]
         container.remove(child)
+    }
+
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
+        // Gtk3.Fixed doesn't let us rearrange children, so we just swap them in
+        // our own list so that at least everything works on the SCUI side. The
+        // only side effect of this approach is that overlapping widgets may
+        // end up with unexpected z ordering. If that becomes an issue we may
+        // have to make a custom replacement for Gtk3.Fixed.
+        let container = container as! Fixed
+        container.children.swapAt(firstIndex, secondIndex)
     }
 
     public func createColorableRectangle() -> Widget {

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -434,9 +434,9 @@ public final class GtkBackend: AppBackend {
         container.removeAllChildren()
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
         let container = container as! Fixed
-        container.put(child, x: 0, y: 0)
+        container.put(child, index: index, x: 0, y: 0)
     }
 
     public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
@@ -444,9 +444,20 @@ public final class GtkBackend: AppBackend {
         container.move(container.children[index], x: Double(position.x), y: Double(position.y))
     }
 
-    public func removeChild(_ child: Widget, from container: Widget) {
+    public func remove(childAt index: Int, from container: Widget) {
         let container = container as! Fixed
+        let child = container.children[index]
         container.remove(child)
+    }
+
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
+        // Gtk.Fixed doesn't let us rearrange children, so we just swap them in
+        // our own list so that at least everything works on the SCUI side. The
+        // only side effect of this approach is that overlapping widgets may
+        // end up with unexpected z ordering. If that becomes an issue we may
+        // have to make a custom replacement for Gtk.Fixed.
+        let container = container as! Fixed
+        container.children.swapAt(firstIndex, secondIndex)
     }
 
     public func createColorableRectangle() -> Widget {

--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -6,7 +6,12 @@ nonisolated(unsafe) private var _logger: Logger?
 
 /// The global logger.
 package var logger: Logger {
-    guard let _logger else { fatalError("logger not yet initialized") }
+    guard let _logger else {
+        let logger = Logger(label: "TestLogger")
+        logger.trace("logger used before initialization")
+        _logger = logger
+        return logger
+    }
     return _logger
 }
 

--- a/Sources/SwiftCrossUI/Backend/AppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/AppBackend.swift
@@ -242,12 +242,15 @@ public protocol AppBackend: Sendable {
     func createContainer() -> Widget
     /// Removes all children of the given container.
     func removeAllChildren(of container: Widget)
-    /// Adds a child to a given container at an exact position.
-    func addChild(_ child: Widget, to container: Widget)
+    /// Inserts a child into a given container at a given index.
+    func insert(_ child: Widget, into container: Widget, at index: Int)
+    /// Swaps the child at firstIndex with the child at secondIndex. May crash if either
+    /// index is out of bounds.
+    func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget)
     /// Sets the position of the specified child in a container.
     func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>)
-    /// Removes a child widget from a container (if the child is a direct child of the container).
-    func removeChild(_ child: Widget, from container: Widget)
+    /// Removes the child at the given index from the given container.
+    func remove(childAt index: Int, from container: Widget)
 
     /// Creates a rectangular widget with configurable color.
     func createColorableRectangle() -> Widget

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -70,6 +70,24 @@ public enum LayoutSystem {
             self.tag = tag
         }
 
+        init<Child: View>(
+            _ node: AnyViewGraphNode<Child>,
+            child: @escaping @Sendable @MainActor () -> Child?
+        ) {
+            self.init(
+                computeLayout: { proposedSize, environment in
+                    node.computeLayout(
+                        with: child(),
+                        proposedSize: proposedSize,
+                        environment: environment
+                    )
+                },
+                commit: {
+                    node.commit()
+                }
+            )
+        }
+
         @MainActor
         public func computeLayout(
             proposedSize: ProposedViewSize,

--- a/Sources/SwiftCrossUI/Scenes/WindowGroupNode.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowGroupNode.swift
@@ -34,7 +34,7 @@ public final class WindowGroupNode<Content: View>: SceneGraphNode {
         let rootWidget = viewGraph.rootNode.concreteNode(for: Backend.self).widget
 
         let container = backend.createContainer()
-        backend.addChild(rootWidget, to: container)
+        backend.insert(rootWidget, into: container, at: 0)
         self.containerWidget = AnyWidget(container)
 
         backend.setChild(ofWindow: window, to: container)

--- a/Sources/SwiftCrossUI/ViewGraph/ErasedViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ErasedViewGraphNode.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 public struct ErasedViewGraphNode {
-    public var node: Any
+    public var node: AnyObject
 
     /// If the new view doesn't have the same type as the old view then the returned
     /// value will have `viewTypeMatched` set to `false`, allowing views such as `AnyView`

--- a/Sources/SwiftCrossUI/Views/EitherView.swift
+++ b/Sources/SwiftCrossUI/Views/EitherView.swift
@@ -118,7 +118,7 @@ extension EitherView: TypeSafeView {
     ) {
         if children.hasSwitchedCase {
             backend.removeAllChildren(of: widget)
-            backend.addChild(children.node.widget.into(), to: widget)
+            backend.insert(children.node.widget.into(), into: widget, at: 0)
             backend.setPosition(ofChildAt: 0, in: widget, to: .zero)
             children.hasSwitchedCase = false
         }

--- a/Sources/SwiftCrossUI/Views/ForEach.swift
+++ b/Sources/SwiftCrossUI/Views/ForEach.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OrderedCollections
 
 /// A view that displays a variable amount of children.
 public struct ForEach<Items: Collection, ID: Hashable, Child> {
@@ -46,7 +45,15 @@ extension ForEach: TypeSafeView, View where Child: View {
         _ children: Children,
         backend: Backend
     ) -> Backend.Widget {
-        return backend.createContainer()
+        let container = backend.createContainer()
+        if idKeyPath == nil {
+            // Deprecated code path. We've centralised the new implementation
+            // into computeLayout and commit.
+            for (index, node) in children.nodes.enumerated() {
+                backend.insert(node.widget.into(), into: container, at: index)
+            }
+        }
+        return container
     }
 
     func computeLayout<Backend: AppBackend>(
@@ -56,12 +63,16 @@ extension ForEach: TypeSafeView, View where Child: View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        func addChild(_ child: Backend.Widget) {
-            children.queuedChanges.append(.addChild(AnyWidget(child)))
+        func insertChild(_ child: Backend.Widget, atIndex index: Int) {
+            children.queuedChanges.append(.insertChild(AnyWidget(child), index))
         }
 
-        func removeChild(_ child: Backend.Widget) {
-            children.queuedChanges.append(.removeChild(AnyWidget(child)))
+        func removeChild(atIndex index: Int) {
+            children.queuedChanges.append(.removeChild(index))
+        }
+
+        func swap(childAt firstIndex: Int, withChildAt secondIndex: Int) {
+            children.queuedChanges.append(.swapChildren(firstIndex, secondIndex))
         }
 
         // Use the previous update Method when no keyPath is set on a
@@ -76,129 +87,106 @@ extension ForEach: TypeSafeView, View where Child: View {
             )
         }
 
-        var layoutableChildren: [LayoutSystem.LayoutableChild] = []
+        var oldIdentifiers = children.identifiers
+        let newIdentifiers = elements.map { $0[keyPath: idKeyPath] }
 
-        let oldNodes = children.nodes
-        let oldMap = children.nodeIdentifierMap
-        let oldIdentifiers = children.identifiers
-        let identifiersStart = oldIdentifiers.startIndex
+        // If the identifiers of our elements have changed, then we must rearrange
+        // our nodes and widgets so that child view states remain with their
+        // corresponding identifiers.
+        if oldIdentifiers != newIdentifiers {
+            var oldIdentifierMap = children.identifierMap
+            var oldNodes = children.nodes
+            var seenIdentifiers = Set<ID>()
+            children.nodes = []
+            children.identifierMap = [:]
+            children.identifiers = []
+            children.layoutableChildren = []
 
-        children.nodes = []
-        children.nodeIdentifierMap = [:]
-        children.identifiers = []
+            var offset = 0
+            var duplicateCount = 0
+            for (index, element) in elements.enumerated() {
+                let identifier = newIdentifiers[index]
+                let childContent = child(element)
+                let node: AnyViewGraphNode<Child>
 
-        // Once this is true, every node that existed in the previous update and
-        // still exists in the new one is reinserted to ensure that items are
-        // rendered in the correct order.
-        var requiresOngoingReinsertion = false
+                if !seenIdentifiers.insert(identifier).inserted {
+                    // We cannot keep view state attached to the correct ForEach element
+                    // when there are duplicate identifiers. Any elements with unique
+                    // identifiers are guaranteed to keep functioning correctly. Elements
+                    // with non-unique identifiers will get their corresponding view graph
+                    // nodes recreated each time the identifiers of our elements change,
+                    // unless they are the first element with the shared identifier, in which
+                    // case they will inherit the view graph node of the previous first element
+                    // with that same identifier.
+                    logger.warning(
+                        "duplicate identifier in ForEach; view state may not act as you would expect",
+                        metadata: ["identifier": "\(identifier)"]
+                    )
+                    duplicateCount += 1
+                }
 
-        // Forces node recreation when enabled (expensive on large Collections).
-        // Use only when idKeyPath yields non-unique values. Prefer Identifiable
-        // or guaranteed unique, constant identifiers for optimal performance.
-        // Node caching and diffing require unique, stable IDs.
-        var ongoingNodeReusingDisabled = false
+                if let oldIndex = oldIdentifierMap.removeValue(forKey: identifier) {
+                    // If the identifier already has a corresponding node, reuse it.
+                    node = oldNodes[oldIndex]
 
-        for element in elements {
-            // Avoid reallocation
-            var inserted = false
-
-            let childContent = child(element)
-            let node: AnyViewGraphNode<Child>
-
-            // Track duplicates: inserted=false if ID exists.
-            // Disables node reuse if any duplicate gets found.
-            (inserted, _) = children.identifiers.append(element[keyPath: idKeyPath])
-            ongoingNodeReusingDisabled = ongoingNodeReusingDisabled || !inserted
-
-            if !ongoingNodeReusingDisabled {
-                if let oldNode = oldMap[element[keyPath: idKeyPath]] {
-                    node = oldNode
-
-                    // Detects reordering or mid-collection insertion:
-                    // Checks if there is a preceding item that was not
-                    // preceding in the previous update.
-                    requiresOngoingReinsertion =
-                        requiresOngoingReinsertion
-                        || {
-                            guard
-                                let ownOldIndex = oldIdentifiers.firstIndex(
-                                    of: element[keyPath: idKeyPath])
-                            else { return false }
-
-                            let subset = oldIdentifiers[identifiersStart..<ownOldIndex]
-                            return !children.identifiers.subtracting(subset).isEmpty
-                        }()
-
-                    // Removes node from its previous position and
-                    // re-adds it at the new correct one.
-                    if requiresOngoingReinsertion, !children.isFirstUpdate {
-                        removeChild(oldNode.widget.into())
-                        addChild(oldNode.widget.into())
+                    // If the node's corresponding widget isn't already at the correct
+                    // position (accounting for insertions), then swap it with the widget
+                    // at the target position and update our accounting accordinly.
+                    if index != offset + oldIndex {
+                        // When talking about current widget indices, we add `offset` to oldIndex.
+                        // When talking about old element indices, we subtract `offset` from index.
+                        swap(childAt: offset + oldIndex, withChildAt: index)
+                        oldNodes.swapAt(oldIndex, index - offset)
+                        oldIdentifierMap[oldIdentifiers[index - offset]] = oldIndex
+                        oldIdentifiers.swapAt(oldIndex, index - offset)
                     }
                 } else {
-                    // New Items need ongoing reinsertion to get
-                    // displayed at the correct location.
-                    requiresOngoingReinsertion = true
+                    // If the identifier is new, create a node for it and insert its
+                    // widget at the correct position.
                     node = AnyViewGraphNode(
                         for: childContent,
                         backend: backend,
                         environment: environment
                     )
-                    if !children.isFirstUpdate {
-                        addChild(node.widget.into())
-                    }
+                    insertChild(node.widget.into(), atIndex: index)
+
+                    // `offset` tracks how many elements have been inserted, which we
+                    // use to adjust old indices. All nodes before the one we just
+                    // inserted are already at their final position, so we never have
+                    // to adjust old indices that point to before our latest insertion, otherwise
+                    // such a simple adjustment wouldn't be possible.
+                    offset += 1
                 }
-                children.nodeIdentifierMap[element[keyPath: idKeyPath]] = node
-            } else {
-                node = AnyViewGraphNode(
-                    for: childContent,
-                    backend: backend,
-                    environment: environment
+
+                children.nodes.append(node)
+                children.identifierMap[identifier] = index
+                children.identifiers.append(identifier)
+                children.layoutableChildren.append(
+                    LayoutSystem.LayoutableChild(node) { child(element) }
                 )
             }
 
-            children.nodes.append(node)
-
-            layoutableChildren.append(
-                LayoutSystem.LayoutableChild(
-                    computeLayout: { proposedSize, environment in
-                        node.computeLayout(
-                            with: childContent,
-                            proposedSize: proposedSize,
-                            environment: environment
-                        )
-                    },
-                    commit: {
-                        node.commit()
-                    }
-                )
-            )
-        }
-
-        if children.isFirstUpdate {
-            for nodeToAdd in children.nodes {
-                addChild(nodeToAdd.widget.into())
-            }
-        } else if !ongoingNodeReusingDisabled {
-            for removed in oldMap.filter({
-                !children.identifiers.contains($0.key)
-            }).values {
-                removeChild(removed.widget.into())
-            }
-        } else {
-            for nodeToRemove in oldNodes {
-                removeChild(nodeToRemove.widget.into())
-            }
-            for nodeToAdd in children.nodes {
-                addChild(nodeToAdd.widget.into())
+            // TODO: We should be able to reuse unused widgets in newly created nodes.
+            // Remove unused widgets, starting from the end of the container for
+            // cheaper removals.
+            let removalCount = oldIdentifierMap.count + duplicateCount
+            if removalCount > 0 {
+                for i in (0..<removalCount).reversed() {
+                    removeChild(atIndex: children.nodes.count + i)
+                }
             }
         }
 
-        children.isFirstUpdate = false
+        // Recompute layoutable children if the last commit cleared them
+        if children.layoutableChildren.isEmpty && !children.nodes.isEmpty {
+            children.layoutableChildren = zip(children.nodes, elements).map { (node, element) in
+                LayoutSystem.LayoutableChild(node) { child(element) }
+            }
+        }
 
         return LayoutSystem.computeStackLayout(
             container: widget,
-            children: layoutableChildren,
+            children: children.layoutableChildren,
             cache: &children.stackLayoutCache,
             proposedSize: proposedSize,
             environment: environment,
@@ -215,13 +203,13 @@ extension ForEach: TypeSafeView, View where Child: View {
         backend: Backend
     ) -> ViewLayoutResult {
         @inline(__always)
-        func addChild(_ child: Backend.Widget) {
-            children.queuedChanges.append(.addChild(AnyWidget(child)))
+        func insertChild(_ child: Backend.Widget, atIndex index: Int) {
+            children.queuedChanges.append(.insertChild(AnyWidget(child), index))
         }
 
         @inline(__always)
-        func removeChild(_ child: Backend.Widget) {
-            children.queuedChanges.append(.removeChild(AnyWidget(child)))
+        func removeChild(atIndex index: Int) {
+            children.queuedChanges.append(.removeChild(index))
         }
 
         let elementsStartIndex = elements.startIndex
@@ -236,22 +224,11 @@ extension ForEach: TypeSafeView, View where Child: View {
                 break
             }
             let index = elements.index(elementsStartIndex, offsetBy: i)
-            let childContent = child(elements[index])
             if children.isFirstUpdate {
-                addChild(node.widget.into())
+                insertChild(node.widget.into(), atIndex: i)
             }
-            layoutableChildren.append(
-                LayoutSystem.LayoutableChild(
-                    computeLayout: { proposedSize, environment in
-                        node.computeLayout(
-                            with: childContent,
-                            proposedSize: proposedSize,
-                            environment: environment
-                        )
-                    },
-                    commit: node.commit
-                )
-            )
+            let layoutableChild = LayoutSystem.LayoutableChild(node) { child(elements[index]) }
+            layoutableChildren.append(layoutableChild)
         }
         children.isFirstUpdate = false
 
@@ -260,33 +237,23 @@ extension ForEach: TypeSafeView, View where Child: View {
         if remainingElementCount > 0 {
             let startIndex = elements.index(elementsStartIndex, offsetBy: nodeCount)
             for i in 0..<remainingElementCount {
-                let childContent = child(elements[elements.index(startIndex, offsetBy: i)])
+                let element = elements[elements.index(startIndex, offsetBy: i)]
                 let node = AnyViewGraphNode(
-                    for: childContent,
+                    for: child(element),
                     backend: backend,
                     environment: environment
                 )
+                insertChild(node.widget.into(), atIndex: children.nodes.count)
                 children.nodes.append(node)
-                addChild(node.widget.into())
-                layoutableChildren.append(
-                    LayoutSystem.LayoutableChild(
-                        computeLayout: { proposedSize, environment in
-                            node.computeLayout(
-                                with: childContent,
-                                proposedSize: proposedSize,
-                                environment: environment
-                            )
-                        },
-                        commit: node.commit
-                    )
-                )
+                let layoutableChild = LayoutSystem.LayoutableChild(node) { child(element) }
+                layoutableChildren.append(layoutableChild)
             }
         } else if remainingElementCount < 0 {
-            let unused = -remainingElementCount
-            for i in (nodeCount - unused)..<nodeCount {
-                removeChild(children.nodes[i].widget.into())
+            let unusedCount = -remainingElementCount
+            for i in 0..<unusedCount {
+                removeChild(atIndex: nodeCount - i - 1)
             }
-            children.nodes.removeLast(unused)
+            children.nodes.removeLast(unusedCount)
         }
 
         return LayoutSystem.computeStackLayout(
@@ -308,33 +275,31 @@ extension ForEach: TypeSafeView, View where Child: View {
     ) {
         for change in children.queuedChanges {
             switch change {
-                case .addChild(let child):
-                    backend.addChild(child.into(), to: widget)
-                case .removeChild(let child):
-                    backend.removeChild(child.into(), from: widget)
+                case .insertChild(let child, let index):
+                    backend.insert(child.into(), into: widget, at: index)
+                case .removeChild(let index):
+                    backend.remove(childAt: index, from: widget)
+                case .swapChildren(let firstIndex, let secondIndex):
+                    backend.swap(childAt: firstIndex, withChildAt: secondIndex, in: widget)
             }
         }
         children.queuedChanges = []
 
         LayoutSystem.commitStackLayout(
             container: widget,
-            children: children.nodes.map { node in
-                LayoutSystem.LayoutableChild(
-                    computeLayout: { proposedSize, environment in
-                        node.computeLayout(
-                            with: nil,
-                            proposedSize: proposedSize,
-                            environment: environment
-                        )
-                    },
-                    commit: node.commit
-                )
-            },
+            children: children.layoutableChildren,
             cache: &children.stackLayoutCache,
             layout: layout,
             environment: environment,
             backend: backend
         )
+
+        // Reset layoutable children cache so that we recompute them during the
+        // next update cycle. This is important at the moment because the `child`
+        // closure and `elements` array may have changed. In future we'll separate
+        // view body recomputation from the computeLayout step, which should simplify
+        // things.
+        children.layoutableChildren = []
     }
 }
 
@@ -356,34 +321,52 @@ class ForEachViewChildren<
     /// The nodes for all current children of the ``ForEach`` view.
     var nodes: [AnyViewGraphNode<Child>] = []
 
-    /// The nodes for all current children of the ``ForEach`` view, queriable by their identifier.
-    var nodeIdentifierMap: [ID: AnyViewGraphNode<Child>]
+    /// A map from element identifier to node index.
+    var identifierMap: [ID: Int]
 
-    /// The identifiers of all current children ``ForEach`` view in the order they are displayed.
-    /// Can be used for checking if an element was moved or an element was inserted in front of it.
-    var identifiers: OrderedSet<ID>
+    /// The identifiers corresponding to ``nodes``.
+    var identifiers: [ID]
 
-    /// Changes queued during `dryRun` updates.
+    /// Changes queued during computeLayout.
     var queuedChanges: [Change] = []
 
-    enum Change {
-        case addChild(AnyWidget)
-        case removeChild(AnyWidget)
+    /// A queued widget operation to perform during `ForEach.commit`.
+    enum Change: CustomStringConvertible {
+        case insertChild(AnyWidget, Int)
+        case removeChild(Int)
+        case swapChildren(Int, Int)
+
+        var description: String {
+            switch self {
+                case .insertChild(let widget, let index):
+                    "Insert widget \(ObjectIdentifier(widget.widget as AnyObject)) at \(index)"
+                case .removeChild(let index):
+                    "Remove widget at \(index)"
+                case .swapChildren(let firstIndex, let secondIndex):
+                    "Swap widgets at \(firstIndex) and \(secondIndex)"
+            }
+        }
     }
 
+    /// Only used by ``ForEach/deprecatedUpdate(_:children:proposedSize:environment:backend:)``.
     var isFirstUpdate = true
+
+    /// A cache of the view's children, used when the ForEach's element
+    /// identifiers haven't changed since the previous layout computation.
+    var layoutableChildren: [LayoutSystem.LayoutableChild] = []
 
     var widgets: [AnyWidget] {
         nodes.map(\.widget)
     }
 
+    // TODO: This pattern of erasing by wrapping in a temporary class seems
+    //   inefficient. Could ErasedViewGraphNode maybe be a struct instead?
     var erasedNodes: [ErasedViewGraphNode] {
         nodes.map(ErasedViewGraphNode.init(wrapping:))
     }
 
     var stackLayoutCache = StackLayoutCache()
 
-    /// Gets a variable length view's children as view graph node children.
     init<Backend: AppBackend>(
         from view: ForEach<Items, ID, Child>,
         backend: Backend,
@@ -391,7 +374,12 @@ class ForEachViewChildren<
         snapshots: [ViewGraphSnapshotter.NodeSnapshot]?,
         environment: EnvironmentValues
     ) {
-        guard let idKeyPath else {
+        identifierMap = [:]
+        identifiers = []
+
+        if idKeyPath == nil {
+            // Deprecated code path. I'm not touching this anymore cause it's
+            // gonna get deleted before any proper release.
             nodes = view.elements
                 .map(view.child)
                 .enumerated()
@@ -405,35 +393,9 @@ class ForEachViewChildren<
                     )
                 }
                 .map(AnyViewGraphNode.init(_:))
-            identifiers = []
-            nodeIdentifierMap = [:]
-            return
+        } else {
+            nodes = []
         }
-        var nodeIdentifierMap = [ID: AnyViewGraphNode<Child>]()
-        var identifiers = OrderedSet<ID>()
-        var viewNodes = [AnyViewGraphNode<Child>]()
-
-        for (index, element) in view.elements.enumerated() {
-            let child = view.child(element)
-            let viewGraphNode = {
-                let snapshot = index < snapshots?.count ?? 0 ? snapshots?[index] : nil
-                return ViewGraphNode(
-                    for: child,
-                    backend: backend,
-                    snapshot: snapshot,
-                    environment: environment
-                )
-            }()
-
-            let anyViewGraphNode = AnyViewGraphNode(viewGraphNode)
-            viewNodes.append(anyViewGraphNode)
-
-            identifiers.append(element[keyPath: idKeyPath])
-            nodeIdentifierMap[element[keyPath: idKeyPath]] = anyViewGraphNode
-        }
-        nodes = viewNodes
-        self.identifiers = identifiers
-        self.nodeIdentifierMap = nodeIdentifierMap
     }
 }
 

--- a/Sources/SwiftCrossUI/Views/GeometryReader.swift
+++ b/Sources/SwiftCrossUI/Views/GeometryReader.swift
@@ -53,7 +53,7 @@ public struct GeometryReader<Content: View>: TypeSafeView, View {
     }
 
     func computeLayout<Backend: AppBackend>(
-        _ widget: Backend.Widget,
+        _ container: Backend.Widget,
         children: GeometryReaderChildren<Content>,
         proposedSize: ProposedViewSize,
         environment: EnvironmentValues,
@@ -75,7 +75,7 @@ public struct GeometryReader<Content: View>: TypeSafeView, View {
             )
             children.node = contentNode
 
-            backend.addChild(contentNode.widget.into(), to: widget)
+            backend.insert(contentNode.widget.into(), into: container, at: 0)
         }
 
         let contentResult = contentNode.computeLayout(

--- a/Sources/SwiftCrossUI/Views/Group.swift
+++ b/Sources/SwiftCrossUI/Views/Group.swift
@@ -17,8 +17,8 @@ public struct Group<Content: View>: View {
         backend: Backend
     ) -> Backend.Widget {
         let container = backend.createContainer()
-        for child in children.widgets(for: backend) {
-            backend.addChild(child, to: container)
+        for (index, child) in children.widgets(for: backend).enumerated() {
+            backend.insert(child, into: container, at: index)
         }
         return container
     }

--- a/Sources/SwiftCrossUI/Views/HStack.swift
+++ b/Sources/SwiftCrossUI/Views/HStack.swift
@@ -22,11 +22,11 @@ public struct HStack<Content: View>: View {
         _ children: any ViewGraphNodeChildren,
         backend: Backend
     ) -> Backend.Widget {
-        let vStack = backend.createContainer()
-        for child in children.widgets(for: backend) {
-            backend.addChild(child, to: vStack)
+        let hStack = backend.createContainer()
+        for (index, child) in children.widgets(for: backend).enumerated() {
+            backend.insert(child, into: hStack, at: index)
         }
-        return vStack
+        return hStack
     }
 
     public func computeLayout<Backend: AppBackend>(

--- a/Sources/SwiftCrossUI/Views/HotReloadableView.swift
+++ b/Sources/SwiftCrossUI/Views/HotReloadableView.swift
@@ -97,7 +97,7 @@ public struct HotReloadableView: TypeSafeView {
     ) {
         if children.hasChangedChild {
             backend.removeAllChildren(of: widget)
-            backend.addChild(children.node.getWidget().into(), to: widget)
+            backend.insert(children.node.getWidget().into(), into: widget, at: 0)
             backend.setPosition(ofChildAt: 0, in: widget, to: .zero)
             children.hasChangedChild = false
         }

--- a/Sources/SwiftCrossUI/Views/Image.swift
+++ b/Sources/SwiftCrossUI/Views/Image.swift
@@ -143,7 +143,11 @@ extension Image: TypeSafeView {
                     environment: environment
                 )
                 if children.isContainerEmpty {
-                    backend.addChild(children.imageWidget.into(), to: children.container.into())
+                    backend.insert(
+                        children.imageWidget.into(),
+                        into: children.container.into(),
+                        at: 0
+                    )
                     backend.setPosition(ofChildAt: 0, in: children.container.into(), to: .zero)
                 }
                 children.isContainerEmpty = false

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FixedSizeModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FixedSizeModifier.swift
@@ -33,7 +33,7 @@ struct FixedSizeModifier<Child: View>: TypeSafeView {
         backend: Backend
     ) -> Backend.Widget {
         let container = backend.createContainer()
-        backend.addChild(children.child0.widget.into(), to: container)
+        backend.insert(children.child0.widget.into(), into: container, at: 0)
         return container
     }
 

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
@@ -68,7 +68,7 @@ struct StrictFrameView<Child: View>: TypeSafeView {
         backend: Backend
     ) -> Backend.Widget {
         let container = backend.createContainer()
-        backend.addChild(children.child0.widget.into(), to: container)
+        backend.insert(children.child0.widget.into(), into: container, at: 0)
         return container
     }
 
@@ -169,7 +169,7 @@ struct FlexibleFrameView<Child: View>: TypeSafeView {
         backend: Backend
     ) -> Backend.Widget {
         let container = backend.createContainer()
-        backend.addChild(children.child0.widget.into(), to: container)
+        backend.insert(children.child0.widget.into(), into: container, at: 0)
         return container
     }
 

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/PaddingModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/PaddingModifier.swift
@@ -93,7 +93,7 @@ struct PaddingModifierView<Child: View>: TypeSafeView {
         backend: Backend
     ) -> Backend.Widget {
         let container = backend.createContainer()
-        backend.addChild(children.child0.widget.into(), to: container)
+        backend.insert(children.child0.widget.into(), into: container, at: 0)
         return container
     }
 

--- a/Sources/SwiftCrossUI/Views/OptionalView.swift
+++ b/Sources/SwiftCrossUI/Views/OptionalView.swift
@@ -90,7 +90,7 @@ extension OptionalView: TypeSafeView {
         if children.hasToggled {
             backend.removeAllChildren(of: widget)
             if let node = children.node {
-                backend.addChild(node.widget.into(), to: widget)
+                backend.insert(node.widget.into(), into: widget, at: 0)
                 backend.setPosition(ofChildAt: 0, in: widget, to: .zero)
             }
             children.hasToggled = false

--- a/Sources/SwiftCrossUI/Views/ScrollView.swift
+++ b/Sources/SwiftCrossUI/Views/ScrollView.swift
@@ -191,7 +191,7 @@ class ScrollViewChildren<Content: View>: ViewGraphNodeChildren {
     ) {
         self.children = children
         let innerContainer = backend.createContainer()
-        backend.addChild(children.child0.widget.into(), to: innerContainer)
+        backend.insert(children.child0.widget.into(), into: innerContainer, at: 0)
         self.innerContainer = AnyWidget(innerContainer)
     }
 }

--- a/Sources/SwiftCrossUI/Views/SplitView.swift
+++ b/Sources/SwiftCrossUI/Views/SplitView.swift
@@ -170,9 +170,17 @@ class SplitViewChildren<Sidebar: View, Detail: View>: ViewGraphNodeChildren {
         self.paneChildren = children
 
         let leadingPaneContainer = backend.createContainer()
-        backend.addChild(paneChildren.child0.widget.into(), to: leadingPaneContainer)
+        backend.insert(
+            paneChildren.child0.widget.into(),
+            into: leadingPaneContainer,
+            at: 0
+        )
         let trailingPaneContainer = backend.createContainer()
-        backend.addChild(paneChildren.child1.widget.into(), to: trailingPaneContainer)
+        backend.insert(
+            paneChildren.child1.widget.into(),
+            into: trailingPaneContainer,
+            at: 0
+        )
 
         self.leadingPaneContainer = AnyWidget(leadingPaneContainer)
         self.trailingPaneContainer = AnyWidget(trailingPaneContainer)

--- a/Sources/SwiftCrossUI/Views/Table.swift
+++ b/Sources/SwiftCrossUI/Views/Table.swift
@@ -60,7 +60,7 @@ public struct Table<RowValue, RowContent: TableRowContent<RowValue>>: TypeSafeVi
                 children.rowNodes.append(rowNode)
                 for cellWidget in rowNode.getChildren().widgets(for: backend) {
                     let cellContainer = backend.createContainer()
-                    backend.addChild(cellWidget, to: cellContainer)
+                    backend.insert(cellWidget, into: cellContainer, at: 0)
                     children.cellContainerWidgets.append(AnyWidget(cellContainer))
                 }
             }

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -33,8 +33,8 @@ public struct VStack<Content: View>: View {
         backend: Backend
     ) -> Backend.Widget {
         let vStack = backend.createContainer()
-        for child in children.widgets(for: backend) {
-            backend.addChild(child, to: vStack)
+        for (index, child) in children.widgets(for: backend).enumerated() {
+            backend.insert(child, into: vStack, at: index)
         }
         return vStack
     }

--- a/Sources/SwiftCrossUI/Views/ZStack.swift
+++ b/Sources/SwiftCrossUI/Views/ZStack.swift
@@ -22,8 +22,8 @@ public struct ZStack<Content: View>: View {
         backend: Backend
     ) -> Backend.Widget {
         let zStack = backend.createContainer()
-        for child in children.widgets(for: backend) {
-            backend.addChild(child, to: zStack)
+        for (index, child) in children.widgets(for: backend).enumerated() {
+            backend.insert(child, into: zStack, at: index)
         }
         return zStack
     }

--- a/Sources/UIKitBackend/UIKitBackend+Container.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Container.swift
@@ -83,8 +83,13 @@ extension UIKitBackend {
         container.childWidgets.forEach { $0.removeFromParentWidget() }
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
-        container.add(childWidget: child)
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
+        (container as! BaseViewWidget).insert(child, at: index)
+    }
+
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
+        container.view.exchangeSubview(at: firstIndex, withSubviewAt: secondIndex)
+        container.childWidgets.swapAt(firstIndex, secondIndex)
     }
 
     public func setPosition(
@@ -102,9 +107,8 @@ extension UIKitBackend {
         child.y = position.y
     }
 
-    public func removeChild(_ child: Widget, from container: Widget) {
-        assert(child.view.isDescendant(of: container.view))
-        child.removeFromParentWidget()
+    public func remove(childAt index: Int, from container: Widget) {
+        container.childWidgets[index].removeFromParentWidget()
     }
 
     public func createColorableRectangle() -> Widget {

--- a/Sources/UIKitBackend/Widget.swift
+++ b/Sources/UIKitBackend/Widget.swift
@@ -15,7 +15,6 @@ public protocol WidgetProtocol: UIResponder {
     var childWidgets: [any WidgetProtocol] { get set }
     var parentWidget: (any WidgetProtocol)? { get set }
 
-    func add(childWidget: some WidgetProtocol)
     func removeFromParentWidget()
 }
 
@@ -192,10 +191,28 @@ class BaseViewWidget: UIView, WidgetProtocolHelpers {
         childWidget.parentWidget = self
     }
 
+    func insert(_ childWidget: some WidgetProtocol, at index: Int) {
+        if childWidget.parentWidget === self { return }
+        childWidget.removeFromParentWidget()
+
+        let childController = childWidget.controller
+
+        insertSubview(childWidget.view, at: index)
+
+        if let controller, let childController {
+            controller.addChild(childController)
+            childController.didMove(toParent: controller)
+        }
+
+        childWidgets.insert(childWidget, at: index)
+        childWidget.parentWidget = self
+    }
+
     func removeFromParentWidget() {
         if let parentWidget {
             parentWidget.childWidgets.remove(
-                at: parentWidget.childWidgets.firstIndex { $0 === self }!)
+                at: parentWidget.childWidgets.firstIndex { $0 === self }!
+            )
             self.parentWidget = nil
         }
         removeFromSuperview()

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -355,9 +355,28 @@ public final class WinUIBackend: AppBackend {
         container.children.clear()
     }
 
-    public func addChild(_ child: Widget, to container: Widget) {
+    public func insert(_ child: Widget, into container: Widget, at index: Int) {
         let container = container as! Canvas
-        container.children.append(child)
+        container.children.insertAt(UInt32(index), child)
+    }
+
+    public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
+        // TODO: Find out if there's an efficient way to do this without WinUI
+        //   getting annoyed at us for having the same element in the list twice.
+        let container = container as! Canvas
+        let largerIndex = UInt32(max(firstIndex, secondIndex))
+        let smallerIndex = UInt32(min(firstIndex, secondIndex))
+        let element1 = container.children[Int(smallerIndex)]
+        let element2 = container.children[Int(largerIndex)]
+        container.children.removeAt(largerIndex)
+        container.children.removeAt(smallerIndex)
+        container.children.insertAt(smallerIndex, element2)
+        container.children.insertAt(largerIndex, element1)
+    }
+
+    public func remove(childAt index: Int, from container: Widget) {
+        let container = container as! Canvas
+        container.children.removeAt(UInt32(index))
     }
 
     public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
@@ -369,19 +388,6 @@ public final class WinUIBackend: AppBackend {
 
         Canvas.setTop(child, Double(position.y))
         Canvas.setLeft(child, Double(position.x))
-    }
-
-    public func removeChild(_ child: Widget, from container: Widget) {
-        let container = container as! Canvas
-        let count = container.children.size
-        for index in 0..<count {
-            if container.children.getAt(index) == child {
-                container.children.removeAt(index)
-                return
-            }
-        }
-
-        logger.warning("child to remove not found")
     }
 
     public func createColorableRectangle() -> Widget {
@@ -1384,7 +1390,7 @@ public final class WinUIBackend: AppBackend {
             fatalError("Unsupported gesture type \(gesture)")
         }
         let tapGestureTarget = TapGestureTarget()
-        addChild(child, to: tapGestureTarget)
+        insert(child, into: tapGestureTarget, at: 0)
         tapGestureTarget.child = child
 
         // Set a background so that the click target's entire area gets hit
@@ -1418,7 +1424,7 @@ public final class WinUIBackend: AppBackend {
 
     public func createHoverTarget(wrapping child: Widget) -> Widget {
         let hoverTarget = HoverGestureTarget()
-        addChild(child, to: hoverTarget)
+        insert(child, into: hoverTarget, at: 0)
         hoverTarget.child = child
 
         // Ensure the hover target covers the full area of the child.

--- a/Tests/SwiftCrossUITests/ForEachTests.swift
+++ b/Tests/SwiftCrossUITests/ForEachTests.swift
@@ -1,0 +1,81 @@
+import Testing
+
+import DummyBackend
+@testable import SwiftCrossUI
+
+@Suite("Testing for ForEach")
+struct ForEachTests {
+    @MainActor
+    @Test("Reordered children")
+    func reorderedChildren() {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil)
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+
+        func makeView(_ ids: [Int]) -> ForEach<[Int], Int, TupleView1<Text>> {
+            ForEach(ids, id: \.self) { x in
+                Text("")
+            }
+        }
+
+        let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        var forEach = makeView(values)
+
+        // Perform the initial update
+        let node = ViewGraphNode(for: forEach, backend: backend, environment: environment)
+        _ = node.computeLayout(
+            proposedSize: .unspecified,
+            environment: environment
+        )
+        _ = node.commit()
+
+        // Initialize the state of each view to match its index
+        let originalErasedNodes = node.children.erasedNodes
+        let originalNodes = originalErasedNodes.map(\.node)
+        let originalWidgets = node.widget.getChildren()
+
+        #expect(originalNodes.count == values.count)
+        #expect(originalWidgets.count == values.count)
+
+        // let values =    [11, 1, 5, 3, 4, 2, 6, 7, 8, 9, 10]
+        let newValues = [11, 1, 5, 6, 2, 4, 3]
+
+        forEach = makeView(newValues)
+        _ = node.computeLayout(
+            with: forEach,
+            proposedSize: .unspecified,
+            environment: environment
+        )
+        _ = node.commit()
+
+        let newErasedNodes = node.children.erasedNodes
+        let newNodes = newErasedNodes.map(\.node)
+        let newWidgets = node.widget.getChildren()
+
+        // Sanity check
+        #expect(newNodes.count == newValues.count)
+        #expect(newWidgets.count == newValues.count)
+
+        // Have we successfully re-used all nodes whose identifiers are present
+        // in both values and newValues?
+        for (originalNode, originalId) in zip(originalNodes, values) {
+            for (newNode, newId) in zip(newNodes, newValues) {
+                #expect(
+                    (originalNode === newNode)
+                    <=>
+                    (originalId == newId)
+                )
+            }
+        }
+
+        // Have we successfully re-arranged the widgets to match the nodes?
+        #expect(zip(originalWidgets, originalErasedNodes).allSatisfy { $0.0 === $0.1.getWidget().into() })
+        #expect(zip(newWidgets, newErasedNodes).allSatisfy { $0.0 === $0.1.getWidget().into() })
+    }
+}
+
+infix operator <=>
+
+func <=> (_ lhs: Bool, _ rhs: Bool) -> Bool {
+    lhs == rhs
+}


### PR DESCRIPTION
This new algorithm should be more efficient, and has better behaviour for AppKitBackend where removing+re-adding subviews results in them losing focus.

Addresses #331 and #300.

I've unit tested this new implementation as a sanity check.

I've tested these changes with all backends.

I also updated ForEachExample to showcase ForEach's identifiable support (added by @MiaKoring) a bit better. It contains state and text fields in each row to showcase that state stays attached to the correct elements and that we handle #331 correctly.