### PR TITLE
CI: Override index.html before publishing docs

### DIFF
--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -415,6 +415,7 @@ jobs:
         cd gh-pages
         cp google5d79e0866e2627dd.html docs/google5d79e0866e2627dd.html
         cp CNAME docs/CNAME
+        cp index.html docs/index.html
         git add docs
 
         if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
The new index.html redirects from `/` to `/documentation`