### PR TITLE
Gtk: pass correct utf8 string length (in bytes) to Pango (fixes #387)

### DIFF
--- a/Sources/Gtk/Utility/Pango.swift
+++ b/Sources/Gtk/Utility/Pango.swift
@@ -26,7 +26,7 @@ public class Pango {
         proposedHeight: Double? = nil
     ) -> (width: Int, height: Int) {
         let layout = pango_layout_new(pangoContext)!
-        pango_layout_set_text(layout, text, Int32(text.count))
+        pango_layout_set_text(layout, text, Int32(text.utf8.count))
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR)
         pango_layout_set_ellipsize(layout, ellipsize.toGtk())
 

--- a/Sources/Gtk3/Utility/Pango.swift
+++ b/Sources/Gtk3/Utility/Pango.swift
@@ -26,7 +26,7 @@ public class Pango {
         proposedHeight: Double? = nil
     ) -> (width: Int, height: Int) {
         let layout = pango_layout_new(pangoContext)!
-        pango_layout_set_text(layout, text, Int32(text.count))
+        pango_layout_set_text(layout, text, Int32(text.utf8.count))
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR)
         pango_layout_set_ellipsize(layout, ellipsize.toGtk())
 


### PR DESCRIPTION
This PR aims to address #387 (which has been experienced by multiple users of SwiftCrossUI). The underlying cause was that we passed the number of UTF8 characters to Pango, instead of passing the number of bytes 🤦‍♂️.