### PR TITLE
WinUIBackend: Print underlying error when file picker fails

### DIFF
--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -1510,34 +1510,32 @@ public final class WinUIBackend: AppBackend {
         if openDialogOptions.allowMultipleSelections {
             let promise = try! picker.pickMultipleFilesAsync()!
             promise.completed = { operation, status in
-                guard
-                    status == .completed,
-                    let operation,
-                    let result = try? operation.getResults()
-                else {
-                    handleResult(.cancelled)
-                    return
+                let result: DialogResult<[URL]> = Self.handleAsyncOperationCompletion(
+                    operation,
+                    status
+                ) { result in
+                    let files = Array(result).compactMap { $0 }
+                        .map(\.path)
+                        .map(URL.init(fileURLWithPath:))
+                    return .success(files)
+                } onFailure: {
+                    return .cancelled
                 }
-
-                let files = Array(result).compactMap { $0 }
-                    .map(\.path)
-                    .map(URL.init(fileURLWithPath:))
-                handleResult(.success(files))
+                handleResult(result)
             }
         } else {
             let promise = try! picker.pickSingleFileAsync()!
             promise.completed = { operation, status in
-                guard
-                    status == .completed,
-                    let operation,
-                    let result = try? operation.getResults()
-                else {
-                    handleResult(.cancelled)
-                    return
+                let result: DialogResult<[URL]> = Self.handleAsyncOperationCompletion(
+                    operation,
+                    status
+                ) { result in
+                    let file = URL(fileURLWithPath: result.path)
+                    return .success([file])
+                } onFailure: {
+                    return .cancelled
                 }
-
-                let file = URL(fileURLWithPath: result.path)
-                handleResult(.success([file]))
+                handleResult(result)
             }
         }
     }
@@ -1558,18 +1556,63 @@ public final class WinUIBackend: AppBackend {
         _ = picker.fileTypeChoices.insert("Text", [".txt"].toVector())
         let promise = try! picker.pickSaveFileAsync()!
         promise.completed = { operation, status in
-            guard
-                status == .completed,
-                let operation,
-                let result = try? operation.getResults()
-            else {
-                handleResult(.cancelled)
-                return
+            let result: DialogResult<URL> = Self.handleAsyncOperationCompletion(
+                operation,
+                status
+            ) { result in
+                let file = URL(fileURLWithPath: result.path)
+                return .success(file)
+            } onFailure: {
+                return .cancelled
             }
-
-            let file = URL(fileURLWithPath: result.path)
-            handleResult(.success(file))
+            handleResult(result)
         }
+    }
+
+    /// A helper method that abstracts out the common failure case handling code
+    /// from all of our file dialog related async operation completion handlers.
+    private static func handleAsyncOperationCompletion<T, R>(
+        _ operation: AnyIAsyncOperation<T?>?,
+        _ status: AsyncStatus,
+        onSuccess handleSuccess: (T) -> R,
+        onFailure handleFailure: () -> R
+    ) -> R {
+        guard let operation else {
+            logger.warning(
+                "operation parameter unexpectedly nil",
+                metadata: [
+                    "function": #function
+                ]
+            )
+            return handleFailure()
+        }
+
+        guard
+            status == .completed,
+            let result = try? operation.getResults()
+        else {
+            if status == .error {
+                logger.error(
+                    "\(WindowsFoundation.Error(hr: operation.errorCode))",
+                    metadata: [
+                        "function": #function
+                    ]
+                )
+
+                if UInt32(bitPattern: operation.errorCode) == 0x80004005 {
+                    // https://github.com/microsoft/WindowsAppSDK/issues/4625#issuecomment-2281358235
+                    logger.warning(
+                        """
+                        This may indicate that you're attempting to launch a \
+                        file picker from an app launched as administrator
+                        """
+                    )
+                }
+            }
+            return handleFailure()
+        }
+
+        return handleSuccess(result)
     }
 
     public func createTapGestureTarget(wrapping child: Widget, gesture: TapGesture) -> Widget {


### PR DESCRIPTION
I spent a little bit of time looking into WinUI file open/save pickers being broken. Turns out that it was just because I was launching my test app as administrator (long story), and it's [a known issue](https://github.com/microsoft/WindowsAppSDK/issues/4625#issuecomment-2281358235) that file open/save pickers don't work in administrator processes.

To save future users the pain I've updated the picker completion handler to log the error message when a picker fails due to an error, and a warning when it fails with error code 0x80004005 (which is the error code that I was facing).