### PR TITLE
Special case `EnvironmentValues.appStorageProvider` a bit less

### DIFF
--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -25,8 +25,6 @@ package var logger: Logger {
 public protocol App {
     /// The backend used to render the app.
     associatedtype Backend: AppBackend
-    /// The app storage provider used to persist state annotated with ``AppStorage``.
-    associatedtype StorageProvider: AppStorageProvider
     /// The type of scene representing the content of the app.
     associatedtype Body: Scene
 
@@ -39,10 +37,6 @@ public protocol App {
 
     /// The application's backend.
     var backend: Backend { get }
-
-    /// The application's app storage provider, used for persisting ``AppStorage``
-    /// data to disk.
-    var appStorageProvider: StorageProvider { get }
 
     /// The content of the app.
     @SceneBuilder var body: Body { get }
@@ -142,14 +136,6 @@ extension App {
             logHandler.logLevel = .info
         #endif
         return logHandler
-    }
-
-    /// The default app storage provider for apps which don't specify a
-    /// custom one.
-    ///
-    /// This uses `UserDefaults` on all platforms.
-    public var appStorageProvider: some AppStorageProvider {
-        DefaultAppStorageProvider()
     }
 
     /// Runs the application.

--- a/Sources/SwiftCrossUI/Environment/AppStorageProvider.swift
+++ b/Sources/SwiftCrossUI/Environment/AppStorageProvider.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-package typealias DefaultAppStorageProvider = UserDefaultsAppStorageProvider
+/// The default app storage provider for apps which don't specify a
+/// custom one.
+///
+/// This uses `UserDefaults` on all platforms.
+public typealias DefaultAppStorageProvider = UserDefaultsAppStorageProvider
 
 /// A type that can be used to persist ``AppStorage`` values to disk.
 public protocol AppStorageProvider: Sendable {

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -42,9 +42,6 @@ public struct EnvironmentValues {
     /// events can propagate.
     var onResize: @MainActor (_ newSize: ViewSize) -> Void
 
-    /// The app storage provider to use for `@AppStorage` property wrappers.
-    public let appStorageProvider: any AppStorageProvider
-
     /// Backing storage for extensible subscript
     private var values: [ObjectIdentifier: Any]
 
@@ -204,13 +201,8 @@ public struct EnvironmentValues {
     ///
     /// - Parameters:
     ///   - backend: The app's backend.
-    ///   - appStorageProvider: The app's app storage provider
-    package init<Backend: AppBackend>(
-        backend: Backend,
-        appStorageProvider: any AppStorageProvider = DefaultAppStorageProvider()
-    ) {
+    package init<Backend: AppBackend>(backend: Backend) {
         self.backend = backend
-        self.appStorageProvider = appStorageProvider
 
         onResize = { _ in }
         values = [:]
@@ -240,6 +232,9 @@ public struct EnvironmentValues {
 }
 
 extension EnvironmentValues {
+    /// The app storage provider to use for `@AppStorage` property wrappers.
+    @Entry public var appStorageProvider: any AppStorageProvider = DefaultAppStorageProvider()
+
     /// The current stack orientation.
     ///
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
@@ -40,7 +40,6 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
                             // property on initialization, we're returning the default value instead.
                             return defaultValue
                         }
-                        print("Reading AppStorage value")
                         return provider.getValue(key: key, defaultValue: defaultValue)
                     case .path(let keyPath):
                         return AppStorageValues(provider: provider)[keyPath: keyPath]
@@ -59,7 +58,6 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
                 }
                 switch mode {
                     case .key(let key, _):
-                        print("Writing AppStorage value")
                         provider.setValue(key: key, newValue: newValue)
                     case .path(let keyPath):
                         var values = AppStorageValues(provider: provider)

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
@@ -15,8 +15,9 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
         var downstreamObservation: Cancellable?
         var provider: (any AppStorageProvider)?
 
-        init(mode: Mode) {
+        init(mode: Mode, provider: (some AppStorageProvider)?) {
             self.mode = mode
+            self.provider = provider
         }
 
         lazy var didChange: Publisher = {
@@ -79,17 +80,30 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
 
     public var projectedValue: Binding<Value> { implementation.projectedValue }
 
-    public init(wrappedValue defaultValue: Value, _ key: String) {
-        implementation = StateImpl(initialStorage: Storage(mode: .key(key, defaultValue)))
+    public init(
+        wrappedValue defaultValue: Value,
+        _ key: String,
+        provider: (some AppStorageProvider)? = nil
+    ) {
+        implementation = StateImpl(
+            initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
+        )
     }
 
-    public init(_ key: String) where Value: ExpressibleByNilLiteral {
-        self.init(wrappedValue: nil, key)
+    public init(
+        _ key: String,
+        provider: (some AppStorageProvider)? = nil
+    ) where Value: ExpressibleByNilLiteral {
+        self.init(wrappedValue: nil, key, provider: provider)
     }
 
     public func update(with environment: EnvironmentValues, previousValue: AppStorage<Value>?) {
         implementation.update(with: environment, previousValue: previousValue?.implementation)
-        storage.provider = environment.appStorageProvider
+
+        // don't override a provider specified by the initializer
+        if storage.provider == nil {
+            storage.provider = environment.appStorageProvider
+        }
     }
 
     enum Mode {
@@ -112,8 +126,14 @@ extension AppStorage {
         *, deprecated,
         message: "'AppStorage' does not work correctly with classes; use a struct instead"
     )
-    public init(wrappedValue defaultValue: Value, _ key: String) where Value: AnyObject {
-        implementation = StateImpl(initialStorage: Storage(mode: .key(key, defaultValue)))
+    public init(
+        wrappedValue defaultValue: Value,
+        _ key: String,
+        provider: (some AppStorageProvider)? = nil
+    ) where Value: AnyObject {
+        implementation = StateImpl(
+            initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
+        )
     }
 
     @available(
@@ -124,19 +144,33 @@ extension AppStorage {
             """
     )
 
-    public init(wrappedValue defaultValue: Value, _ key: String) where Value: ObservableObject {
-        implementation = StateImpl(initialStorage: Storage(mode: .key(key, defaultValue)))
+    public init(
+        wrappedValue defaultValue: Value,
+        _ key: String,
+        provider: (some AppStorageProvider)? = nil
+    ) where Value: ObservableObject {
+        implementation = StateImpl(
+            initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
+        )
     }
 }
 
 // MARK: - AppStorageKey
 
 extension AppStorage {
-    public init<Key: AppStorageKey<Value>>(_: Key.Type) {
-        self.init(wrappedValue: Key.defaultValue, Key.name)
+    public init<Key: AppStorageKey<Value>>(
+        _: Key.Type,
+        provider: (some AppStorageProvider)? = nil
+    ) {
+        self.init(wrappedValue: Key.defaultValue, Key.name, provider: provider)
     }
 
-    public init(_ keyPath: WritableKeyPath<AppStorageValues, Value>) {
-        implementation = StateImpl(initialStorage: Storage(mode: .path(keyPath)))
+    public init(
+        _ keyPath: WritableKeyPath<AppStorageValues, Value>,
+        provider: (some AppStorageProvider)? = nil
+    ) {
+        implementation = StateImpl(
+            initialStorage: Storage(mode: .path(keyPath), provider: provider)
+        )
     }
 }

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
@@ -15,7 +15,7 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
         var downstreamObservation: Cancellable?
         var provider: (any AppStorageProvider)?
 
-        init(mode: Mode, provider: (some AppStorageProvider)?) {
+        init(mode: Mode, provider: (any AppStorageProvider)?) {
             self.mode = mode
             self.provider = provider
         }
@@ -83,7 +83,7 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
     public init(
         wrappedValue defaultValue: Value,
         _ key: String,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) {
         implementation = StateImpl(
             initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
@@ -92,7 +92,7 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
 
     public init(
         _ key: String,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) where Value: ExpressibleByNilLiteral {
         self.init(wrappedValue: nil, key, provider: provider)
     }
@@ -129,7 +129,7 @@ extension AppStorage {
     public init(
         wrappedValue defaultValue: Value,
         _ key: String,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) where Value: AnyObject {
         implementation = StateImpl(
             initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
@@ -147,7 +147,7 @@ extension AppStorage {
     public init(
         wrappedValue defaultValue: Value,
         _ key: String,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) where Value: ObservableObject {
         implementation = StateImpl(
             initialStorage: Storage(mode: .key(key, defaultValue), provider: provider)
@@ -160,14 +160,14 @@ extension AppStorage {
 extension AppStorage {
     public init<Key: AppStorageKey<Value>>(
         _: Key.Type,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) {
         self.init(wrappedValue: Key.defaultValue, Key.name, provider: provider)
     }
 
     public init(
         _ keyPath: WritableKeyPath<AppStorageValues, Value>,
-        provider: (some AppStorageProvider)? = nil
+        provider: (any AppStorageProvider)? = nil
     ) {
         implementation = StateImpl(
             initialStorage: Storage(mode: .path(keyPath), provider: provider)

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/State basics.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/State basics.md
@@ -17,10 +17,16 @@ For situations where you need data to trickle back up again, use ``Binding``
 
 - ``State``
 - ``Binding``
-- ``AppStorage``
-- ``AppStorageKey``
-- ``AppStorageProvider``
 - ``ObservableObject``
 - ``Published``
 - ``Publisher``
 - ``Cancellable``
+
+## App Storage
+
+- ``AppStorage``
+- ``AppStorageKey``
+- ``AppStorageValues``
+- ``AppStorageProvider``
+- ``DefaultAppStorageProvider``
+- ``View/appStorageProvider(_:)``

--- a/Sources/SwiftCrossUI/Views/Modifiers/AppStorageProviderModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/AppStorageProviderModifier.swift
@@ -5,8 +5,17 @@ extension View {
     /// - Parameter provider: The app storage provider to use in this
     ///   view and its subviews.
     public func appStorageProvider(_ provider: some AppStorageProvider) -> some View {
-        EnvironmentModifier(self) { environment in
-            environment.with(\.appStorageProvider, provider)
-        }
+        environment(\.appStorageProvider, provider)
+    }
+}
+
+extension Scene {
+    /// Sets the app storage provider used to persist state annotated
+    /// with ``AppStorage``.
+    ///
+    /// - Parameter provider: The app storage provider to use in this
+    ///   scene and its subviews.
+    public func appStorageProvider(_ provider: some AppStorageProvider) -> some Scene {
+        environment(\.appStorageProvider, provider)
     }
 }

--- a/Sources/SwiftCrossUI/Views/Modifiers/AppStorageProviderModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/AppStorageProviderModifier.swift
@@ -1,0 +1,12 @@
+extension View {
+    /// Sets the app storage provider used to persist state annotated
+    /// with ``AppStorage``.
+    ///
+    /// - Parameter provider: The app storage provider to use in this
+    ///   view and its subviews.
+    public func appStorageProvider(_ provider: some AppStorageProvider) -> some View {
+        EnvironmentModifier(self) { environment in
+            environment.with(\.appStorageProvider, provider)
+        }
+    }
+}

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -22,10 +22,7 @@ class _App<AppRoot: App> {
     init(_ app: AppRoot) {
         backend = app.backend
         self.app = app
-        self.environment = EnvironmentValues(
-            backend: backend,
-            appStorageProvider: app.appStorageProvider
-        )
+        self.environment = EnvironmentValues(backend: backend)
         self.cancellables = []
 
         dynamicPropertyUpdater = DynamicPropertyUpdater(for: app)
@@ -50,10 +47,7 @@ class _App<AppRoot: App> {
     /// Runs the app using the app's selected backend.
     func run() {
         backend.runMainLoop { [self] in
-            let baseEnvironment = EnvironmentValues(
-                backend: backend,
-                appStorageProvider: app.appStorageProvider
-            )
+            let baseEnvironment = EnvironmentValues(backend: backend)
             environment = backend.computeRootEnvironment(
                 defaultEnvironment: baseEnvironment
             )


### PR DESCRIPTION
Previously, the app storage provider was set app-wide via a stored property requirement / associated type on `App`. This PR removes those requirements and replaces them with `appStorageProvider(_:)` view and scene modifiers, which can set the provider for individual views as well as for entire scenes.