### PR TITLE
Fix WinUIBackend & GtkBackend menu bar support

### DIFF
--- a/Sources/SwiftCrossUI/Scenes/AlertScene.swift
+++ b/Sources/SwiftCrossUI/Scenes/AlertScene.swift
@@ -47,15 +47,21 @@ public final class AlertSceneNode: SceneGraphNode {
         self.scene = scene
     }
 
-    public func update<Backend: AppBackend>(
-        _ newScene: AlertScene?,
-        backend: Backend,
+    public func updateNode(
+        _ newScene: NodeScene?,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) -> SceneNodeUpdateResult {
         if let newScene {
             self.scene = newScene
         }
 
+        return .leafScene()
+    }
+
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
         if scene.isPresented, alert == nil {
             let alert = backend.createAlert()
             backend.updateAlert(
@@ -75,7 +81,5 @@ public final class AlertSceneNode: SceneGraphNode {
             backend.dismissAlert(alert as! Backend.Alert, window: nil)
             self.alert = nil
         }
-
-        return .leafScene()
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/Graph/SceneGraphNode.swift
+++ b/Sources/SwiftCrossUI/Scenes/Graph/SceneGraphNode.swift
@@ -26,20 +26,29 @@ public protocol SceneGraphNode: AnyObject {
         environment: EnvironmentValues
     )
 
+    /// Updates the scene's node without committing anything to screen or
+    /// propagating the update to child views.
+    ///
+    /// - Parameters:
+    ///   - newScene: The recomputed scene if the update is due to it being
+    ///     recomputed.
+    ///   - environment: The current root-level environment.
+    /// - Returns: The result of updating the scene node.
+    func updateNode(
+        _ newScene: NodeScene?,
+        environment: EnvironmentValues
+    ) -> SceneNodeUpdateResult
+
     /// Updates the scene.
     ///
     /// Unlike views (which have state), scenes are only ever updated when
     /// they're recomputed or immediately after they're created.
     ///
     /// - Parameters:
-    ///   - newScene: The recomputed scene if the update is due to it being
-    ///     recomputed.
     ///   - backend: The app's backend.
-    ///   - environment: The current root-level environment.
-    /// - Returns: The result of updating the scene.
+    ///   - environment: The current environment.
     func update<Backend: AppBackend>(
-        _ newScene: NodeScene?,
         backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult
+    )
 }

--- a/Sources/SwiftCrossUI/Scenes/Graph/SceneNodeUpdateResult.swift
+++ b/Sources/SwiftCrossUI/Scenes/Graph/SceneNodeUpdateResult.swift
@@ -1,5 +1,5 @@
-/// The result of updating a scene.
-public struct SceneUpdateResult: Sendable {
+/// The result of updating a scene graph node.
+public struct SceneNodeUpdateResult: Sendable {
     /// The preference values produced by the scene and its children.
     public var preferences: ScenePreferenceValues
 
@@ -9,13 +9,13 @@ public struct SceneUpdateResult: Sendable {
 
     /// Creates an update result by combining the preference values of a scene's
     /// children.
-    public init(childResults: [SceneUpdateResult]) {
+    public init(childResults: [SceneNodeUpdateResult]) {
         preferences = ScenePreferenceValues(merging: childResults.map(\.preferences))
     }
 
     /// Creates the layout result of a leaf scene (one with no children and no
     /// special preference behaviour). Uses ``ScenePreferenceValues/default``.
     public static func leafScene() -> Self {
-        SceneUpdateResult(preferences: .default)
+        SceneNodeUpdateResult(preferences: .default)
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/Modifiers/CommandsModifier.swift
+++ b/Sources/SwiftCrossUI/Scenes/Modifiers/CommandsModifier.swift
@@ -41,21 +41,26 @@ final class CommandsModifierNode<Content: Scene>: SceneGraphNode {
         )
     }
 
-    func update<Backend: AppBackend>(
+    func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) -> SceneNodeUpdateResult {
         if let newScene {
             self.commands = newScene.commands
         }
 
-        var result = contentNode.update(
-            newScene?.content,
+        var result = contentNode.updateNode(newScene?.content, environment: environment)
+        result.preferences.commands = result.preferences.commands.overlayed(with: commands)
+        return result
+    }
+
+    func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        contentNode.update(
             backend: backend,
             environment: environment
         )
-        result.preferences.commands = result.preferences.commands.overlayed(with: commands)
-        return result
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/Modifiers/SceneEnvironmentModifier.swift
+++ b/Sources/SwiftCrossUI/Scenes/Modifiers/SceneEnvironmentModifier.swift
@@ -64,17 +64,25 @@ final class SceneEnvironmentModifierNode<Content: Scene>: SceneGraphNode {
         )
     }
 
-    func update<Backend: AppBackend>(
+    func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) -> SceneNodeUpdateResult {
         if let newScene {
             self.modification = newScene.modification
         }
 
-        return contentNode.update(
+        return contentNode.updateNode(
             newScene?.content,
+            environment: modification(environment)
+        )
+    }
+
+    func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        contentNode.update(
             backend: backend,
             environment: modification(environment)
         )

--- a/Sources/SwiftCrossUI/Scenes/TupleScene.swift
+++ b/Sources/SwiftCrossUI/Scenes/TupleScene.swift
@@ -28,20 +28,26 @@ public final class TupleSceneNode2<Scene0: Scene, Scene1: Scene>: SceneGraphNode
         node1 = Scene1.Node(from: scene.scene1, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene3<Scene0: Scene, Scene1: Scene, Scene2: Scene>: Scene {
     public typealias Node = TupleSceneNode3<Scene0, Scene1, Scene2>
 
@@ -73,21 +79,28 @@ public final class TupleSceneNode3<Scene0: Scene, Scene1: Scene, Scene2: Scene>:
         node2 = Scene2.Node(from: scene.scene2, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene4<Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene>: Scene {
     public typealias Node = TupleSceneNode4<Scene0, Scene1, Scene2, Scene3>
 
@@ -125,22 +138,30 @@ public final class TupleSceneNode4<Scene0: Scene, Scene1: Scene, Scene2: Scene, 
         node3 = Scene3.Node(from: scene.scene3, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene5<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene
 >: Scene {
@@ -186,23 +207,32 @@ public final class TupleSceneNode5<
         node4 = Scene4.Node(from: scene.scene4, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene6<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene
 >: Scene {
@@ -253,24 +283,34 @@ public final class TupleSceneNode6<
         node5 = Scene5.Node(from: scene.scene5, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene7<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene
@@ -327,25 +367,36 @@ public final class TupleSceneNode7<
         node6 = Scene6.Node(from: scene.scene6, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene8<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene
@@ -410,26 +461,38 @@ public final class TupleSceneNode8<
         node7 = Scene7.Node(from: scene.scene7, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene9<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene
@@ -498,27 +561,40 @@ public final class TupleSceneNode9<
         node8 = Scene8.Node(from: scene.scene8, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene10<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene
@@ -591,28 +667,42 @@ public final class TupleSceneNode10<
         node9 = Scene9.Node(from: scene.scene9, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene11<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene
@@ -690,29 +780,44 @@ public final class TupleSceneNode11<
         node10 = Scene10.Node(from: scene.scene10, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene12<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene
@@ -796,30 +901,46 @@ public final class TupleSceneNode12<
         node11 = Scene11.Node(from: scene.scene11, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene13<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -909,31 +1030,48 @@ public final class TupleSceneNode13<
         node12 = Scene12.Node(from: scene.scene12, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene14<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1027,32 +1165,50 @@ public final class TupleSceneNode14<
         node13 = Scene13.Node(from: scene.scene13, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene15<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1151,33 +1307,52 @@ public final class TupleSceneNode15<
         node14 = Scene14.Node(from: scene.scene14, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene16<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1280,34 +1455,54 @@ public final class TupleSceneNode16<
         node15 = Scene15.Node(from: scene.scene15, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
-                node15.update(newScene?.scene15, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
+                node15.updateNode(newScene?.scene15, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+        node15.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene17<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1414,35 +1609,56 @@ public final class TupleSceneNode17<
         node16 = Scene16.Node(from: scene.scene16, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
-                node15.update(newScene?.scene15, backend: backend, environment: environment),
-                node16.update(newScene?.scene16, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
+                node15.updateNode(newScene?.scene15, environment: environment),
+                node16.updateNode(newScene?.scene16, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+        node15.update(backend: backend, environment: environment)
+        node16.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene18<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1553,36 +1769,58 @@ public final class TupleSceneNode18<
         node17 = Scene17.Node(from: scene.scene17, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
-                node15.update(newScene?.scene15, backend: backend, environment: environment),
-                node16.update(newScene?.scene16, backend: backend, environment: environment),
-                node17.update(newScene?.scene17, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
+                node15.updateNode(newScene?.scene15, environment: environment),
+                node16.updateNode(newScene?.scene16, environment: environment),
+                node17.updateNode(newScene?.scene17, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+        node15.update(backend: backend, environment: environment)
+        node16.update(backend: backend, environment: environment)
+        node17.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene19<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1700,37 +1938,60 @@ public final class TupleSceneNode19<
         node18 = Scene18.Node(from: scene.scene18, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
-                node15.update(newScene?.scene15, backend: backend, environment: environment),
-                node16.update(newScene?.scene16, backend: backend, environment: environment),
-                node17.update(newScene?.scene17, backend: backend, environment: environment),
-                node18.update(newScene?.scene18, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
+                node15.updateNode(newScene?.scene15, environment: environment),
+                node16.updateNode(newScene?.scene16, environment: environment),
+                node17.updateNode(newScene?.scene17, environment: environment),
+                node18.updateNode(newScene?.scene18, environment: environment),
             ]
         )
     }
-}
 
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+        node15.update(backend: backend, environment: environment)
+        node16.update(backend: backend, environment: environment)
+        node17.update(backend: backend, environment: environment)
+        node18.update(backend: backend, environment: environment)
+    }
+}
 public struct TupleScene20<
     Scene0: Scene, Scene1: Scene, Scene2: Scene, Scene3: Scene, Scene4: Scene, Scene5: Scene,
     Scene6: Scene, Scene7: Scene, Scene8: Scene, Scene9: Scene, Scene10: Scene, Scene11: Scene,
@@ -1852,34 +2113,59 @@ public final class TupleSceneNode20<
         node19 = Scene19.Node(from: scene.scene19, backend: backend, environment: environment)
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
-                node0.update(newScene?.scene0, backend: backend, environment: environment),
-                node1.update(newScene?.scene1, backend: backend, environment: environment),
-                node2.update(newScene?.scene2, backend: backend, environment: environment),
-                node3.update(newScene?.scene3, backend: backend, environment: environment),
-                node4.update(newScene?.scene4, backend: backend, environment: environment),
-                node5.update(newScene?.scene5, backend: backend, environment: environment),
-                node6.update(newScene?.scene6, backend: backend, environment: environment),
-                node7.update(newScene?.scene7, backend: backend, environment: environment),
-                node8.update(newScene?.scene8, backend: backend, environment: environment),
-                node9.update(newScene?.scene9, backend: backend, environment: environment),
-                node10.update(newScene?.scene10, backend: backend, environment: environment),
-                node11.update(newScene?.scene11, backend: backend, environment: environment),
-                node12.update(newScene?.scene12, backend: backend, environment: environment),
-                node13.update(newScene?.scene13, backend: backend, environment: environment),
-                node14.update(newScene?.scene14, backend: backend, environment: environment),
-                node15.update(newScene?.scene15, backend: backend, environment: environment),
-                node16.update(newScene?.scene16, backend: backend, environment: environment),
-                node17.update(newScene?.scene17, backend: backend, environment: environment),
-                node18.update(newScene?.scene18, backend: backend, environment: environment),
-                node19.update(newScene?.scene19, backend: backend, environment: environment),
+                node0.updateNode(newScene?.scene0, environment: environment),
+                node1.updateNode(newScene?.scene1, environment: environment),
+                node2.updateNode(newScene?.scene2, environment: environment),
+                node3.updateNode(newScene?.scene3, environment: environment),
+                node4.updateNode(newScene?.scene4, environment: environment),
+                node5.updateNode(newScene?.scene5, environment: environment),
+                node6.updateNode(newScene?.scene6, environment: environment),
+                node7.updateNode(newScene?.scene7, environment: environment),
+                node8.updateNode(newScene?.scene8, environment: environment),
+                node9.updateNode(newScene?.scene9, environment: environment),
+                node10.updateNode(newScene?.scene10, environment: environment),
+                node11.updateNode(newScene?.scene11, environment: environment),
+                node12.updateNode(newScene?.scene12, environment: environment),
+                node13.updateNode(newScene?.scene13, environment: environment),
+                node14.updateNode(newScene?.scene14, environment: environment),
+                node15.updateNode(newScene?.scene15, environment: environment),
+                node16.updateNode(newScene?.scene16, environment: environment),
+                node17.updateNode(newScene?.scene17, environment: environment),
+                node18.updateNode(newScene?.scene18, environment: environment),
+                node19.updateNode(newScene?.scene19, environment: environment),
             ]
         )
+    }
+
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        node0.update(backend: backend, environment: environment)
+        node1.update(backend: backend, environment: environment)
+        node2.update(backend: backend, environment: environment)
+        node3.update(backend: backend, environment: environment)
+        node4.update(backend: backend, environment: environment)
+        node5.update(backend: backend, environment: environment)
+        node6.update(backend: backend, environment: environment)
+        node7.update(backend: backend, environment: environment)
+        node8.update(backend: backend, environment: environment)
+        node9.update(backend: backend, environment: environment)
+        node10.update(backend: backend, environment: environment)
+        node11.update(backend: backend, environment: environment)
+        node12.update(backend: backend, environment: environment)
+        node13.update(backend: backend, environment: environment)
+        node14.update(backend: backend, environment: environment)
+        node15.update(backend: backend, environment: environment)
+        node16.update(backend: backend, environment: environment)
+        node17.update(backend: backend, environment: environment)
+        node18.update(backend: backend, environment: environment)
+        node19.update(backend: backend, environment: environment)
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/TupleScene.swift.gyb
+++ b/Sources/SwiftCrossUI/Scenes/TupleScene.swift.gyb
@@ -36,18 +36,26 @@ public final class TupleSceneNode${i}<${", ".join("Scene%d: Scene" % j for j in 
         %end
     }
 
-    public func update<Backend: AppBackend>(
+    public func updateNode(
         _ newScene: NodeScene?,
-        backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
-        return SceneUpdateResult(
+    ) -> SceneNodeUpdateResult {
+        return SceneNodeUpdateResult(
             childResults: [
                 %for j in range(i):
-                node${j}.update(newScene?.scene${j}, backend: backend, environment: environment),
+                node${j}.updateNode(newScene?.scene${j}, environment: environment),
                 %end
             ]
         )
+    }
+
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
+        %for j in range(i):
+        node${j}.update(backend: backend, environment: environment)
+        %end
     }
 }
 %end

--- a/Sources/SwiftCrossUI/Scenes/Window.swift
+++ b/Sources/SwiftCrossUI/Scenes/Window.swift
@@ -63,15 +63,21 @@ public final class WindowNode<Content: View>: SceneGraphNode {
         }
     }
 
-    public func update<Backend: AppBackend>(
-        _ newScene: Window<Content>?,
-        backend: Backend,
+    public func updateNode(
+        _ newScene: NodeScene?,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) -> SceneNodeUpdateResult {
         if let newScene {
             self.scene = newScene
         }
 
+        return .leafScene()
+    }
+
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
         environment.openWindowFunctionsByID.value[scene.id] = { [weak self] in
             guard let self else { return }
 
@@ -88,7 +94,7 @@ public final class WindowNode<Content: View>: SceneGraphNode {
                 )
                 windowReference = reference
 
-                _ = reference.update(
+                reference.update(
                     nil,
                     backend: backend,
                     environment: environment
@@ -96,10 +102,10 @@ public final class WindowNode<Content: View>: SceneGraphNode {
             }
         }
 
-        return windowReference?.update(
-            newScene,
+        windowReference?.update(
+            scene,
             backend: backend,
             environment: environment
-        ) ?? .leafScene()
+        )
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
@@ -70,15 +70,21 @@ public final class WindowGroupNode<Content: View>: SceneGraphNode {
         }
     }
 
-    public func update<Backend: AppBackend>(
-        _ newScene: WindowGroup<Content>?,
-        backend: Backend,
+    public func updateNode(
+        _ newScene: NodeScene?,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) -> SceneNodeUpdateResult {
         if let newScene {
             self.scene = newScene
         }
 
+        return .leafScene()
+    }
+
+    public func update<Backend: AppBackend>(
+        backend: Backend,
+        environment: EnvironmentValues
+    ) {
         if let id = scene.id {
             environment.openWindowFunctionsByID.value[id] = { [weak self] in
                 guard let self else { return }
@@ -100,13 +106,12 @@ public final class WindowGroupNode<Content: View>: SceneGraphNode {
             }
         }
 
-        let results = windowReferences.values.map { windowReference in
+        for windowReference in windowReferences.values {
             windowReference.update(
-                newScene,
+                scene,
                 backend: backend,
                 environment: environment
             )
         }
-        return SceneUpdateResult(childResults: results)
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -76,7 +76,7 @@ final class WindowReference<SceneType: WindowingScene> {
         _ newScene: SceneType?,
         backend: Backend,
         environment: EnvironmentValues
-    ) -> SceneUpdateResult {
+    ) {
         guard let window = window as? Backend.Window else {
             fatalError("Scene updated with a backend incompatible with the window it was given")
         }
@@ -94,7 +94,7 @@ final class WindowReference<SceneType: WindowingScene> {
             usedDefaultSize = false
         }
 
-        return update(
+        update(
             newScene,
             proposedWindowSize: proposedWindowSize,
             needsWindowSizeCommit: usedDefaultSize,
@@ -106,7 +106,7 @@ final class WindowReference<SceneType: WindowingScene> {
 
     /// Updates the `WindowReference`.
     /// - Parameters:
-    ///   - newScene: The scene. `nil` if this is the first update.
+    ///   - newScene: The scene. `nil` if reusing previous scene value.
     ///   - proposedWindowSize: The proposed window size.
     ///   - needsWindowSizeCommit: Whether the proposed window size matches the
     ///     windows current size (or imminent size in the case of a window
@@ -127,7 +127,7 @@ final class WindowReference<SceneType: WindowingScene> {
         backend: Backend,
         environment: EnvironmentValues,
         windowSizeIsFinal: Bool = false
-    ) -> SceneUpdateResult {
+    ) {
         guard let window = window as? Backend.Window else {
             fatalError("Scene updated with a backend incompatible with the window it was given")
         }
@@ -245,8 +245,6 @@ final class WindowReference<SceneType: WindowingScene> {
             backend.show(window: window)
             isFirstUpdate = false
         }
-
-        return .leafScene()
     }
 
     func activate<Backend: AppBackend>(backend: Backend) {

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -38,12 +38,12 @@ class _App<AppRoot: App> {
         dynamicPropertyUpdater.update(app, with: environment, previousValue: nil)
 
         if let sceneGraphRoot {
-            let result = sceneGraphRoot.update(
-                app.body,
+            let result = sceneGraphRoot.updateNode(app.body, environment: environment)
+            backend.setApplicationMenu(result.preferences.commands.resolve())
+            sceneGraphRoot.update(
                 backend: backend,
                 environment: environment
             )
-            backend.setApplicationMenu(result.preferences.commands.resolve())
         }
     }
 
@@ -96,17 +96,13 @@ class _App<AppRoot: App> {
                 self.refreshSceneGraph()
             }
 
-            let result = rootNode.update(
-                nil,
-                backend: backend,
-                environment: backend.computeRootEnvironment(
-                    defaultEnvironment: baseEnvironment
-                )
-            )
-            self.sceneGraphRoot = rootNode
+            let result = rootNode.updateNode(nil, environment: environment)
 
             // Update application-wide menu
             backend.setApplicationMenu(result.preferences.commands.resolve())
+
+            rootNode.update(backend: backend, environment: environment)
+            self.sceneGraphRoot = rootNode
         }
     }
 }

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -207,7 +207,7 @@ public final class WinUIBackend: AppBackend {
         let height = Double(size.height) / scaleFactor
         let out = SIMD2(
             Int(width.rounded(.towardZero)),
-            Int(height.rounded(.towardZero)) - CustomWindow.menuBarHeight
+            Int(height.rounded(.towardZero)) - window.contentHeightAdjustment
         )
         return out
     }
@@ -220,7 +220,7 @@ public final class WinUIBackend: AppBackend {
     public func setSize(ofWindow window: Window, to newSize: SIMD2<Int>) {
         let scaleFactor = window.scaleFactor
         let width = scaleFactor * Double(newSize.x)
-        let height = scaleFactor * Double(newSize.y + CustomWindow.menuBarHeight)
+        let height = scaleFactor * Double(newSize.y + window.contentHeightAdjustment)
         let size = UWP.SizeInt32(
             width: Int32(width.rounded(.towardZero)),
             height: Int32(height.rounded(.towardZero))
@@ -243,7 +243,7 @@ public final class WinUIBackend: AppBackend {
         window.sizeChanged.addHandler { _, args in
             let size = SIMD2(
                 Int(args!.size.width.rounded(.awayFromZero)),
-                Int(args!.size.height.rounded(.awayFromZero)) - CustomWindow.menuBarHeight
+                Int(args!.size.height.rounded(.awayFromZero)) - window.contentHeightAdjustment
             )
             action(size)
         }
@@ -360,6 +360,7 @@ public final class WinUIBackend: AppBackend {
             for item in items {
                 window.menuBar.items.append(item)
             }
+            window.setMenuBarVisible(!items.isEmpty)
         }
     }
 
@@ -2140,13 +2141,21 @@ class SwiftIInitializeWithWindow: WindowsFoundation.IUnknown {
 
 public class CustomWindow: WinUI.Window {
     /// Hardcoded menu bar height from MenuBar_themeresources.xaml in the
-    /// microsoft-ui-xaml repository.
-    static let menuBarHeight = 0
+    /// microsoft-ui-xaml repository (the MenuBarHeight property)
+    private static let menuBarHeight = 40
 
     var menuBar = WinUI.MenuBar()
     var child: WinUIBackend.Widget?
     var grid: WinUI.Grid
     var cachedAppWindow: WinAppSDK.AppWindow!
+
+    private(set) var menuBarIsVisible = false
+
+    /// The amount of height to subtract off the window height to obtain the
+    /// window's available content height.
+    var contentHeightAdjustment: Int {
+        menuBarIsVisible ? Self.menuBarHeight : 0
+    }
 
     var scaleFactor: Double {
         // I'm leaving this code here for future travellers. Be warned that this always
@@ -2181,10 +2190,6 @@ public class CustomWindow: WinUI.Window {
         super.init()
 
         let menuBarRowDefinition = WinUI.RowDefinition()
-        menuBarRowDefinition.height = WinUI.GridLength(
-            value: Double(Self.menuBarHeight),
-            gridUnitType: .pixel
-        )
         let contentRowDefinition = WinUI.RowDefinition()
         grid.rowDefinitions.append(menuBarRowDefinition)
         grid.rowDefinitions.append(contentRowDefinition)
@@ -2195,6 +2200,20 @@ public class CustomWindow: WinUI.Window {
         // Caching appWindow is apparently a good idea in terms of performance:
         // https://github.com/thebrowsercompany/swift-winrt/issues/199#issuecomment-2611006020
         cachedAppWindow = appWindow
+
+        // Default to not showing the menu bar; we only want to show it when it's non-empty
+        setMenuBarVisible(menuBarIsVisible)
+    }
+
+    /// Sets whether the menu bar of the current window is visible. The menu bar
+    /// is what holds the in-window app menu, it's not the title bar (the one with
+    /// the window controls).
+    public func setMenuBarVisible(_ visible: Bool) {
+        grid.rowDefinitions[0]!.height = WinUI.GridLength(
+            value: visible ? Double(Self.menuBarHeight) : 0,
+            gridUnitType: .pixel
+        )
+        menuBarIsVisible = visible
     }
 
     public func setChild(_ child: WinUIBackend.Widget) {


### PR DESCRIPTION
As mentioned in #388, WinUIBackend hasn't been showing app menu bars, even though it did already have all the code required to support them. This was because I had some issues with them in the past and essentially disabled them by setting the menu bar height to zero.

This PR re-enables WinUIBackend menu bars. And to fix the issue that originally made me disable support for them, it hides the window menu bars when the menu is empty.

I had to make some changes to the `SceneGraphNode` protocol in order to be able to compute the app's commands (menu bar items) before update each window's content, because whether or not the menu bar is empty now affects how much space is available in the windows (as the menu bar takes up window space when visible).

As a side effect of the `SceneGraphNode` protocol restructuring, I ended up resolving the GtkBackend menu bar support issues as well (I think because we could set the menu bar before showing the window).

---

This PR fully resolves #388 