### PR TITLE
Reimplement `_forEachField` from the stdlib and use it (aka perverse runtime black magic)

### DIFF
--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -25,21 +25,19 @@ struct DynamicPropertyUpdater<Base> {
     /// - Parameters:
     ///   - base: The base value to update the dynamic properties of.
     @MainActor
-    init(for _: Base.Type) {
+    init(for value: Base) {
         self.propertyOffsets = []
 
         // Unlikely shortcut, but worthwhile when we can.
-        if MemoryLayout<Base>.size == 0 {
-            return
-        }
+        guard MemoryLayout<Base>.size > 0 else { return }
 
         if let cachedUpdater = updaterCache[ObjectIdentifier(Base.self)] {
             self = cachedUpdater as! Self
             return
         }
 
-        forEachField(of: Base.self) { _, offset, type in
-            if let type = type as? any DynamicProperty.Type {
+        forEachField(of: value) { _, offset, field in
+            if let type = type(of: field) as? any DynamicProperty.Type {
                 propertyOffsets.append((offset, type))
             }
         }

--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -36,8 +36,8 @@ struct DynamicPropertyUpdater<Base> {
             return
         }
 
-        forEachField(of: value) { _, offset, field in
-            if let type = type(of: field) as? any DynamicProperty.Type {
+        forEachField(of: value) { _, offset, fieldValue in
+            if let type = type(of: fieldValue) as? any DynamicProperty.Type {
                 propertyOffsets.append((offset, type))
             }
         }

--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -7,7 +7,7 @@
 /// From some basic testing, this caching seems to reduce layout times by 5-10%
 /// (at the time of implementation).
 @MainActor
-var updaterCache: [ObjectIdentifier: Any] = [:]
+private var updaterCache: [ObjectIdentifier: Any] = [:]
 
 /// A helper for updating the dynamic properties of a stateful struct (e.g.
 /// a struct conforming to ``View`` or ``App``).
@@ -46,23 +46,21 @@ struct DynamicPropertyUpdater<Base> {
     ///   - mirror: An existing mirror of `base`. If not provided, a mirror will
     ///     be created.
     @MainActor
-    init(for base: Base, mirror: Mirror? = nil) {
+    init(for base: Base) {
         // Unlikely shortcut, but worthwhile when we can.
         if MemoryLayout<Base>.size == 0 {
             self.propertyUpdaters = []
             return
         }
 
-        if let cachedUpdater = updaterCache[ObjectIdentifier(Base.self)],
-           let cachedUpdater = cachedUpdater as? Self
-        {
-            self = cachedUpdater
+        if let cachedUpdater = updaterCache[ObjectIdentifier(Base.self)] {
+            self = cachedUpdater as! Self
             return
         }
 
         var propertyUpdaters: [PropertyUpdater] = []
 
-        let mirror = mirror ?? Mirror(reflecting: base)
+        let mirror = Mirror(reflecting: base)
         for child in mirror.children {
             let label = child.label ?? "<unlabelled>"
             let value = child.value
@@ -108,6 +106,12 @@ struct DynamicPropertyUpdater<Base> {
             Self.updateFallback(of: value, previousValue: previousValue, environment: environment)
             return
         }
+
+        logger.info("_forEachField start")
+        _forEachField(of: value) { name, value in
+            logger.info("name: \(name), value: \(value)")
+        }
+        logger.info("_forEachField end")
 
         for updater in propertyUpdaters {
             updater(previousValue, value, environment)

--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -25,7 +25,7 @@ struct DynamicPropertyUpdater<Base> {
     /// - Parameters:
     ///   - base: The base value to update the dynamic properties of.
     @MainActor
-    init(for base: Base) {
+    init(for _: Base.Type) {
         self.propertyOffsets = []
 
         // Unlikely shortcut, but worthwhile when we can.
@@ -38,9 +38,9 @@ struct DynamicPropertyUpdater<Base> {
             return
         }
 
-        _forEachField(of: base) { _, offset, value in
-            if let value = value as? any DynamicProperty {
-                propertyOffsets.append((offset, type(of: value)))
+        _forEachField(of: Base.self) { _, offset, type in
+            if let type = type as? any DynamicProperty.Type {
+                propertyOffsets.append((offset, type))
             }
         }
 

--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -38,7 +38,7 @@ struct DynamicPropertyUpdater<Base> {
             return
         }
 
-        _forEachField(of: Base.self) { _, offset, type in
+        forEachField(of: Base.self) { _, offset, type in
             if let type = type as? any DynamicProperty.Type {
                 propertyOffsets.append((offset, type))
             }
@@ -53,18 +53,12 @@ struct DynamicPropertyUpdater<Base> {
             update(type)
 
             func update<Property: DynamicProperty>(_: Property.Type) {
-                getProperty(of: value).update(
+                getProperty(Property.self, of: value, at: offset).update(
                     with: environment,
-                    previousValue: previousValue.map(getProperty(of:))
-                )
-
-                func getProperty(of base: Base) -> Property {
-                    withUnsafeBytes(of: base) { buffer in
-                        buffer.baseAddress!.advanced(by: offset)
-                            .assumingMemoryBound(to: Property.self)
-                            .pointee
+                    previousValue: previousValue.map {
+                        getProperty(Property.self, of: $0, at: offset)
                     }
-                }
+                )
             }
         }
     }

--- a/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
+++ b/Sources/SwiftCrossUI/State/DynamicPropertyUpdater.swift
@@ -12,44 +12,24 @@ private var updaterCache: [ObjectIdentifier: Any] = [:]
 /// A helper for updating the dynamic properties of a stateful struct (e.g.
 /// a struct conforming to ``View`` or ``App``).
 ///
-/// Dynamic properties are those that conform to ``DynamicProperty``, e.g. those
-/// annotated with the ``State`` property wrapper.
-///
-/// At initialisation, the updater will attempt to determine the byte offset of
-/// each stateful property in the struct. This is guaranteed to succeed if every
-/// dynamic property in the provided struct instance contains internal mutable
-/// storage, because the storage pointers will provide unique byte sequences.
-/// Otherwise, offset discovery will fail when two dynamic properties share the
-/// same pattern in memory. When offset discovery fails the updater will fall
-/// back to using `Mirror`s each time `update` gets called, which can be 1500x
-/// times slower when the view has 0 state properties, and 9x slower when the
-/// view has 4 properties, with the factor slowly dropping as the number of
-/// properties increases.
+/// At initialisation the updater will determine the byte offset of each
+/// stateful property in the struct.
 struct DynamicPropertyUpdater<Base> {
-    typealias PropertyUpdater = (
-        _ old: Base?,
-        _ new: Base,
-        _ environment: EnvironmentValues
-    ) -> Void
-
-    /// The updaters for each of `Base`'s dynamic properties.
-    ///
-    /// If `nil`, then we failed to compute the updaters.
-    let propertyUpdaters: [PropertyUpdater]?
+    /// The offsets and types of each of `Base`'s dynamic properties.
+    private var propertyOffsets: [(offset: Int, type: any DynamicProperty.Type)]
 
     /// Creates a new dynamic property updater which can efficiently update
     /// all dynamic properties on any value of type `Base` without creating
-    /// any mirrors after the initial creation of the updater.
+    /// any mirrors.
     ///
     /// - Parameters:
     ///   - base: The base value to update the dynamic properties of.
-    ///   - mirror: An existing mirror of `base`. If not provided, a mirror will
-    ///     be created.
     @MainActor
     init(for base: Base) {
+        self.propertyOffsets = []
+
         // Unlikely shortcut, but worthwhile when we can.
         if MemoryLayout<Base>.size == 0 {
-            self.propertyUpdaters = []
             return
         }
 
@@ -58,166 +38,34 @@ struct DynamicPropertyUpdater<Base> {
             return
         }
 
-        var propertyUpdaters: [PropertyUpdater] = []
-
-        let mirror = Mirror(reflecting: base)
-        for child in mirror.children {
-            let label = child.label ?? "<unlabelled>"
-            let value = child.value
-
-            guard let value = value as? any DynamicProperty else {
-                continue
+        _forEachField(of: base) { _, offset, value in
+            if let value = value as? any DynamicProperty {
+                propertyOffsets.append((offset, type(of: value)))
             }
-
-            guard let updater = Self.getUpdater(for: value, base: base, label: label) else {
-                // We have failed to create the required property updaters. Fallback
-                // to using Mirrors to update all properties.
-                logger.warning(
-                    """
-                    failed to produce DynamicPropertyUpdater; falling back to \
-                    slower Mirror-based property updating approach
-                    """,
-                    metadata: ["type": "\(Base.self)"]
-                )
-                self.propertyUpdaters = nil
-
-                // We intentionally return without caching the updaters here so
-                // that we if this failure is a fluke we can recover on a
-                // subsequent attempt for the same type. It may turn out that in
-                // practice types that fail are ones that always fail, in which
-                // case we should update this code to add the current updater to
-                // the cache.
-                return
-            }
-
-            propertyUpdaters.append(updater)
         }
-
-        self.propertyUpdaters = propertyUpdaters
 
         updaterCache[ObjectIdentifier(Base.self)] = self
     }
 
     /// Updates each dynamic property of the given value.
     func update(_ value: Base, with environment: EnvironmentValues, previousValue: Base?) {
-        guard let propertyUpdaters else {
-            // Fall back to our old dynamic property updating approach which involves a lot of
-            // Mirror overhead. This should be rare.
-            Self.updateFallback(of: value, previousValue: previousValue, environment: environment)
-            return
-        }
+        for (offset, type) in propertyOffsets {
+            update(type)
 
-        logger.info("_forEachField start")
-        _forEachField(of: value) { name, value in
-            logger.info("name: \(name), value: \(value)")
-        }
-        logger.info("_forEachField end")
+            func update<Property: DynamicProperty>(_: Property.Type) {
+                getProperty(of: value).update(
+                    with: environment,
+                    previousValue: previousValue.map(getProperty(of:))
+                )
 
-        for updater in propertyUpdaters {
-            updater(previousValue, value, environment)
-        }
-    }
-
-    /// Gets an updater for the property of base with the given value. If multiple
-    /// properties exist matching the byte pattern of `value`, then `nil` is returned.
-    ///
-    /// The returned updater is reusable and doesn't use Mirror.
-    private static func getUpdater<T: DynamicProperty>(
-        for value: T,
-        base: Base,
-        label: String
-    ) -> PropertyUpdater? {
-        guard let keyPath = DynamicKeyPath(forProperty: value, of: base, label: label) else {
-            return nil
-        }
-
-        let updater = { (old: Base?, new: Base, environment: EnvironmentValues) in
-            let property = keyPath.get(new)
-            property.update(
-                with: environment,
-                previousValue: old.map(keyPath.get)
-            )
-        }
-
-        return updater
-    }
-
-    /// Updates the dynamic properties of a value given a previous instance of the
-    /// type (if one exists) and the current environment.
-    private static func updateFallback<T>(
-        of value: T,
-        previousValue: T?,
-        environment: EnvironmentValues
-    ) {
-        let newMirror = Mirror(reflecting: value)
-        let previousMirror = previousValue.map(Mirror.init(reflecting:))
-        if let previousChildren = previousMirror?.children {
-            let propertySequence = zip(newMirror.children, previousChildren)
-            for (newProperty, previousProperty) in propertySequence {
-                guard
-                    let newValue = newProperty.value as? any DynamicProperty,
-                    let previousValue = previousProperty.value as? any DynamicProperty
-                else {
-                    continue
+                func getProperty(of base: Base) -> Property {
+                    withUnsafeBytes(of: base) { buffer in
+                        buffer.baseAddress!.advanced(by: offset)
+                            .assumingMemoryBound(to: Property.self)
+                            .pointee
+                    }
                 }
-
-                updateDynamicPropertyFallback(
-                    newProperty: newValue,
-                    previousProperty: previousValue,
-                    environment: environment,
-                    enclosingTypeName: "\(T.self)",
-                    propertyName: newProperty.label
-                )
-            }
-        } else {
-            for property in newMirror.children {
-                guard let newValue = property.value as? any DynamicProperty else {
-                    continue
-                }
-
-                updateDynamicPropertyFallback(
-                    newProperty: newValue,
-                    previousProperty: nil,
-                    environment: environment,
-                    enclosingTypeName: "\(T.self)",
-                    propertyName: property.label
-                )
             }
         }
-    }
-
-    /// Updates a dynamic property. Required to unmask the concrete type of the
-    /// property. Since the two properties can technically be two different
-    /// types, Swift correctly wouldn't allow us to assume they're both the
-    /// same. So we unwrap one and then dynamically check whether the other
-    /// matches using a type cast.
-    private static func updateDynamicPropertyFallback<Property: DynamicProperty>(
-        newProperty: Property,
-        previousProperty: (any DynamicProperty)?,
-        environment: EnvironmentValues,
-        enclosingTypeName: String,
-        propertyName: String?
-    ) {
-        let castedPreviousProperty: Property?
-        if let previousProperty {
-            guard let previousProperty = previousProperty as? Property else {
-                fatalError(
-                    """
-                    Supposedly unreachable... previous and current types of \
-                    \(enclosingTypeName).\(propertyName ?? "<unknown property>") \
-                    don't match.
-                    """
-                )
-            }
-
-            castedPreviousProperty = previousProperty
-        } else {
-            castedPreviousProperty = nil
-        }
-
-        newProperty.update(
-            with: environment,
-            previousValue: castedPreviousProperty
-        )
     }
 }

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("swift_reflectionMirror_recursiveCount")
+private func _getRecursiveChildCount(_: Any.Type) -> Int
+
+private typealias NameFreeFunc = @convention(c) (UnsafePointer<CChar>?) -> Void
+
+@_silgen_name("swift_reflectionMirror_subscript")
+private func _getChild<T>(
+    of: T,
+    type: Any.Type,
+    index: Int,
+    outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+    outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
+) -> Any
+
+/// Calls the given closure on every field of the specified value.
+///
+/// - Parameters:
+///   - value: The value to inspect.
+///   - body: A closure to call with information about each field in `value`.
+///     The parameters to `body` are the name of the field and the value of the
+///     field.
+func _forEachField<Value>(of value: Value, body: (String?, Any) -> Void) {
+    let childCount = _getRecursiveChildCount(Value.self)
+    for index in 0..<childCount {
+        var nameC: UnsafePointer<CChar>? = nil
+        var freeFunc: NameFreeFunc? = nil
+        defer { unsafe freeFunc?(nameC) }
+
+        let childValue = unsafe _getChild(
+            of: value,
+            type: Value.self,
+            index: index,
+            outName: &nameC,
+            outFreeFunc: &freeFunc
+        )
+        let childName = unsafe nameC.flatMap(String.init(validatingCString:))
+
+        body(childName, childValue)
+    }
+}

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -1,57 +1,63 @@
-//===----------------------------------------------------------------------===//
-//
-// This source file is part of the Swift.org open source project
-//
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
-//===----------------------------------------------------------------------===//
+// Adapted from https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/ReflectionMirror.swift
+
+// NB: I have absolutely zero clue why this is importable here. Xcode just shows
+// me an empty file when I command-click it. Nevertheless, it works just fine and
+// SourceKit seems to have no trouble finding stuff from here, so I'll roll
+// with it for now.
+private import SwiftShims
 
 @_silgen_name("swift_reflectionMirror_recursiveCount")
 private func _getRecursiveChildCount(_: Any.Type) -> Int
 
+@_silgen_name("swift_reflectionMirror_recursiveChildMetadata")
+private func _getChildMetadata(
+    _: Any.Type,
+    index: Int,
+    fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
+) -> Any.Type
+
 @_silgen_name("swift_reflectionMirror_recursiveChildOffset")
 private func _getChildOffset(_: Any.Type, index: Int) -> Int
 
-private typealias NameFreeFunc = @convention(c) (UnsafePointer<CChar>?) -> Void
-
-@_silgen_name("swift_reflectionMirror_subscript")
-private func _getChild<T>(
-    of: T,
-    type: Any.Type,
-    index: Int,
-    outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
-    outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
-) -> Any
-
-/// Calls the given closure on every field of the specified value.
+/// Calls the given closure on every field of the specified type.
+///
+/// The standard library exposes a function named `_forEachField(of:options:body:)`,
+/// which calls directly into the runtime's reflection facilities in order to
+/// get the names and types of the provided value's stored properties, bypassing
+/// most of the `Mirror` overhead. However, it's annotated with `@_spi(Reflection)`,
+/// and most people's toolchain installations don't include the stdlib's SPI
+/// interfaces. So we have to reimplement this function ourselves.
+///
+/// There are three runtime functions used to implement this:
+/// - `swift_reflectionMirror_recursiveCount(_:)`
+/// - `swift_reflectionMirror_recursiveChildMetadata(_:index:fieldMetadata:)`
+/// - `swift_reflectionMirror_recursiveChildOffset(_:index:)`
+///
+/// All three of these have been present in the runtime for at least 6 years (probably
+/// longer), and since `_forEachField(of:options:body:)` is used [within Combine] (and
+/// presumably other Apple frameworks), it's fairly unlikely that either it or the
+/// functions it depends on (which are the same as shown above) will be removed any
+/// time soon.
+///
+/// - SeeAlso: The [original implementation] as of Swift 6.2.3.
+///
+/// [within Combine]: https://forums.swift.org/t/how-is-the-published-property-wrapper-implemented/58223/11
+/// [original implementation]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/ReflectionMirror.swift
 ///
 /// - Parameters:
-///   - value: The value to inspect.
-///   - body: A closure to call with information about each field in `value`.
+///   - type: The type to inspect.
+///   - body: A closure to call with information about each field in `type`.
 ///     The parameters to `body` are the name of the field, the offset of the
-///     field, and the value of the field.
-func _forEachField<Value>(of value: Value, body: (String?, Int, Any) -> Void) {
-    let childCount = _getRecursiveChildCount(Value.self)
+///     field, and the type of the field.
+func _forEachField(of type: Any.Type, body: (String?, Int, Any.Type) -> Void) {
+    let childCount = _getRecursiveChildCount(type)
     for index in 0..<childCount {
-        let offset = _getChildOffset(Value.self, index: index)
+        let offset = _getChildOffset(type, index: index)
 
-        var nameC: UnsafePointer<CChar>? = nil
-        var freeFunc: NameFreeFunc? = nil
-        defer { freeFunc?(nameC) }
+        var field = _FieldReflectionMetadata()
+        let childType = _getChildMetadata(type, index: index, fieldMetadata: &field)
+        defer { field.freeFunc?(field.name) }
 
-        let childValue = _getChild(
-            of: value,
-            type: Value.self,
-            index: index,
-            outName: &nameC,
-            outFreeFunc: &freeFunc
-        )
-        let childName = nameC.flatMap(String.init(validatingCString:))
-
-        body(childName, offset, childValue)
+        body(field.name.flatMap(String.init(validatingCString:)), offset, childType)
     }
 }

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -68,7 +68,6 @@ func forEachField(
 /// > Safety: You must ensure that the `Base` type has a stored property at `offset` with a type of
 /// > `Property` (or another type that can be safely bit-casted to `Property` for all possible
 /// > values); breaking these invariants will cause undefined behavior.
-@unsafe
 func getProperty<Base, Property>(_: Property.Type, of base: Base, at offset: Int) -> Property {
     assert(offset + MemoryLayout<Property>.size <= MemoryLayout<Base>.size)
     return withUnsafeBytes(of: base) { buffer in

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -21,28 +21,26 @@ private func getChildOffset(of: Any.Type, index: Int) -> Int
 
 /// Calls the given closure on every field of the specified type.
 ///
-/// The standard library exposes a function named `_forEachField(of:options:body:)`,
-/// which calls directly into the runtime's reflection facilities in order to
-/// get the names and types of the provided value's stored properties, bypassing
-/// most of the `Mirror` overhead. However, it's annotated with `@_spi(Reflection)`,
-/// and most people's toolchain installations don't include the stdlib's SPI
-/// interfaces. So we have to reimplement this function ourselves.
+/// The standard library exposes a function named `_forEachField(of:options:body:)` (used
+/// [by Combine]), which calls directly into the runtime's reflection facilities in order to get
+/// the names and types of the provided value's stored properties, bypassing most of the `Mirror`
+/// overhead. However, it's annotated with `@_spi(Reflection)`, and most people's toolchain
+/// installations don't include the stdlib's SPI interfaces. So we have to reimplement this
+/// function ourselves.
 ///
 /// There are three runtime functions used to implement this:
 /// - `swift_reflectionMirror_recursiveCount(_:)`
 /// - `swift_reflectionMirror_recursiveChildMetadata(_:index:fieldMetadata:)`
 /// - `swift_reflectionMirror_recursiveChildOffset(_:index:)`
 ///
-/// All three of these have been present in the runtime for at least 6 years (probably
-/// longer), and since `_forEachField(of:options:body:)` is used [within Combine] (and
-/// presumably other Apple frameworks), it's fairly unlikely that either it or the
-/// functions it depends on (which are the same as shown above) will be removed any
-/// time soon.
+/// All three of these are public runtime API/ABI, as noted by the docs for the
+/// [`SWIFT_RUNTIME_STDLIB_API`] C macro that they are annotated with.
 ///
 /// - SeeAlso: The [original implementation] as of Swift 6.2.3.
 ///
-/// [within Combine]: https://forums.swift.org/t/how-is-the-published-property-wrapper-implemented/58223/11
+/// [by Combine]: https://forums.swift.org/t/how-is-the-published-property-wrapper-implemented/58223/11
 /// [original implementation]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/ReflectionMirror.swift
+/// [`SWIFT_RUNTIME_STDLIB_API`]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/SwiftShims/swift/shims/Visibility.h#L265-L267
 ///
 /// - Parameters:
 ///   - type: The type to inspect.

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -9,15 +9,17 @@ private import SwiftShims
 @_silgen_name("swift_reflectionMirror_recursiveCount")
 private func getRecursiveChildCount(of: Any.Type) -> Int
 
-@_silgen_name("swift_reflectionMirror_recursiveChildMetadata")
-private func getChildMetadata(
-    of: Any.Type,
-    index: Int,
-    fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
-) -> Any.Type
-
 @_silgen_name("swift_reflectionMirror_recursiveChildOffset")
 private func getChildOffset(of: Any.Type, index: Int) -> Int
+
+@_silgen_name("swift_reflectionMirror_subscript")
+private func getChild<T>(
+    of: T,
+    type: Any.Type,
+    index: Int,
+    outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
+    outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
+) -> Any
 
 /// Calls the given closure on every field of the specified type.
 ///
@@ -30,8 +32,8 @@ private func getChildOffset(of: Any.Type, index: Int) -> Int
 ///
 /// There are three runtime functions used to implement this:
 /// - `swift_reflectionMirror_recursiveCount(_:)`
-/// - `swift_reflectionMirror_recursiveChildMetadata(_:index:fieldMetadata:)`
 /// - `swift_reflectionMirror_recursiveChildOffset(_:index:)`
+/// - `swift_reflectionMirror_subscript(_:type:index:outName:outFreeFunc:)`
 ///
 /// All three of these are public runtime API/ABI, as noted by the docs for the
 /// [`SWIFT_RUNTIME_STDLIB_API`] C macro that they are annotated with.
@@ -39,27 +41,35 @@ private func getChildOffset(of: Any.Type, index: Int) -> Int
 /// - SeeAlso: The [original implementation] as of Swift 6.2.3.
 ///
 /// [by Combine]: https://forums.swift.org/t/how-is-the-published-property-wrapper-implemented/58223/11
-/// [original implementation]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/ReflectionMirror.swift
+/// [original implementation]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/core/ReflectionMirror.swift#L280-L284
 /// [`SWIFT_RUNTIME_STDLIB_API`]: https://github.com/swiftlang/swift/blob/swift-6.2.3-RELEASE/stdlib/public/SwiftShims/swift/shims/Visibility.h#L265-L267
 ///
 /// - Parameters:
 ///   - type: The type to inspect.
 ///   - body: A closure to call with information about each field in `type`.
 ///     The parameters to `body` are the name of the field, the offset of the
-///     field, and the type of the field.
-func forEachField(
-    of type: Any.Type,
-    body: (_ name: String?, _ offset: Int, _ type: Any.Type) -> Void
+///     field, and the field's value.
+func forEachField<Value>(
+    of value: Value,
+    body: (_ name: String?, _ offset: Int, _ field: Any) -> Void
 ) {
-    let childCount = getRecursiveChildCount(of: type)
+    let childCount = getRecursiveChildCount(of: Value.self)
     for index in 0..<childCount {
-        let offset = getChildOffset(of: type, index: index)
+        let offset = getChildOffset(of: Value.self, index: index)
 
-        var field = _FieldReflectionMetadata()
-        let childType = getChildMetadata(of: type, index: index, fieldMetadata: &field)
-        defer { field.freeFunc?(field.name) }
+        var name: UnsafePointer<CChar>? = nil
+        var freeFunc: NameFreeFunc? = nil
+        defer { freeFunc?(name) }
 
-        body(field.name.flatMap(String.init(validatingCString:)), offset, childType)
+        let childValue = getChild(
+            of: value,
+            type: Value.self,
+            index: index,
+            outName: &name,
+            outFreeFunc: &freeFunc
+        )
+
+        body(name.flatMap(String.init(validatingCString:)), offset, childValue)
     }
 }
 

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -65,8 +65,13 @@ func forEachField(
     }
 }
 
+/// > Safety: You must ensure that the `Base` type has a stored property at `offset` with a type of
+/// > `Property` (or another type that can be safely bit-casted to `Property` for all possible
+/// > values); breaking these invariants will cause undefined behavior.
+@unsafe
 func getProperty<Base, Property>(_: Property.Type, of base: Base, at offset: Int) -> Property {
-    withUnsafeBytes(of: base) { buffer in
+    assert(offset + MemoryLayout<Property>.size <= MemoryLayout<Base>.size)
+    return withUnsafeBytes(of: base) { buffer in
         buffer.baseAddress!.advanced(by: offset)
             .assumingMemoryBound(to: Property.self)
             .pointee

--- a/Sources/SwiftCrossUI/State/ForEachField.swift
+++ b/Sources/SwiftCrossUI/State/ForEachField.swift
@@ -51,7 +51,7 @@ private func getChild<T>(
 ///     field, and the field's value.
 func forEachField<Value>(
     of value: Value,
-    body: (_ name: String?, _ offset: Int, _ field: Any) -> Void
+    body: (_ name: String?, _ offset: Int, _ fieldValue: Any) -> Void
 ) {
     let childCount = getRecursiveChildCount(of: Value.self)
     for index in 0..<childCount {

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -77,7 +77,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         // First create the view's child nodes and widgets
         let childSnapshots =
             snapshot?.isValid(for: NodeView.self) == true
-                ? snapshot?.children : snapshot.map { [$0] }
+            ? snapshot?.children : snapshot.map { [$0] }
 
         currentLayout = nil
         resultCache = [:]
@@ -85,7 +85,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         parentEnvironment = environment
         cancellables = []
 
-        dynamicPropertyUpdater = DynamicPropertyUpdater(for: NodeView.self)
+        dynamicPropertyUpdater = DynamicPropertyUpdater(for: nodeView)
 
         let viewEnvironment = updateEnvironment(environment)
 
@@ -109,20 +109,21 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         backend.tag(widget: widget, as: tag)
 
         // Update the view and its children when state changes (children are always updated first).
-        let mirror = Mirror(reflecting: view)
-        for property in mirror.children {
-            if property.label == "state" && property.value is ObservableObject {
-                logger.warning(
-                    """
-                    the View.state protocol requirement has been removed in favour of \
-                    SwiftUI-style @State annotations; decorate \(NodeView.self).state \
-                    with the @State property wrapper to restore previous behaviour
-                    """
-                )
-            }
+        forEachField(of: view) { name, _, field in
+            #if DEBUG
+                if name == "state", field is ObservableObject {
+                    logger.warning(
+                        """
+                        the View.state protocol requirement has been removed in favour of \
+                        SwiftUI-style @State annotations; decorate \(NodeView.self).state \
+                        with the @State property wrapper to restore previous behaviour
+                        """
+                    )
+                }
+            #endif
 
-            guard let value = property.value as? any ObservableProperty else {
-                continue
+            guard let value = field as? any ObservableProperty else {
+                return // i.e. continue
             }
 
             let cancellable = value.didChange.observeAsUIUpdater(backend: backend) { [weak self] in

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -86,7 +86,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         cancellables = []
 
         let mirror = Mirror(reflecting: view)
-        dynamicPropertyUpdater = DynamicPropertyUpdater(for: view, mirror: mirror)
+        dynamicPropertyUpdater = DynamicPropertyUpdater(for: view)
 
         let viewEnvironment = updateEnvironment(environment)
 

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -85,8 +85,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         parentEnvironment = environment
         cancellables = []
 
-        let mirror = Mirror(reflecting: view)
-        dynamicPropertyUpdater = DynamicPropertyUpdater(for: view)
+        dynamicPropertyUpdater = DynamicPropertyUpdater(for: NodeView.self)
 
         let viewEnvironment = updateEnvironment(environment)
 
@@ -110,6 +109,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         backend.tag(widget: widget, as: tag)
 
         // Update the view and its children when state changes (children are always updated first).
+        let mirror = Mirror(reflecting: view)
         for property in mirror.children {
             if property.label == "state" && property.value is ObservableObject {
                 logger.warning(
@@ -125,13 +125,10 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
                 continue
             }
 
-            cancellables.append(
-                value.didChange
-                    .observeAsUIUpdater(backend: backend) { [weak self] in
-                        guard let self else { return }
-                        self.bottomUpUpdate()
-                    }
-            )
+            let cancellable = value.didChange.observeAsUIUpdater(backend: backend) { [weak self] in
+                self?.bottomUpUpdate()
+            }
+            cancellables.append(cancellable)
         }
     }
 

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -109,9 +109,9 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         backend.tag(widget: widget, as: tag)
 
         // Update the view and its children when state changes (children are always updated first).
-        forEachField(of: view) { name, _, field in
+        forEachField(of: view) { name, _, fieldValue in
             #if DEBUG
-                if name == "state", field is ObservableObject {
+                if name == "state", fieldValue is ObservableObject {
                     logger.warning(
                         """
                         the View.state protocol requirement has been removed in favour of \
@@ -122,7 +122,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
                 }
             #endif
 
-            guard let value = field as? any ObservableProperty else {
+            guard let value = fieldValue as? any ObservableProperty else {
                 return // i.e. continue
             }
 

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -75,9 +75,9 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
         snapshot?.restore(to: view)
 
         // First create the view's child nodes and widgets
-        let childSnapshots =
-            snapshot?.isValid(for: NodeView.self) == true
-            ? snapshot?.children : snapshot.map { [$0] }
+        let childSnapshots = snapshot.map { snapshot in
+            snapshot.isValid(for: NodeView.self) ? snapshot.children : [snapshot]
+        }
 
         currentLayout = nil
         resultCache = [:]
@@ -123,7 +123,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
             #endif
 
             guard let value = fieldValue as? any ObservableProperty else {
-                return // i.e. continue
+                return  // i.e. continue
             }
 
             let cancellable = value.didChange.observeAsUIUpdater(backend: backend) { [weak self] in

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphSnapshotter.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphSnapshotter.swift
@@ -52,14 +52,13 @@ public struct ViewGraphSnapshotter: ErasedViewGraphNodeTransformer {
         }
 
         private static func updateState<V: View>(of view: V, withSnapshot state: [String: Data]) {
-            let mirror = Mirror(reflecting: view)
-            for property in mirror.children {
+            forEachField(of: view) { name, _, field in
                 guard
-                    let stateProperty = property as? any SnapshottableProperty,
-                    let propertyName = property.label,
+                    let stateProperty = field as? any SnapshottableProperty,
+                    let propertyName = name,
                     let encodedState = state[propertyName]
                 else {
-                    continue
+                    return // i.e. continue
                 }
                 stateProperty.tryRestoreFromSnapshot(encodedState)
             }
@@ -76,14 +75,13 @@ public struct ViewGraphSnapshotter: ErasedViewGraphNodeTransformer {
 
     public static func snapshot<V: View>(of node: AnyViewGraphNode<V>) -> NodeSnapshot {
         var stateSnapshot: [String: Data] = [:]
-        let mirror = Mirror(reflecting: node.getView())
-        for property in mirror.children {
+        forEachField(of: node.getView()) { name, _, field in
             guard
-                let propertyName = property.label,
-                let property = property as? any SnapshottableProperty,
-                let encodedState = try? property.snapshot()
+                let stateProperty = field as? any SnapshottableProperty,
+                let propertyName = name,
+                let encodedState = try? stateProperty.snapshot()
             else {
-                continue
+                return // i.e. continue
             }
             stateSnapshot[propertyName] = encodedState
         }

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphSnapshotter.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphSnapshotter.swift
@@ -52,9 +52,9 @@ public struct ViewGraphSnapshotter: ErasedViewGraphNodeTransformer {
         }
 
         private static func updateState<V: View>(of view: V, withSnapshot state: [String: Data]) {
-            forEachField(of: view) { name, _, field in
+            forEachField(of: view) { name, _, fieldValue in
                 guard
-                    let stateProperty = field as? any SnapshottableProperty,
+                    let stateProperty = fieldValue as? any SnapshottableProperty,
                     let propertyName = name,
                     let encodedState = state[propertyName]
                 else {
@@ -75,9 +75,9 @@ public struct ViewGraphSnapshotter: ErasedViewGraphNodeTransformer {
 
     public static func snapshot<V: View>(of node: AnyViewGraphNode<V>) -> NodeSnapshot {
         var stateSnapshot: [String: Data] = [:]
-        forEachField(of: node.getView()) { name, _, field in
+        forEachField(of: node.getView()) { name, _, fieldValue in
             guard
-                let stateProperty = field as? any SnapshottableProperty,
+                let stateProperty = fieldValue as? any SnapshottableProperty,
                 let propertyName = name,
                 let encodedState = try? stateProperty.snapshot()
             else {

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -25,7 +25,7 @@ class _App<AppRoot: App> {
         self.environment = EnvironmentValues(backend: backend)
         self.cancellables = []
 
-        dynamicPropertyUpdater = DynamicPropertyUpdater(for: app)
+        dynamicPropertyUpdater = DynamicPropertyUpdater(for: AppRoot.self)
     }
 
     func refreshSceneGraph() {

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -25,7 +25,7 @@ class _App<AppRoot: App> {
         self.environment = EnvironmentValues(backend: backend)
         self.cancellables = []
 
-        dynamicPropertyUpdater = DynamicPropertyUpdater(for: AppRoot.self)
+        dynamicPropertyUpdater = DynamicPropertyUpdater(for: app)
     }
 
     func refreshSceneGraph() {
@@ -59,20 +59,21 @@ class _App<AppRoot: App> {
 
             dynamicPropertyUpdater.update(app, with: environment, previousValue: nil)
 
-            let mirror = Mirror(reflecting: app)
-            for property in mirror.children {
-                if property.label == "state" && property.value is ObservableObject {
-                    logger.warning(
-                        """
-                        the App.state protocol requirement has been removed in favour of \
-                        SwiftUI-style @State annotations; decorate \(AppRoot.self).state \
-                        with the @State property wrapper to restore previous behaviour
-                        """
-                    )
-                }
+            forEachField(of: app) { name, _, field in
+                #if DEBUG
+                    if name == "state", field is ObservableObject {
+                        logger.warning(
+                            """
+                            the App.state protocol requirement has been removed in favour of \
+                            SwiftUI-style @State annotations; decorate \(AppRoot.self).state \
+                            with the @State property wrapper to restore previous behaviour
+                            """
+                        )
+                    }
+                #endif
 
-                guard let value = property.value as? any ObservableProperty else {
-                    continue
+                guard let value = field as? any ObservableProperty else {
+                    return // i.e. continue
                 }
 
                 let cancellable =

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -59,9 +59,9 @@ class _App<AppRoot: App> {
 
             dynamicPropertyUpdater.update(app, with: environment, previousValue: nil)
 
-            forEachField(of: app) { name, _, field in
+            forEachField(of: app) { name, _, fieldValue in
                 #if DEBUG
-                    if name == "state", field is ObservableObject {
+                    if name == "state", fieldValue is ObservableObject {
                         logger.warning(
                             """
                             the App.state protocol requirement has been removed in favour of \
@@ -72,7 +72,7 @@ class _App<AppRoot: App> {
                     }
                 #endif
 
-                guard let value = field as? any ObservableProperty else {
+                guard let value = fieldValue as? any ObservableProperty else {
                     return // i.e. continue
                 }
 


### PR DESCRIPTION
There's a function called `_forEachField(of:options:body:)` [in the standard library](https://github.com/swiftlang/swift/blob/0546ff3de1a67fcef5a6d4e94a8cd05eccf08194/stdlib/public/core/ReflectionMirror.swift#L280), which calls directly into the runtime to retrieve the names, types, and (importantly for us) offsets of a type's stored properties. Since it doesn't create any `Mirror` instances, it's (presumably) more performant than iterating over `Mirror.children`, and it's unaffected by `CustomReflectable` conformances.

This function would be _perfect_ for updating dynamic properties, but there's a catch: `_forEachField(of:options:body:)` is annotated with `@_spi(Reflection)`, effectively making it inaccessible in release toolchains. So what I did was copy the stdlib's implementation into SwiftCrossUI, then shrink it down to what we actually need. In the end, we only required three runtime functions:

```swift
@_silgen_name("swift_reflectionMirror_recursiveCount")
private func getRecursiveChildCount(of: Any.Type) -> Int

@_silgen_name("swift_reflectionMirror_recursiveChildMetadata")
private func getChildMetadata(
    of: Any.Type,
    index: Int,
    fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
) -> Any.Type

@_silgen_name("swift_reflectionMirror_recursiveChildOffset")
private func getChildOffset(of: Any.Type, index: Int) -> Int
```

(`_FieldReflectionMetadata` comes from the `SwiftShims` module, which for reasons beyond my mortal comprehension is completely accessible and can be imported like any other module.)

[Here's the Swift Forums thread @stackotter created](https://forums.swift.org/t/are-swift-reflectionmirror-runtime-methods-safe-to-use-in-forward-compatible-code/84196) discussing whether these functions are safe for us to use long-term -- we never got an official answer from the Swift team, but [the conclusion reached by \@tera](https://forums.swift.org/t/are-swift-reflectionmirror-runtime-methods-safe-to-use-in-forward-compatible-code/84196/6) was:

- _technically_ not
- _practically_ yes

Of course, benchmarking this to make sure that it's actually meaningfully faster than the current implementation will be a necessity.