### PR TITLE
Update usage example in README.md to use versioned dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ import PackageDescription
 let package = Package(
     name: "YourApp",
     dependencies: [
-        .package(url: "https://github.com/moreSwift/swift-cross-ui", branch: "main")
+        .package(
+            url: "https://github.com/moreSwift/swift-cross-ui",
+            .upToNextMinor(from: "0.2.0")
+        ),
     ],
     targets: [
         .executableTarget(
@@ -54,7 +57,7 @@ let package = Package(
                 .product(name: "SwiftCrossUI", package: "swift-cross-ui"),
                 .product(name: "DefaultBackend", package: "swift-cross-ui"),
             ]
-        )
+        ),
     ]
 )
 ```


### PR DESCRIPTION
Now that I've begun producing releases more often, we should encourage people to use a versioned dependency on SwiftCrossUI rather than a simple main branch requirement (which is prone to breaking when we introduce breaking changes).