### PR TITLE
Fixes layout on iOS and tvOS when windowResizability is fixed

### DIFF
--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -424,7 +424,7 @@ public final class AppKitBackend: AppBackend {
     public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: NSView) {
         assert(
             container.subviews.indices.contains(firstIndex)
-            && container.subviews.indices.contains(secondIndex),
+                && container.subviews.indices.contains(secondIndex),
             """
             attempted to swap container child out of bounds; container count \
             = \(container.subviews.count); firstIndex = \(firstIndex); \

--- a/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
@@ -3,7 +3,7 @@
 #endif
 
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #endif
 
 /// A scene that presents a group of identically structured windows. Currently
@@ -55,19 +55,17 @@ public struct WindowGroup<Content: View>: Scene {
     /// Sets the resizability of a window.
     public func windowResizability(_ resizability: WindowResizability) -> Self {
         var windowGroup = self
-        
+
         // ``WindowResizability/contentSize`` currently only works
-        // correctly on backends where the backend sets the size of the window
-        // as it doesn't have an effect on full-screen operating systems like
-        // iOS and tvOS they are excluded from changing the resizability
+        // correctly on backends where the backend sets the size of the window.
+        // As it doesn't have an effect on full-screen operating systems like
+        // iOS and tvOS they are excluded from changing the resizability.
         //
-        // This might be a temporary fix and be moved to the layout system later
-#if canImport(UIKit)
-        if [.phone, .tv].contains(UIDevice.current.userInterfaceIdiom) {
-            return windowGroup
-        }
-#endif
-        windowGroup.resizability = resizability
+        // TODO: This is a temporary targeted fix and should be done
+        // by the layout system instead in communication with backends.
+        #if !os(iOS) && !os(tvOS) && !targetEnvironment(macCatalyst)
+            windowGroup.resizability = resizability
+        #endif
         return windowGroup
     }
 }

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -54,7 +54,7 @@ public struct VStack<Content: View>: View {
                 "VStack will not function correctly with non-TupleView content",
                 metadata: [
                     "childrenType": "\(type(of: children))",
-                    "contentType": "\(Content.self)"
+                    "contentType": "\(Content.self)",
                 ]
             )
         }

--- a/Sources/UIKitBackend/UIKitBackend+Menu.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Menu.swift
@@ -22,11 +22,12 @@ extension UIKitBackend {
         for item in content.items {
             switch item {
                 case .button(let label, let action):
-                    let uiAction = if let action {
-                        UIAction(title: label) { _ in action() }
-                    } else {
-                        UIAction(title: label, attributes: .disabled) { _ in }
-                    }
+                    let uiAction =
+                        if let action {
+                            UIAction(title: label) { _ in action() }
+                        } else {
+                            UIAction(title: label, attributes: .disabled) { _ in }
+                        }
                     currentSection.append(uiAction)
                 case .toggle(let label, let value, let onChange):
                     currentSection.append(
@@ -45,16 +46,17 @@ extension UIKitBackend {
             }
         }
 
-        let children = if previousSections.isEmpty {
-            // There are no dividers; just return the current section to keep the menu tree flat.
-            currentSection
-        } else {
-            // Create a list of submenus, each with the displayInline option set so that they
-            // display as sections with separators.
-            (previousSections + [currentSection]).map {
-                UIMenu(title: "", options: .displayInline, children: $0)
+        let children =
+            if previousSections.isEmpty {
+                // There are no dividers; just return the current section to keep the menu tree flat.
+                currentSection
+            } else {
+                // Create a list of submenus, each with the displayInline option set so that they
+                // display as sections with separators.
+                (previousSections + [currentSection]).map {
+                    UIMenu(title: "", options: .displayInline, children: $0)
+                }
             }
-        }
 
         return UIMenu(title: label, identifier: identifier, children: children)
     }


### PR DESCRIPTION
Fixes remaining problems of https://github.com/stackotter/swift-cross-ui/issues/333

The layout issues occured when views resized inside a WindowGroup on a backend/device where the window size cannot be set. The layout system just positions the Content at x = 0, y = 0 under the assumption that the window has got the dictated size.

This PR excludes iOS and tvOS from modifying the window resizability through an early exit at runtime. 

iPadOS is not excluded, as it theoretically supports resizing windows, even though its currently being ignored as far as I know.

Its a targeted workaround at the moment as its entirely transparent to the layout engine. I would propose a way for backends to let the layout engine know if the current device/window supports resizing at the moment, as it can also change on iPadOS and Android during runtime. This proposal would be a better solution and should replace this fix in the future.