### PR TITLE
Fix fixedSize modifier sizing (typo in computeLayout)

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FixedSizeModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FixedSizeModifier.swift
@@ -53,7 +53,7 @@ struct FixedSizeModifier<Child: View>: TypeSafeView {
         }
         let childResult = children.child0.computeLayout(
             with: body.view0,
-            proposedSize: proposedSize,
+            proposedSize: childProposal,
             environment: environment
         )
 


### PR DESCRIPTION
This was a simple fix. I discovered the bug while looking into #328, but it's unrelated to that issue.