### PR TITLE
Add support for implicitly unwrapped optionals to `Entry`

### DIFF
--- a/Sources/SwiftCrossUIMacrosPlugin/EntryMacro.swift
+++ b/Sources/SwiftCrossUIMacrosPlugin/EntryMacro.swift
@@ -122,7 +122,13 @@ public struct EntryMacro: AccessorMacro, PeerMacro {
 
         let typeDeclaration: String
         if let typeName = patternBinding.type?.normalizedDescription {
-            typeDeclaration = ": \(typeName)"
+            // NB: Swift won't automatically infer the `Value` type if it's an
+            // implicitly unwrapped optional.
+            typeDeclaration = if typeName.hasSuffix("!") {
+                ": \(typeName.dropLast())?"
+            } else {
+                ": \(typeName)"
+            }
         } else {
             typeDeclaration = ""
         }
@@ -130,7 +136,8 @@ public struct EntryMacro: AccessorMacro, PeerMacro {
         // Verify defaultValue
         let defaultValueDeclaration: String
         if patternBinding.initialValue == nil,
-            patternBinding.type?.isOptional == true
+            let type = patternBinding.type,
+            type.isOptional || type._syntax.trimmedDescription.hasSuffix("!")
         {
             defaultValueDeclaration = "static let defaultValue\(typeDeclaration) = nil"
         } else if let initialValue = patternBinding.initialValue?._syntax.trimmedDescription {


### PR DESCRIPTION
The title says it all. `@Entry` previously didn't support implicitly unwrapped optionals because Swift won't automatically fill in associated type requirements if the inferred type is an implicitly unwrapped optional (I have no idea _why_ this is the case, but such is life). This PR tweaks the implementation of the macro to simply treat those types as if they were normal optionals.