### PR TITLE
Fix task modifier impl to fix VStack children warning (fixes #330)

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/Lifecycle/TaskModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Lifecycle/TaskModifier.swift
@@ -45,9 +45,7 @@ struct TaskModifier<Id: Equatable, Content: View> {
 
 extension TaskModifier: View {
     var body: some View {
-        // Explicitly return to disable result builder (we don't want an extra
-        // layer of views).
-        return content.onChange(of: id, initial: true) {
+        content.onChange(of: id, initial: true) {
             task?.cancel()
             task = Task(priority: priority) {
                 await action()

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -51,8 +51,11 @@ public struct VStack<Content: View>: View {
             //   these edge cases without a second thought. Would also make introducing
             //   a port of SwiftUI's Layout protocol much easier.
             logger.warning(
-                "HStack will not function correctly with non-TupleView content",
-                metadata: ["childrenType": "\(type(of: children))"]
+                "VStack will not function correctly with non-TupleView content",
+                metadata: [
+                    "childrenType": "\(type(of: children))",
+                    "contentType": "\(Content.self)"
+                ]
             )
         }
         var cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache()


### PR DESCRIPTION
Fixes #330. The fix was pretty simple in the end. Turns out that using the `task` modifier was the underlying cause of this warning. The warning had a typo and the issue was actually related to a VStack not a HStack. I've fixed the typo in the warning.