### PR TITLE
[FIX] namespaced observation ignored noop

### DIFF
--- a/Sources/AppKitBackend/AppKitBackend+MenuBar.swift
+++ b/Sources/AppKitBackend/AppKitBackend+MenuBar.swift
@@ -178,7 +178,7 @@ enum MenuBar {
                 // check if the menu titles match. If they do, we move every item from the user's
                 // menu to our own.
                 if let submenu = menu.submenu,
-                   let matchingMenu = defaultMenus.first(where: { $0.title == menu.title })
+                    let matchingMenu = defaultMenus.first(where: { $0.title == menu.title })
                 {
                     let items = submenu.items
                     submenu.removeAllItems()

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -161,7 +161,7 @@ public final class AppKitBackend: AppBackend {
     public func activate(window: Window) {
         window.makeKeyAndOrderFront(nil)
     }
-    
+
     public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
         MenuBar.setUpMenuBar(extraMenus: submenus.map(Self.renderSubmenu(_:)))
     }

--- a/Sources/SwiftCrossUIMacrosPlugin/Observability/ObservableObjectMacro.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/Observability/ObservableObjectMacro.swift
@@ -34,7 +34,8 @@ public struct ObservableObjectMacro: MemberAttributeMacro, ExtensionMacro {
                         "SwiftCrossUI.Published",
                     ].contains(attr.attribute?._syntax.trimmedDescription)
             }),
-            !variable.hasMacroApplication("ObservationIgnored"),
+            try !variable.hasMacroApplication("ObservationIgnored"),
+            try !variable.hasMacroApplication("SwiftCrossUI.ObservationIgnored"),
             // Only include properties without accessors
             let binding = destructureSingle(variable.bindings),
             // Don't allow any accessors, because even when the property is

--- a/Sources/SwiftCrossUIMacrosPlugin/Observability/ObservableObjectMacro.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/Observability/ObservableObjectMacro.swift
@@ -34,8 +34,8 @@ public struct ObservableObjectMacro: MemberAttributeMacro, ExtensionMacro {
                         "SwiftCrossUI.Published",
                     ].contains(attr.attribute?._syntax.trimmedDescription)
             }),
-            try !variable.hasMacroApplication("ObservationIgnored"),
-            try !variable.hasMacroApplication("SwiftCrossUI.ObservationIgnored"),
+            !variable.hasMacroApplication("ObservationIgnored"),
+            !variable.hasMacroApplication("SwiftCrossUI.ObservationIgnored"),
             // Only include properties without accessors
             let binding = destructureSingle(variable.bindings),
             // Don't allow any accessors, because even when the property is

--- a/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
@@ -8,7 +8,7 @@ extension Variable {
     // Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
     // Licensed under Apache License v2.0 with Runtime Library Exception
     // Source https://github.com/swiftlang/swift/blob/2e8977f/lib/Macros/Sources/ObservationMacros/Extensions.swift#L111
-    func hasMacroApplication(_ name: String) throws -> Bool {
+    func hasMacroApplication(_ name: String) -> Bool {
         let parts = name.split(separator: ".")
 
         var expectation: [TokenKind] = []

--- a/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
@@ -8,13 +8,25 @@ extension Variable {
     // Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
     // Licensed under Apache License v2.0 with Runtime Library Exception
     // Source https://github.com/swiftlang/swift/blob/2e8977f/lib/Macros/Sources/ObservationMacros/Extensions.swift#L111
-    func hasMacroApplication(_ name: String) -> Bool {
+    func hasMacroApplication(_ name: String) throws -> Bool {
+        let parts = name.split(separator: ".")
+
+        var expectation: [TokenKind] = []
+
+        for (i, identifier) in parts.enumerated() {
+            expectation.append(.identifier(String(identifier)))
+
+            if i < parts.count - 1 {
+                expectation.append(.period)
+            }
+        }
+
         for attribute in _syntax.attributes {
             switch attribute {
                 case .attribute(let attr):
-                    if attr.attributeName.tokens(viewMode: .all).map({ $0.tokenKind }) == [
-                        .identifier(name)
-                    ] {
+                    if attr.attributeName.tokens(viewMode: .all).map({
+                        $0.tokenKind
+                    }) == expectation {
                         return true
                     }
                 default:

--- a/Tests/SwiftCrossUITests/ObservableObjectMacroTests.swift
+++ b/Tests/SwiftCrossUITests/ObservableObjectMacroTests.swift
@@ -164,4 +164,28 @@ struct ObservableTests {
             }
         )
     }
+    
+    @Test("Namespaced ObservationIgnored blocks application")
+    func namespacedObservationIgnoredBlocksApplication() async throws {
+        assertMacroExpansion(
+            """
+            @ObservableObject
+            class ViewModel {
+                @SwiftCrossUI.ObservationIgnored var skipMe = false
+            }
+            """,
+            expandedSource: """
+            class ViewModel {
+                @SwiftCrossUI.ObservationIgnored var skipMe = false
+            }
+            
+            extension ViewModel: SwiftCrossUI.ObservableObject {
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: { spec in
+                Issue.record(spec.issueComment)
+            }
+        )
+    }
 }

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -39,18 +39,18 @@ struct SwiftCrossUITests {
         path.append(1)
         path.append([1, 2, 3])
         path.append(5.0)
-
+        
         let components = path.path(destinationTypes: [
             String.self, Int.self, [Int].self, Double.self,
         ])
-
+        
         let encoded = try JSONEncoder().encode(path)
         let decodedPath = try JSONDecoder().decode(NavigationPath.self, from: encoded)
-
+        
         let decodedComponents = decodedPath.path(destinationTypes: [
             String.self, Int.self, [Int].self, Double.self,
         ])
-
+        
         #expect(Self.compareComponents(ofType: String.self, components[0], decodedComponents[0]))
         #expect(Self.compareComponents(ofType: Int.self, components[1], decodedComponents[1]))
         #expect(Self.compareComponents(ofType: [Int].self, components[2], decodedComponents[2]))


### PR DESCRIPTION
When you import **Foundation** `@ObservationIgnored` is ambiguous. 
To fix it you would use `@SwiftCrossUI.ObservationIgnored`. 
The namespaced variant wasn’t covered by the macro yet.

This PR adds 
- support for namespaced identifiers in `Variable/hasMacroApplication(_)`
- additional check for the namespaced variant of the macro
- a test validating the fix

changes in other files are caused by the format script