### PR TITLE
Avoid crash: Suppress secondary window launching in WindowingExample on Windows

### DIFF
--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -294,6 +294,9 @@ struct WindowingApp: App {
             }
             .defaultSize(width: 200, height: 200)
             .windowResizability(enforceMaxSize ? .contentSize : .contentMinSize)
+            #if os(Windows)
+                .defaultLaunchBehavior(.suppressed)
+            #endif
 
             WindowGroup("Tertiary window (hidden)", id: "tertiary-window") {
                 #hotReloadable {
@@ -310,6 +313,9 @@ struct WindowingApp: App {
                 }
             }
             .defaultSize(width: 200, height: 200)
+            #if os(Windows)
+                .defaultLaunchBehavior(.suppressed)
+            #endif
         #endif
     }
 }


### PR DESCRIPTION
Just a temporary workaround for a known Windows crash. Still have to look into the cause of this one.