### PR TITLE
CI: Give update-docs workflow write perms (post-transfer fixup)

### DIFF
--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -333,6 +333,9 @@ jobs:
     needs: [macos, uikit, windows, linux]
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
+    permissions:
+      contents: write
+
     steps:
     - name: Setup Xcode version
       uses: maxim-lobanov/setup-xcode@v1.6.0


### PR DESCRIPTION
This is needed now that the repo is under an organisation.