### PR TITLE
Switch to nicklockwood/SwiftFormat for formatting

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,7 +1,0 @@
-{
-    "version": 1,
-    "indentation": {
-        "spaces": 4
-    },
-    "indentSwitchCaseLabels": true
-}

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,18 @@
+--swift-version 5.10
+--max-width 100
+--indent-case true
+--no-space-operators ...,..<
+--pattern-let inline
+--semicolons never
+--strip-unused-args closure-only
+--wrap-collections before-first
+--wrap-parameters before-first
+--single-line-for-each convert
+--allow-partial-wrapping false
+--wrap-arguments before-first
+--wrap-parameters before-first
+--rules blockComments,consecutiveBlankLines, \
+        consecutiveSpaces,consistentSwitchCaseSpacing, \
+        docCommentsBeforeModifiers,duplicateImports, \
+        lineBreakAtEndOfFile,preferKeyPath, \
+        singlePropertyPerLine,spaceInsideComments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 3. Supply screenshots for each applicable platform if you’ve introduced a UI feature or otherwise changed the appearance of a SwiftCrossUI feature in some way
 4. Add unit tests to cover your changes if your changes would benefit from tests. If it’s not obvious whether a change would benefit from unit tests, omit them and ask for clarification in your pull request description.
 5. If you are adding a new feature, consider adding an example usage of it to the examples
-6. Run `Scripts/format.sh` (requires installing [`swift-format`](https://github.com/swiftlang/swift-format))
+6. Run `Scripts/format.sh` (requires installing [`SwiftFormat`](https://github.com/nicklockwood/SwiftFormat?tab=readme-ov-file#command-line-tool))
 
 ## 3. Finding something to do
 
@@ -79,6 +79,10 @@ Here are a few rules regarding special files;
 4. Use `guard` statements where possible, especially when introducing early returns, as they are easier to skim read than if statements (as long as you understand the condition, you can skip over the body of the guard statement knowing that it will exit the current scope no matter what).
 
 ## 7. Code formatting
+
+As a baseline, we use Nick Lockwood's [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)
+tool with the configuration file at [.swiftformat](./.swiftformat). This tool doesn't cover
+all of our preferences, so here are our main rules;
 
 1. Use 4 space indentation
 2. Keep lines under 80 characters where possible, with a hard limit at 100 characters

--- a/Examples/Sources/PathsExample/PathsApp.swift
+++ b/Examples/Sources/PathsExample/PathsApp.swift
@@ -1,5 +1,5 @@
 import DefaultBackend
-import Foundation  // for sin, cos
+import Foundation // for sin, cos
 import SwiftCrossUI
 
 struct ArcShape: StyledShape {

--- a/Scripts/format.sh
+++ b/Scripts/format.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"/../
 
 if [ -z "$1" ]; then
-  swift format format --in-place --recursive --configuration .swift-format Sources Examples/Sources
+  swiftformat .
 else
-  swift format format --in-place --recursive --configuration .swift-format $1
+  swiftformat $1
 fi

--- a/Sources/Gtk/Widgets/Range+ManualAdditions.swift
+++ b/Sources/Gtk/Widgets/Range+ManualAdditions.swift
@@ -1,7 +1,7 @@
 import CGtk
 
 extension Range {
-    public var value: Double {  // has no property
+    public var value: Double { // has no property
         get {
             return gtk_range_get_value(castedPointer())
         }

--- a/Sources/Gtk3/Widgets/Range+ManualAdditions.swift
+++ b/Sources/Gtk3/Widgets/Range+ManualAdditions.swift
@@ -1,7 +1,7 @@
 import CGtk3
 
 extension Range {
-    public var value: Double {  // has no property
+    public var value: Double { // has no property
         get {
             return gtk_range_get_value(castedPointer())
         }

--- a/Sources/Gtk3Backend/Gtk3Backend+Color.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend+Color.swift
@@ -11,25 +11,25 @@ extension Gtk3Backend {
         switch environment.colorScheme {
             case .light:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.208, green: 0.518, blue: 0.894)  // Blue 3
-                    case .brown: .init(red: 0.596, green: 0.416, blue: 0.267)  // Brown 3
-                    case .gray: .init(red: 0.467, green: 0.463, blue: 0.482)  // Dark 1
-                    case .green: .init(red: 0.2, green: 0.819, blue: 0.478)  // Green 3
-                    case .orange: .init(red: 1.0, green: 0.471, blue: 0.0)  // Orange 3
-                    case .purple: .init(red: 0.569, green: 0.255, blue: 0.674)  // Purple 3
-                    case .red: .init(red: 0.878, green: 0.106, blue: 0.141)  // Red 3
-                    case .yellow: .init(red: 0.965, green: 0.827, blue: 0.176)  // Yellow 3
+                    case .blue: .init(red: 0.208, green: 0.518, blue: 0.894) // Blue 3
+                    case .brown: .init(red: 0.596, green: 0.416, blue: 0.267) // Brown 3
+                    case .gray: .init(red: 0.467, green: 0.463, blue: 0.482) // Dark 1
+                    case .green: .init(red: 0.2, green: 0.819, blue: 0.478) // Green 3
+                    case .orange: .init(red: 1.0, green: 0.471, blue: 0.0) // Orange 3
+                    case .purple: .init(red: 0.569, green: 0.255, blue: 0.674) // Purple 3
+                    case .red: .init(red: 0.878, green: 0.106, blue: 0.141) // Red 3
+                    case .yellow: .init(red: 0.965, green: 0.827, blue: 0.176) // Yellow 3
                 }
             case .dark:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.384, green: 0.627, blue: 0.918)  // Blue 2
-                    case .brown: .init(red: 0.709, green: 0.514, blue: 0.353)  // Brown 2
-                    case .gray: .init(red: 0.604, green: 0.6, blue: 0.588)  // Light 5
-                    case .green: .init(red: 0.341, green: 0.89, blue: 0.537)  // Green 2
-                    case .orange: .init(red: 1.0, green: 0.639, blue: 0.282)  // Orange 2
-                    case .purple: .init(red: 0.753, green: 0.379, blue: 0.796)  // Purple 2
-                    case .red: .init(red: 0.929, green: 0.2, blue: 0.231)  // Red 2
-                    case .yellow: .init(red: 0.973, green: 0.894, blue: 0.361)  // Yellow 2
+                    case .blue: .init(red: 0.384, green: 0.627, blue: 0.918) // Blue 2
+                    case .brown: .init(red: 0.709, green: 0.514, blue: 0.353) // Brown 2
+                    case .gray: .init(red: 0.604, green: 0.6, blue: 0.588) // Light 5
+                    case .green: .init(red: 0.341, green: 0.89, blue: 0.537) // Green 2
+                    case .orange: .init(red: 1.0, green: 0.639, blue: 0.282) // Orange 2
+                    case .purple: .init(red: 0.753, green: 0.379, blue: 0.796) // Purple 2
+                    case .red: .init(red: 0.929, green: 0.2, blue: 0.231) // Red 2
+                    case .yellow: .init(red: 0.973, green: 0.894, blue: 0.361) // Yellow 2
                 }
         }
     }

--- a/Sources/GtkBackend/GtkBackend+Color.swift
+++ b/Sources/GtkBackend/GtkBackend+Color.swift
@@ -11,25 +11,25 @@ extension GtkBackend {
         switch environment.colorScheme {
             case .light:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.208, green: 0.518, blue: 0.894)  // Blue 3
-                    case .brown: .init(red: 0.596, green: 0.416, blue: 0.267)  // Brown 3
-                    case .gray: .init(red: 0.467, green: 0.463, blue: 0.482)  // Dark 1
-                    case .green: .init(red: 0.2, green: 0.819, blue: 0.478)  // Green 3
-                    case .orange: .init(red: 1.0, green: 0.471, blue: 0.0)  // Orange 3
-                    case .purple: .init(red: 0.569, green: 0.255, blue: 0.674)  // Purple 3
-                    case .red: .init(red: 0.878, green: 0.106, blue: 0.141)  // Red 3
-                    case .yellow: .init(red: 0.965, green: 0.827, blue: 0.176)  // Yellow 3
+                    case .blue: .init(red: 0.208, green: 0.518, blue: 0.894) // Blue 3
+                    case .brown: .init(red: 0.596, green: 0.416, blue: 0.267) // Brown 3
+                    case .gray: .init(red: 0.467, green: 0.463, blue: 0.482) // Dark 1
+                    case .green: .init(red: 0.2, green: 0.819, blue: 0.478) // Green 3
+                    case .orange: .init(red: 1.0, green: 0.471, blue: 0.0) // Orange 3
+                    case .purple: .init(red: 0.569, green: 0.255, blue: 0.674) // Purple 3
+                    case .red: .init(red: 0.878, green: 0.106, blue: 0.141) // Red 3
+                    case .yellow: .init(red: 0.965, green: 0.827, blue: 0.176) // Yellow 3
                 }
             case .dark:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.384, green: 0.627, blue: 0.918)  // Blue 2
-                    case .brown: .init(red: 0.709, green: 0.514, blue: 0.353)  // Brown 2
-                    case .gray: .init(red: 0.604, green: 0.6, blue: 0.588)  // Light 5
-                    case .green: .init(red: 0.341, green: 0.89, blue: 0.537)  // Green 2
-                    case .orange: .init(red: 1.0, green: 0.639, blue: 0.282)  // Orange 2
-                    case .purple: .init(red: 0.753, green: 0.379, blue: 0.796)  // Purple 2
-                    case .red: .init(red: 0.929, green: 0.2, blue: 0.231)  // Red 2
-                    case .yellow: .init(red: 0.973, green: 0.894, blue: 0.361)  // Yellow 2
+                    case .blue: .init(red: 0.384, green: 0.627, blue: 0.918) // Blue 2
+                    case .brown: .init(red: 0.709, green: 0.514, blue: 0.353) // Brown 2
+                    case .gray: .init(red: 0.604, green: 0.6, blue: 0.588) // Light 5
+                    case .green: .init(red: 0.341, green: 0.89, blue: 0.537) // Green 2
+                    case .orange: .init(red: 1.0, green: 0.639, blue: 0.282) // Orange 2
+                    case .purple: .init(red: 0.753, green: 0.379, blue: 0.796) // Purple 2
+                    case .red: .init(red: 0.929, green: 0.2, blue: 0.231) // Red 2
+                    case .yellow: .init(red: 0.973, green: 0.894, blue: 0.361) // Yellow 2
                 }
         }
     }

--- a/Sources/SwiftCrossUI/Environment/Actions/PresentFileSaveDialogAction.swift
+++ b/Sources/SwiftCrossUI/Environment/Actions/PresentFileSaveDialogAction.swift
@@ -22,7 +22,7 @@ public struct PresentFileSaveDialogAction: Sendable {
     ///   - defaultFileName: The default file name. Defaults to `nil`, which
     ///     uses the backend-specific default.
     /// - Returns: The URL of the user's chosen save destination, or `nil` if
-    ///   the user cancelled the dialog. 
+    ///   the user cancelled the dialog.
     public func callAsFunction(
         title: String = "Save",
         message: String = "",

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -109,7 +109,7 @@ public struct EnvironmentValues {
     let backend: any AppBackend
 
     /// Presents an 'Open file' dialog fit for selecting a single file.
-    /// 
+    ///
     /// Displays as a modal for the current window, or the entire app if
     /// accessed outside of a scene's view graph (in which case the backend
     /// can decide whether to make it an app modal, a standalone window, or a

--- a/Sources/SwiftCrossUI/Values/Path.swift
+++ b/Sources/SwiftCrossUI/Values/Path.swift
@@ -1,4 +1,4 @@
-import Foundation  // for sin and cos
+import Foundation // for sin and cos
 
 public enum StrokeCap: Sendable {
     /// The stroke ends square exactly at the last point.

--- a/Sources/SwiftCrossUI/ViewGraph/PreferenceValues.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/PreferenceValues.swift
@@ -54,18 +54,16 @@ extension PreferenceValues {
         }
 
         // For presentation modifiers, take the outer-most value (using child ordering to break ties).
-        presentationDetents = children.compactMap { $0.presentationDetents }.first
-        presentationCornerRadius = children.compactMap { $0.presentationCornerRadius }.first
+        presentationDetents = children.compactMap(\.presentationDetents).first
+        presentationCornerRadius = children.compactMap(\.presentationCornerRadius).first
         presentationDragIndicatorVisibility =
-            children.compactMap {
-                $0.presentationDragIndicatorVisibility
-            }.first
-        presentationBackground = children.compactMap { $0.presentationBackground }.first
-        interactiveDismissDisabled = children.compactMap { $0.interactiveDismissDisabled }.first
+            children.compactMap(\.presentationDragIndicatorVisibility).first
+        presentationBackground = children.compactMap(\.presentationBackground).first
+        interactiveDismissDisabled = children.compactMap(\.interactiveDismissDisabled).first
 
-        windowDismissBehavior = children.compactMap { $0.windowDismissBehavior }.first
+        windowDismissBehavior = children.compactMap(\.windowDismissBehavior).first
         preferredWindowMinimizeBehavior =
-            children.compactMap { $0.preferredWindowMinimizeBehavior }.first
-        windowResizeBehavior = children.compactMap { $0.windowResizeBehavior }.first
+            children.compactMap(\.preferredWindowMinimizeBehavior).first
+        windowResizeBehavior = children.compactMap(\.windowResizeBehavior).first
     }
 }

--- a/Sources/SwiftCrossUI/Views/DatePicker.swift
+++ b/Sources/SwiftCrossUI/Views/DatePicker.swift
@@ -11,17 +11,15 @@ public struct DatePickerComponents: OptionSet, Sendable {
         self.rawValue = 0
     }
 
-    /*
-     * These magic numbers are the same as SwiftUI. It's actually a bitfield:
-     *
-     *                        smhdMy--
-     *                   date 00011100
-     *          hourAndMinute 01100000
-     *    hourMinuteAndSecond 11100000
-     *
-     * Like SwiftUI, not all combinations are valid (SwiftUI fatalErrors if you try to get creative
-     * with your choice of flags), and hourMinuteAndSecond intentionally includes hourAndMinute.
-     */
+    // These magic numbers are the same as SwiftUI. It's actually a bitfield:
+    //
+    //                        smhdMy--
+    //                   date 00011100
+    //          hourAndMinute 01100000
+    //    hourMinuteAndSecond 11100000
+    //
+    // Like SwiftUI, not all combinations are valid (SwiftUI fatalErrors if you try to get creative
+    // with your choice of flags), and hourMinuteAndSecond intentionally includes hourAndMinute.
 
     public static let date = DatePickerComponents(rawValue: 0x1C)
     public static let hourAndMinute = DatePickerComponents(rawValue: 0x60)

--- a/Sources/SwiftCrossUI/Views/Image.swift
+++ b/Sources/SwiftCrossUI/Views/Image.swift
@@ -27,7 +27,7 @@ public struct Image: Sendable {
     }
 
     /// Displays an image from raw pixel data.
-    /// 
+    ///
     /// - Parameter image: The image data to display.
     public init(_ image: ImageFormats.Image<RGBA>) {
         source = .image(image)

--- a/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/Utils/VariableExtension.swift
@@ -24,9 +24,7 @@ extension Variable {
         for attribute in _syntax.attributes {
             switch attribute {
                 case .attribute(let attr):
-                    if attr.attributeName.tokens(viewMode: .all).map({
-                        $0.tokenKind
-                    }) == expectation {
+                    if attr.attributeName.tokens(viewMode: .all).map(\.tokenKind) == expectation {
                         return true
                     }
                 default:

--- a/Sources/WinUIBackend/WinUIBackend+Color.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Color.swift
@@ -10,25 +10,25 @@ extension WinUIBackend {
         switch environment.colorScheme {
             case .light:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.0, green: 0.471, blue: 0.831)  // colorPaletteBlueBorderActive
-                    case .brown: .init(red: 0.557, green: 0.337, blue: 0.18)  // colorPaletteBrownBorderActive
-                    case .gray: .init(red: 0.478, green: 0.459, blue: 0.455)  // colorPaletteBeigeBorderActive
-                    case .green: .init(red: 0.067, green: 0.569, blue: 0.051)  // colorPaletteLightGreenForeground1
-                    case .orange: .init(red: 1.0, green: 0.549, blue: 0.0)  // colorPalettePeachBorderActive
-                    case .purple: .init(red: 0.686, green: 0.2, blue: 0.631)  // colorPaletteBerryForeground1
-                    case .red: .init(red: 0.737, green: 0.184, blue: 0.196)  // colorPaletteRedForeground1
-                    case .yellow: .init(red: 0.992, green: 0.89, blue: 0.0)  // colorPaletteYellowForeground3
+                    case .blue: .init(red: 0.0, green: 0.471, blue: 0.831) // colorPaletteBlueBorderActive
+                    case .brown: .init(red: 0.557, green: 0.337, blue: 0.18) // colorPaletteBrownBorderActive
+                    case .gray: .init(red: 0.478, green: 0.459, blue: 0.455) // colorPaletteBeigeBorderActive
+                    case .green: .init(red: 0.067, green: 0.569, blue: 0.051) // colorPaletteLightGreenForeground1
+                    case .orange: .init(red: 1.0, green: 0.549, blue: 0.0) // colorPalettePeachBorderActive
+                    case .purple: .init(red: 0.686, green: 0.2, blue: 0.631) // colorPaletteBerryForeground1
+                    case .red: .init(red: 0.737, green: 0.184, blue: 0.196) // colorPaletteRedForeground1
+                    case .yellow: .init(red: 0.992, green: 0.89, blue: 0.0) // colorPaletteYellowForeground3
                 }
             case .dark:
                 switch adaptiveColor.kind {
-                    case .blue: .init(red: 0.361, green: 0.667, blue: 0.898)  // colorPaletteBlueBorderActive
-                    case .brown: .init(red: 0.733, green: 0.561, blue: 0.435)  // colorPaletteBrownBorderActive
-                    case .gray: .init(red: 0.686, green: 0.671, blue: 0.667)  // colorPaletteBeigeBorderActive
-                    case .green: .init(red: 0.369, green: 0.78, blue: 0.353)  // colorPaletteLightGreenForeground1
-                    case .orange: .init(red: 1.0, green: 0.729, blue: 0.4)  // colorPalettePeachBorderActive
-                    case .purple: .init(red: 0.855, green: 0.494, blue: 0.816)  // colorPaletteBerryForeground1
-                    case .red: .init(red: 0.89, green: 0.49, blue: 0.502)  // colorPaletteRedForeground1
-                    case .yellow: .init(red: 0.992, green: 0.918, blue: 0.239)  // colorPaletteYellowForeground3
+                    case .blue: .init(red: 0.361, green: 0.667, blue: 0.898) // colorPaletteBlueBorderActive
+                    case .brown: .init(red: 0.733, green: 0.561, blue: 0.435) // colorPaletteBrownBorderActive
+                    case .gray: .init(red: 0.686, green: 0.671, blue: 0.667) // colorPaletteBeigeBorderActive
+                    case .green: .init(red: 0.369, green: 0.78, blue: 0.353) // colorPaletteLightGreenForeground1
+                    case .orange: .init(red: 1.0, green: 0.729, blue: 0.4) // colorPalettePeachBorderActive
+                    case .purple: .init(red: 0.855, green: 0.494, blue: 0.816) // colorPaletteBerryForeground1
+                    case .red: .init(red: 0.89, green: 0.49, blue: 0.502) // colorPaletteRedForeground1
+                    case .yellow: .init(red: 0.992, green: 0.918, blue: 0.239) // colorPaletteYellowForeground3
                 }
         }
     }

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -57,7 +57,7 @@ public final class WinUIBackend: AppBackend {
     public typealias Menu = Void
     public typealias Alert = WinUI.ContentDialog
     public typealias Path = GeometryGroupHolder
-    public typealias Sheet = CustomWindow  // Only for protocol conformance. WinUI doesn't currently support it.
+    public typealias Sheet = CustomWindow // Only for protocol conformance. WinUI doesn't currently support it.
 
     public let defaultTableRowContentHeight = 20
     public let defaultTableCellVerticalPadding = 4

--- a/Tests/SwiftCrossUITests/EntryMacroTests.swift
+++ b/Tests/SwiftCrossUITests/EntryMacroTests.swift
@@ -251,4 +251,3 @@ struct EntryMacroTests {
     
     // TODO: Add test for raw identifiers after SwiftSyntax version bump to 602.0.0+
 }
-


### PR DESCRIPTION
Nick Lockwood's formatter is much more capable than the built-in Swift formatter.

The only shortcoming that I've noticed so far is that it doesn't seem to force indent switch cases; the `--indent-cases` option seems to just allow case indentation without enforcing it afaict