### PR TITLE
[GTK3] Notify settings with "gtk-shell-shows-menubar" on menubar change

### DIFF
--- a/Sources/Gtk3/Application.swift
+++ b/Sources/Gtk3/Application.swift
@@ -27,6 +27,13 @@ public class Application: GObject, GActionMap {
                 applicationPointer,
                 (newValue?.pointer).map(UnsafeMutablePointer.init)
             )
+
+            // works around issue with adding a menubar after showing the window
+            // https://gitlab.gnome.org/GNOME/gtk/-/issues/2834
+            if let settings = gtk_settings_get_default() {
+                g_object_notify(settings.cast(), "gtk-shell-shows-menubar")
+            }
+
             _menuBarModel = newValue
         }
     }


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/moreSwift/swift-cross-ui/pull/325. 

This change caused the GTK3 application menu bar to get set _after_ the window is already shown, and apparently [GTK doesn't like that](https://gitlab.gnome.org/GNOME/gtk/-/issues/2834). 

This is apparently a #wontfix over on GNOME's gitlab:
```
I don't think application windows with menubars are common enough to fix this.
```
???

This is the only bandaid I could think of, and I'm not setup with a GTK4 environment to see if it's needed there.