### PR TITLE
Implement View.preferredColorScheme(_:) modifier (sets window theme)

### DIFF
--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -225,7 +225,7 @@ struct WindowingApp: App {
             return Bundle.main.bundleURL.appendingPathComponent(
                 "Contents/Resources/Banner.png"
             )
-        #elseif os(Linux) || os(Windows)
+        #elseif os(iOS) || os(Linux) || os(Windows)
             return Bundle.main.bundleURL.appendingPathComponent(
                 "Examples_WindowingExample.bundle/Banner.png"
             )
@@ -281,7 +281,7 @@ struct WindowingApp: App {
         .commands {
             CommandMenu("Demo menu") {
                 Button("Menu item") {}
-                Toggle("Toggle", active: $toggle)
+                Toggle("Toggle", isOn: $toggle)
 
                 Divider()
 

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -31,6 +31,7 @@ public final class AppKitBackend: AppBackend {
     public let supportedPickerStyles: [BackendPickerStyle] = [
         .menu, .segmented, .radioGroup,
     ]
+    public let canOverrideWindowColorScheme = true
 
     public var scrollBarWidth: Int {
         // We assume that all scrollers have their controlSize set to `.regular` by default.
@@ -89,6 +90,10 @@ public final class AppKitBackend: AppBackend {
         window.isReleasedWhenClosed = false
 
         return window
+    }
+
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        window.appearance = environment.colorScheme.nsAppearance
     }
 
     public func size(ofWindow window: Window) -> SIMD2<Int> {

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -15,6 +15,7 @@ public final class DummyBackend: AppBackend {
         public var content: Widget?
         public var resizeHandler: ((SIMD2<Int>) -> Void)?
         public var closeHandler: (() -> Void)?
+        public var colorScheme = ColorScheme.light
 
         public init(defaultSize: SIMD2<Int>?) {
             size = defaultSize ?? Self.defaultSize
@@ -261,6 +262,7 @@ public final class DummyBackend: AppBackend {
     public var supportsMultipleWindows = true
     public var supportedDatePickerStyles: [DatePickerStyle] = []
     public var supportedPickerStyles: [BackendPickerStyle] = []
+    public let canOverrideWindowColorScheme = true
 
     public var incomingURLHandler: ((URL) -> Void)?
 
@@ -272,6 +274,10 @@ public final class DummyBackend: AppBackend {
 
     public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
         Window(defaultSize: defaultSize)
+    }
+
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        window.colorScheme = environment.colorScheme
     }
 
     public func setTitle(ofWindow window: Window, to title: String) {

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -36,6 +36,7 @@ public final class Gtk3Backend: AppBackend {
     public let deviceClass = DeviceClass.desktop
     public let supportedDatePickerStyles: [DatePickerStyle] = []
     public let supportedPickerStyles: [BackendPickerStyle] = []
+    public let canOverrideWindowColorScheme = false
 
     var gtkApp: Application
 
@@ -175,6 +176,10 @@ public final class Gtk3Backend: AppBackend {
         }
 
         return window
+    }
+
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        // TODO(stackotter): Support preferredColorScheme
     }
 
     public func setTitle(ofWindow window: Window, to title: String) {

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -41,6 +41,7 @@ public final class GtkBackend: AppBackend {
     public let defaultSheetCornerRadius = 10
     public let supportedDatePickerStyles: [DatePickerStyle] = [.automatic, .graphical]
     public let supportedPickerStyles: [BackendPickerStyle] = [.menu]
+    public let canOverrideWindowColorScheme = false
 
     var gtkApp: Application
 
@@ -166,6 +167,10 @@ public final class GtkBackend: AppBackend {
         window.setChild(Gtk.Box())
 
         return window
+    }
+
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        // TODO(stackotter): Support preferredColorScheme
     }
 
     public func setTitle(ofWindow window: Window, to title: String) {

--- a/Sources/SwiftCrossUI/Backend/AppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/AppBackend.swift
@@ -124,6 +124,11 @@ public protocol AppBackend: Sendable {
     /// The picker style used by ``PickerStyle/automatic``.
     var defaultPickerStyle: BackendPickerStyle { get }
 
+    /// Whether the backend supports overriding window color schemes (as you may
+    /// do with the 'preferredColorScheme(_:)' modifier). If false, then SwiftCrossUI
+    /// will ignore the preferredColorScheme(_:) modifier as a nicer failure mode.
+    var canOverrideWindowColorScheme: Bool { get }
+
     /// Runs the backend's main run loop.
     ///
     /// The app will exit when this method returns. This will always be the
@@ -168,6 +173,11 @@ public protocol AppBackend: Sendable {
     ///   preferred window size from a previous session.
     /// - Returns: The created window.
     func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window
+    /// Updates a window, generally to react to the current color scheme from the
+    /// environment.
+    ///
+    /// - Parameter environment: the current environment.
+    func updateWindow(_ window: Window, environment: EnvironmentValues)
     /// Sets the title of a window.
     ///
     /// - Parameters:

--- a/Sources/SwiftCrossUI/Scenes/Window.swift
+++ b/Sources/SwiftCrossUI/Scenes/Window.swift
@@ -35,7 +35,7 @@ public final class WindowNode<Content: View>: SceneGraphNode {
     /// the window's view graph.
     ///
     /// `nil` if the window is closed.
-    private var windowReference: WindowReference<Window<Content>>? = nil
+    var windowReference: WindowReference<Window<Content>>? = nil
 
     /// The underlying scene.
     private var scene: Window<Content>

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -6,7 +6,7 @@ final class WindowReference<SceneType: WindowingScene> {
     /// The view graph of the window's root view.
     private let viewGraph: ViewGraph<SceneType.Content>
     /// The window being rendered in.
-    private let window: Any
+    let window: Any
     /// `false` after the first scene update.
     private var isFirstUpdate = true
     /// The environment most recently provided by this node's parent scene.

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -13,6 +13,8 @@ final class WindowReference<SceneType: WindowingScene> {
     private var parentEnvironment: EnvironmentValues
     /// The container used to center the root view in the window.
     private let containerWidget: AnyWidget
+    /// The window's preferred color scheme, cached from the last update.
+    private var preferredColorScheme: ColorScheme?
 
     /// - Parameters:
     ///   - closeHandler: The action to perform when the window is closed. Should
@@ -144,7 +146,7 @@ final class WindowReference<SceneType: WindowingScene> {
             scene = newScene
         }
 
-        let environment =
+        var environment =
             backend.computeWindowEnvironment(window: window, rootEnvironment: environment)
             .with(\.onResize) { [weak self] _ in
                 guard let self else { return }
@@ -160,27 +162,51 @@ final class WindowReference<SceneType: WindowingScene> {
                 )
             }
             .with(\.window, window)
+        let outerColorScheme = environment.colorScheme
 
-        let minimumWindowSize = viewGraph.computeLayout(
+        // Update environment with latest cached value before first update to
+        // minimise toggling between outer color scheme and preferred color
+        // scheme where possible (could confuse people when logging the color
+        // scheme or debugging things)
+        if let preferredColorScheme {
+            environment.colorScheme = preferredColorScheme
+        }
+
+        let probingResult = viewGraph.computeLayout(
             with: newScene?.content(),
             proposedSize: .zero,
-            environment: environment.with(\.allowLayoutCaching, true)
-        ).size
+            environment: environment
+                .with(\.allowLayoutCaching, true)
+        )
+        let minimumWindowSize = probingResult.size
+        updateEnvironment(
+            &environment,
+            viewLayoutResult: probingResult,
+            outerColorScheme: outerColorScheme,
+            backend: backend
+        )
 
         // With `.contentSize`, the window's maximum size is the maximum size of its
         // content. With `.contentMinSize` (and `.automatic`), there is no maximum
         // size.
-        let maximumWindowSize: ViewSize? =
-            switch environment.windowResizability {
-                case .contentSize:
-                    viewGraph.computeLayout(
-                        with: newScene?.content(),
-                        proposedSize: .infinity,
-                        environment: environment.with(\.allowLayoutCaching, true)
-                    ).size
-                case .automatic, .contentMinSize:
-                    nil
-            }
+        let maximumWindowSize: ViewSize?
+        switch environment.windowResizability {
+            case .contentSize:
+                let result = viewGraph.computeLayout(
+                    with: newScene?.content(),
+                    proposedSize: .infinity,
+                    environment: environment.with(\.allowLayoutCaching, true)
+                )
+                updateEnvironment(
+                    &environment,
+                    viewLayoutResult: result,
+                    outerColorScheme: outerColorScheme,
+                    backend: backend
+                )
+                maximumWindowSize = result.size
+            case .automatic, .contentMinSize:
+                maximumWindowSize = nil
+        }
 
         let clampedWindowSize = ViewSize(
             min(
@@ -218,6 +244,12 @@ final class WindowReference<SceneType: WindowingScene> {
             proposedSize: ProposedViewSize(proposedWindowSize),
             environment: environment
         )
+        updateEnvironment(
+            &environment,
+            viewLayoutResult: finalContentResult,
+            outerColorScheme: outerColorScheme,
+            backend: backend
+        )
 
         backend.setPosition(
             ofChildAt: 0,
@@ -239,6 +271,9 @@ final class WindowReference<SceneType: WindowingScene> {
                 finalContentResult.preferences.windowResizeBehavior?.isEnabled ?? true
         )
 
+        // Generally just used to update the window color scheme
+        backend.updateWindow(window, environment: environment)
+
         // Delay committing the view graph so that the View.inspectWindow(_:)
         // modifiers can be used to overwrite certain SwiftCrossUI behaviors
         viewGraph.commit()
@@ -255,5 +290,24 @@ final class WindowReference<SceneType: WindowingScene> {
         }
 
         backend.activate(window: window)
+    }
+
+    private func updateEnvironment<Backend: AppBackend>(
+        _ environment: inout EnvironmentValues,
+        viewLayoutResult: ViewLayoutResult,
+        outerColorScheme: ColorScheme,
+        backend: Backend
+    ) {
+        preferredColorScheme = viewLayoutResult.preferences.preferredColorScheme
+
+        // Update environment with preferred color scheme if provided
+        if let preferredColorScheme, backend.canOverrideWindowColorScheme {
+            environment.colorScheme = preferredColorScheme
+        } else {
+            // If the preferred color scheme just changed to nil, then we must
+            // reset the environment's color scheme to the outer color scheme
+            // provided by a higher scene or the system.
+            environment.colorScheme = outerColorScheme
+        }
     }
 }

--- a/Sources/SwiftCrossUI/ViewGraph/PreferenceValues.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/PreferenceValues.swift
@@ -31,6 +31,9 @@ public struct PreferenceValues: Sendable {
     /// The background color for enclosing sheets.
     public var presentationBackground: Color?
 
+    /// Sets the preferred color scheme for the nearest enclosing presentation.
+    public var preferredColorScheme: ColorScheme?
+
     /// Controls whether the user can interactively dismiss enclosing sheets.
     public var interactiveDismissDisabled: Bool?
 
@@ -79,6 +82,7 @@ extension PreferenceValues {
         presentationDragIndicatorVisibility =
             children.compactMap(\.presentationDragIndicatorVisibility).first
         presentationBackground = children.compactMap(\.presentationBackground).first
+        preferredColorScheme = children.compactMap(\.preferredColorScheme).first
         interactiveDismissDisabled = children.compactMap(\.interactiveDismissDisabled).first
 
         windowDismissBehavior = children.compactMap(\.windowDismissBehavior).first

--- a/Sources/SwiftCrossUI/Views/Modifiers/PresentationModifiers.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/PresentationModifiers.swift
@@ -76,4 +76,18 @@ extension View {
     public func interactiveDismissDisabled(_ isDisabled: Bool = true) -> some View {
         preference(key: \.interactiveDismissDisabled, value: isDisabled)
     }
+
+    /// Sets the preferred color scheme for the nearest enclosing presentation,
+    /// such as a sheet or window.
+    ///
+    /// > Note: Not supported by GtkBackend or Gtk3Backend. When targeting those
+    /// > platforms this modifier has no effect.
+    ///
+    /// - Parameter colorScheme: The preferred color scheme for the nearest
+    ///   enclosing presentation.
+    /// - Returns: A view with the ``PreferenceValues/preferredColorScheme``
+    ///   preference set.
+    public func preferredColorScheme(_ colorScheme: ColorScheme?) -> some View {
+        preference(key: \.preferredColorScheme, value: colorScheme)
+    }
 }

--- a/Sources/UIKitBackend/UIKitBackend+Window.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Window.swift
@@ -89,6 +89,14 @@ extension UIKitBackend {
         return window
     }
 
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        // TODO(stackotter): Support preferredColorScheme
+        window.backgroundColor = switch environment.colorScheme {
+            case .light: .white
+            case .dark: .black
+        }
+    }
+
     public func setTitle(ofWindow window: Window, to title: String) {
         // I don't think this achieves much of anything but might as well
         window.rootViewController!.title = title

--- a/Sources/UIKitBackend/UIKitBackend.swift
+++ b/Sources/UIKitBackend/UIKitBackend.swift
@@ -26,6 +26,7 @@ public final class UIKitBackend: AppBackend {
 
     public let canRevealFiles = false
     public let supportsMultipleWindows = false
+    public let canOverrideWindowColorScheme = true
 
     public var deviceClass: DeviceClass {
         switch UIDevice.current.userInterfaceIdiom {

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -72,6 +72,7 @@ public final class WinUIBackend: AppBackend {
         .automatic, .graphical, .compact, .wheel,
     ]
     public let supportedPickerStyles: [BackendPickerStyle] = [.menu, .radioGroup]
+    public let canOverrideWindowColorScheme = true
 
     public var scrollBarWidth: Int {
         12
@@ -198,6 +199,21 @@ public final class WinUIBackend: AppBackend {
             setSize(ofWindow: window, to: size)
         }
         return window
+    }
+
+    public func updateWindow(_ window: Window, environment: EnvironmentValues) {
+        window.menuBar.requestedTheme = switch environment.colorScheme {
+            case .light: .light
+            case .dark: .dark
+        }
+
+        let backgroundColor: SwiftCrossUI.Color = switch environment.colorScheme {
+            case .light: .white
+            case .dark: .black
+        }
+        let brush = WinUI.SolidColorBrush()
+        brush.color = backgroundColor.resolve(in: environment).uwpColor
+        window.grid.background = brush
     }
 
     public func size(ofWindow window: Window) -> SIMD2<Int> {
@@ -361,6 +377,7 @@ public final class WinUIBackend: AppBackend {
                 window.menuBar.items.append(item)
             }
             window.setMenuBarVisible(!items.isEmpty)
+            window.menuBar.requestedTheme = .dark
         }
     }
 

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -116,6 +116,45 @@ struct SwiftCrossUITests {
         #expect(child.size == expectedSize.vector)
     }
 
+    @Test("Ensure that preferredColorScheme modifier works")
+    @MainActor
+    func testPreferredColorScheme() async throws {
+        let backend = DummyBackend()
+        let environment = EnvironmentValues(backend: backend)
+            .with(\.defaultLaunchBehavior, .presented)
+
+        #expect(environment.colorScheme == .light)
+
+        let ambientColorScheme = Box<ColorScheme?>(nil)
+
+        struct TestView: View {
+            @Environment(\.colorScheme) var colorScheme
+            var ambientColorScheme: Box<ColorScheme?>
+
+            var body: some View {
+                VStack {
+                    Text("Button")
+                    Button("Button") {}
+                        .preferredColorScheme(.dark)
+                }
+                .onChange(of: colorScheme) {
+                    ambientColorScheme.value = colorScheme
+                }
+            }
+        }
+
+        let scene = Window("Test", id: "test") {
+            TestView(ambientColorScheme: ambientColorScheme)
+        }
+
+        let node = type(of: scene).Node(from: scene, backend: backend, environment: environment)
+        node.update(backend: backend, environment: environment)
+
+        let window = node.windowReference!.window as! DummyBackend.Window
+        #expect(window.colorScheme == .dark)
+        #expect(ambientColorScheme.value == .dark)
+    }
+
     #if canImport(AppKitBackend)
         @Test("Ensure that a basic view has the expected dimensions under AppKitBackend")
         @MainActor


### PR DESCRIPTION
The View.preferredColorScheme modifier propagates the provided colorScheme up to the nearest enclosing window and overrides the color scheme of the window. That preferred color scheme becomes the default color scheme for views within the window where not specified.

In particular, this;

- overrides the window background on iOS, macOS, and Windows,
- overrides the menu bar theme on Windows, and
- overrides the title bar theme on macOS (just the window as a whole)

Not implemented for GtkBackend or Gtk3Backend yet.

We could override the title bar theme on Windows as well, but it'd be quite tedious because Windows gives us a bit too much freedom; i.e. we have to specify the button foreground and background/hover colors, title bar foreground/background colors, and a few others. This would also be particularly annoying for users with custom themes, so I believe that we shouldn't do so by default.