### PR TITLE
Fix Swift 6 concurrency errors in hot reloading macro output

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e6fea19cc72c1752f9d84acaf7941d3e9aa60df7a8bc00887939d6caacfe5ae6",
+  "originHash" : "dd63f095d6a2b7b6ab3aff17c27568510af59a6b664b9279065e23edc63cc6ed",
   "pins" : [
     {
       "identity" : "aexml",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-bundler",
       "state" : {
-        "revision" : "2dbcb92047148efbc20e9ed47f66bc2dfd93b3f7"
+        "revision" : "5d2ecbc11df78e56afeab0621c43d8e898dae98e"
       }
     },
     {

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -14,7 +14,7 @@ var hotReloadingDependencies: [Package.Dependency] = []
     hotReloadingDependencies = [
         .package(
             url: "https://github.com/moreSwift/swift-bundler",
-            revision: "2dbcb92047148efbc20e9ed47f66bc2dfd93b3f7"
+            revision: "5d2ecbc11df78e56afeab0621c43d8e898dae98e"
         )
     ]
     exampleDependencies.append(


### PR DESCRIPTION
Pretty self explanatory. Only fixes Swift 6 support when used in conjunction with Swift Bundler versions after the merge of https://github.com/moreSwift/swift-bundler/pull/134.