### PR TITLE
Fix greediness of empty ScrollView (fixes #328)

### DIFF
--- a/Sources/SwiftCrossUI/Views/Group.swift
+++ b/Sources/SwiftCrossUI/Views/Group.swift
@@ -30,7 +30,7 @@ public struct Group<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        if !(children is TupleViewChildren) {
+        if !(children is TupleViewChildren || children is EmptyViewChildren) {
             logger.warning(
                 "Group will not function correctly with non-TupleView content",
                 metadata: ["childrenType": "\(type(of: children))"]

--- a/Sources/SwiftCrossUI/Views/HStack.swift
+++ b/Sources/SwiftCrossUI/Views/HStack.swift
@@ -36,7 +36,7 @@ public struct HStack<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        if !(children is TupleViewChildren) {
+        if !(children is TupleViewChildren || children is EmptyViewChildren) {
             logger.warning(
                 "HStack will not function correctly with non-TupleView content",
                 metadata: ["childrenType": "\(type(of: children))"]

--- a/Sources/SwiftCrossUI/Views/ScrollView.swift
+++ b/Sources/SwiftCrossUI/Views/ScrollView.swift
@@ -138,7 +138,8 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
 
         return ViewLayoutResult(
             size: outerSize,
-            childResults: [finalChildResult]
+            childResults: [finalChildResult],
+            participateInStackLayoutsWhenEmpty: true
         )
     }
 

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -46,7 +46,7 @@ public struct VStack<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        if !(children is TupleViewChildren) {
+        if !(children is TupleViewChildren || children is EmptyViewChildren) {
             // TODO: Make layout caching a ViewGraphNode feature so that we can handle
             //   these edge cases without a second thought. Would also make introducing
             //   a port of SwiftUI's Layout protocol much easier.

--- a/Tests/SwiftCrossUITests/StackLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/StackLayoutTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+import DummyBackend
+@testable import SwiftCrossUI
+
+@Suite("Testing for stack layouts")
+struct StackLayoutTests {
+    @MainActor
+    @Test("Empty ScrollView should still be greedy in stack (#328)")
+    func emptyScrollViewInStack() {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil)
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+
+        let view = VStack {
+            Text("Dummy")
+            ScrollView {}
+        }
+
+        let height = 200.0
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        let result = node.computeLayout(
+            proposedSize: ProposedViewSize(100, height),
+            environment: environment
+        )
+
+        #expect(result.size.height == height)
+    }
+}


### PR DESCRIPTION
This PR fixes #328.

### Context

When we lay out stack views, we check whether a child is 'hidden' or not by checking the 'participatesInStackLayouts' property on the result of querying the view for its minimum size. This system of identifying 'hidden' views is required so that e.g. an empty ForEach doesn't get spacing both above and below; we want the empty ForEach to be equivalent to not putting a view there at all.

Same for an `OptionalView` (created via an if statement without an else statement). Suppose that the if statement's condition is false. We would like deleting that if statement to not affect the stack layout.

### Issue

The issue here was that ScrollView had the `participatesInStackLayoutsWhenEmpty` property of its layout result set to `false`, meaning that if its minimum size was 0x0, then it'd get given a size of 0x0 and get excluded from the stack layout.

The reason that this affects GtkBackend and AppKitBackend differently is that AppKitBackend reports a non-zero scroll bar width; so if the ScrollView's content has a non-zero ideal height then the ScrollView would get a scroll bar when proposed zero height, and would report a minimum size of 16x0. GtkBackend on the other hand, doesn't leave space for scroll bars atm because its scroll bars are generally much thinner.

---

This PR also adds a unit test for the bug.

While I was at it, I fixed a spurious runtime warning that fosdem-scui-demo was facing.