### PR TITLE
Support environment stuff in menus

### DIFF
--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -67,6 +67,8 @@ struct ControlsApp: App {
                                     Text("Text item 1")
                                     Text("Text item 2")
                                 }
+                                Button("Disabled item") {}
+                                    .disabled()
                             }
                         }
 

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -67,8 +67,6 @@ struct ControlsApp: App {
                                     Text("Text item 1")
                                     Text("Text item 2")
                                 }
-                                Button("Disabled item") {}
-                                    .disabled()
                             }
                         }
 

--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -288,6 +288,8 @@ struct WindowingApp: App {
                 Menu("Submenu") {
                     Button("Item 1") {}
                     Button("Item 2") {}
+                    Button("Disabled item") {}
+                        .disabled()
                 }
             }
         }

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -174,8 +174,13 @@ public final class AppKitBackend: AppBackend {
         window.makeKeyAndOrderFront(nil)
     }
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
-        MenuBar.setUpMenuBar(extraMenus: submenus.map(Self.renderSubmenu(_:)))
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) {
+        MenuBar.setUpMenuBar(extraMenus: submenus.map {
+            Self.renderSubmenu($0, environment: environment)
+        })
     }
 
     public func close(window: Window) {
@@ -197,53 +202,67 @@ public final class AppKitBackend: AppBackend {
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
-    private static func renderMenuItems(_ items: [ResolvedMenu.Item]) -> [NSMenuItem] {
-        items.map { item in
-            switch item {
-                case .button(let label, let action):
-                    // Custom subclass is used to keep strong reference to action
-                    // wrapper.
-                    let renderedItem = NSCustomMenuItem(
-                        title: label,
-                        action: nil,
-                        keyEquivalent: ""
-                    )
-                    if let action {
-                        let wrappedAction = Action(action)
-                        renderedItem.actionWrapper = wrappedAction
-                        renderedItem.action = #selector(wrappedAction.run)
-                        renderedItem.target = wrappedAction
-                    }
-                    return renderedItem
-                case .toggle(let label, let value, let onChange):
-                    // Custom subclass is used to keep strong reference to action
-                    // wrapper.
-                    let renderedItem = NSCustomMenuItem(
-                        title: label,
-                        action: nil,
-                        keyEquivalent: ""
-                    )
-                    renderedItem.isOn = value
+    private static func renderMenuItem(
+        _ item: ResolvedMenu.Item,
+        environment: EnvironmentValues
+    ) -> NSMenuItem {
+        switch item {
+            case .button(let label, let action):
+                // Custom subclass is used to keep strong reference to action
+                // wrapper.
+                let renderedItem = NSCustomMenuItem(
+                    title: label,
+                    action: nil,
+                    keyEquivalent: ""
+                )
+                if let action, environment.isEnabled {
+                    let wrappedAction = Action(action)
+                    renderedItem.actionWrapper = wrappedAction
+                    renderedItem.action = #selector(wrappedAction.run)
+                    renderedItem.target = wrappedAction
+                }
+                return renderedItem
+            case .toggle(let label, let value, let onChange):
+                // Custom subclass is used to keep strong reference to action
+                // wrapper.
+                let renderedItem = NSCustomMenuItem(
+                    title: label,
+                    action: nil,
+                    keyEquivalent: ""
+                )
+                renderedItem.isOn = value
 
+                if environment.isEnabled {
                     let wrappedAction = Action {
                         onChange(!renderedItem.isOn)
                     }
                     renderedItem.actionWrapper = wrappedAction
                     renderedItem.action = #selector(wrappedAction.run)
                     renderedItem.target = wrappedAction
+                }
 
-                    return renderedItem
-                case .separator:
-                    return NSCustomMenuItem.separator()
-                case .submenu(let submenu):
-                    return renderSubmenu(submenu)
-            }
+                return renderedItem
+            case .separator:
+                return NSCustomMenuItem.separator()
+            case .submenu(let submenu):
+                return renderSubmenu(submenu, environment: environment)
+
+            case .modifiedEnvironment(let item, let modification):
+                return renderMenuItem(
+                    item,
+                    environment: modification(environment)
+                )
         }
     }
 
-    static func renderSubmenu(_ submenu: ResolvedMenu.Submenu) -> NSMenuItem {
+    static func renderSubmenu(
+        _ submenu: ResolvedMenu.Submenu,
+        environment: EnvironmentValues
+    ) -> NSMenuItem {
         let renderedMenu = NSMenu()
-        renderedMenu.items = renderMenuItems(submenu.content.items)
+        renderedMenu.items = submenu.content.items.map {
+            Self.renderMenuItem($0, environment: environment)
+        }
 
         let menuItem = NSMenuItem()
         menuItem.title = submenu.label
@@ -1159,7 +1178,9 @@ public final class AppKitBackend: AppBackend {
         environment: EnvironmentValues
     ) {
         menu.appearance = environment.colorScheme.nsAppearance
-        menu.items = Self.renderMenuItems(content.items)
+        menu.items = content.items.map {
+            Self.renderMenuItem($0, environment: environment)
+        }
     }
 
     public func showPopoverMenu(

--- a/Sources/Gtk/Utility/GSimpleAction.swift
+++ b/Sources/Gtk/Utility/GSimpleAction.swift
@@ -8,7 +8,7 @@ public class GSimpleAction: GAction, GObjectRepresentable {
         UnsafeMutablePointer<CGtk.GObject>(actionPointer)
     }
 
-    @GObjectProperty(named: "enabled") var enabled: Bool
+    @GObjectProperty(named: "enabled") public var enabled: Bool
 
     private class Box<T> {
         var value: T

--- a/Sources/Gtk3/Utility/GSimpleAction.swift
+++ b/Sources/Gtk3/Utility/GSimpleAction.swift
@@ -8,7 +8,7 @@ public class GSimpleAction: GAction, GObjectRepresentable {
         UnsafeMutablePointer<CGtk3.GObject>(actionPointer)
     }
 
-    @GObjectProperty(named: "enabled") var enabled: Bool
+    @GObjectProperty(named: "enabled") public var enabled: Bool
 
     private class Box<T> {
         var value: T

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -273,7 +273,8 @@ public final class Gtk3Backend: AppBackend {
         _ menu: ResolvedMenu,
         actionMap: any GActionMap,
         actionNamespace: String,
-        actionPrefix: String?
+        actionPrefix: String?,
+        environment: EnvironmentValues
     ) -> GMenu {
         var currentSection = GMenu()
         var previousSections: [GMenu] = []
@@ -286,41 +287,49 @@ public final class Gtk3Backend: AppBackend {
                     "\(i)"
                 }
 
-            switch item {
-                case .button(let label, let action):
-                    if let action {
-                        actionMap.addAction(GSimpleAction(name: actionName, action: action))
-                    }
+            render(item: item, environment: environment)
+            func render(item: ResolvedMenu.Item, environment: EnvironmentValues) {
+                switch item {
+                    case .button(let label, let action):
+                        if let action {
+                            let gAction = GSimpleAction(name: actionName, action: action)
+                            gAction.enabled = environment.isEnabled
+                            actionMap.addAction(gAction)
+                        }
 
-                    currentSection.appendItem(
-                        label: label,
-                        actionName: "\(actionNamespace).\(actionName)"
-                    )
-                case .toggle(let label, let value, let onChange):
-                    actionMap.addAction(
-                        GSimpleAction(name: actionName, state: value, action: onChange)
-                    )
-
-                    currentSection.appendItem(
-                        label: label,
-                        actionName: "\(actionNamespace).\(actionName)"
-                    )
-                case .separator:
-                    // GTK[3] doesn't have explicit separators per se, but instead deals with
-                    // sections (actually quite similar to what you can do in SwiftUI with the
-                    // Section view). It'll automatically draw separators between sections.
-                    previousSections.append(currentSection)
-                    currentSection = GMenu()
-                case .submenu(let submenu):
-                    currentSection.appendSubmenu(
-                        label: submenu.label,
-                        content: renderMenu(
-                            submenu.content,
-                            actionMap: actionMap,
-                            actionNamespace: actionNamespace,
-                            actionPrefix: actionName
+                        currentSection.appendItem(
+                            label: label,
+                            actionName: "\(actionNamespace).\(actionName)"
                         )
-                    )
+                    case .toggle(let label, let value, let onChange):
+                        let gAction = GSimpleAction(name: actionName, state: value, action: onChange)
+                        gAction.enabled = environment.isEnabled
+                        actionMap.addAction(gAction)
+
+                        currentSection.appendItem(
+                            label: label,
+                            actionName: "\(actionNamespace).\(actionName)"
+                        )
+                    case .separator:
+                        // GTK[3] doesn't have explicit separators per se, but instead deals with
+                        // sections (actually quite similar to what you can do in SwiftUI with the
+                        // Section view). It'll automatically draw separators between sections.
+                        previousSections.append(currentSection)
+                        currentSection = GMenu()
+                    case .submenu(let submenu):
+                        currentSection.appendSubmenu(
+                            label: submenu.label,
+                            content: renderMenu(
+                                submenu.content,
+                                actionMap: actionMap,
+                                actionNamespace: actionNamespace,
+                                actionPrefix: actionName,
+                                environment: environment
+                            )
+                        )
+                    case .modifiedEnvironment(let item, let modification):
+                        render(item: item, environment: modification(environment))
+                }
             }
         }
 
@@ -336,7 +345,10 @@ public final class Gtk3Backend: AppBackend {
         }
     }
 
-    private func renderMenuBar(_ submenus: [ResolvedMenu.Submenu]) -> GMenu {
+    private func renderMenuBar(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) -> GMenu {
         let model = GMenu()
         for (i, submenu) in submenus.enumerated() {
             model.appendSubmenu(
@@ -345,7 +357,8 @@ public final class Gtk3Backend: AppBackend {
                     submenu.content,
                     actionMap: gtkApp,
                     actionNamespace: "app",
-                    actionPrefix: "\(i)"
+                    actionPrefix: "\(i)",
+                    environment: environment
                 )
             )
         }
@@ -353,8 +366,11 @@ public final class Gtk3Backend: AppBackend {
         return model
     }
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
-        let model = renderMenuBar(submenus)
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) {
+        let model = renderMenuBar(submenus, environment: environment)
         gtkApp.menuBarModel = model
 
         let showMenuBar = !submenus.isEmpty
@@ -1211,7 +1227,8 @@ public final class Gtk3Backend: AppBackend {
             content,
             actionMap: actionGroup,
             actionNamespace: "menu",
-            actionPrefix: nil
+            actionPrefix: nil,
+            environment: environment
         )
         menu.bindModel(model)
         menu.insertActionGroup("menu", actionGroup)

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -324,7 +324,8 @@ public final class GtkBackend: AppBackend {
         _ menu: ResolvedMenu,
         actionMap: any GActionMap,
         actionNamespace: String,
-        actionPrefix: String?
+        actionPrefix: String?,
+        environment: EnvironmentValues
     ) -> GMenu {
         var currentSection = GMenu()
         var previousSections: [GMenu] = []
@@ -337,41 +338,49 @@ public final class GtkBackend: AppBackend {
                     "\(i)"
                 }
 
-            switch item {
-                case .button(let label, let action):
-                    if let action {
-                        actionMap.addAction(GSimpleAction(name: actionName, action: action))
-                    }
+            render(item: item, environment: environment)
+            func render(item: ResolvedMenu.Item, environment: EnvironmentValues) {
+                switch item {
+                    case .button(let label, let action):
+                        if let action {
+                            let gAction = GSimpleAction(name: actionName, action: action)
+                            gAction.enabled = environment.isEnabled
+                            actionMap.addAction(gAction)
+                        }
 
-                    currentSection.appendItem(
-                        label: label,
-                        actionName: "\(actionNamespace).\(actionName)"
-                    )
-                case .toggle(let label, let value, let onChange):
-                    actionMap.addAction(
-                        GSimpleAction(name: actionName, state: value, action: onChange)
-                    )
-
-                    currentSection.appendItem(
-                        label: label,
-                        actionName: "\(actionNamespace).\(actionName)"
-                    )
-                case .separator:
-                    // GTK[3] doesn't have explicit separators per se, but instead deals with
-                    // sections (actually quite similar to what you can do in SwiftUI with the
-                    // Section view). It'll automatically draw separators between sections.
-                    previousSections.append(currentSection)
-                    currentSection = GMenu()
-                case .submenu(let submenu):
-                    currentSection.appendSubmenu(
-                        label: submenu.label,
-                        content: renderMenu(
-                            submenu.content,
-                            actionMap: actionMap,
-                            actionNamespace: actionNamespace,
-                            actionPrefix: actionName
+                        currentSection.appendItem(
+                            label: label,
+                            actionName: "\(actionNamespace).\(actionName)"
                         )
-                    )
+                    case .toggle(let label, let value, let onChange):
+                        let gAction = GSimpleAction(name: actionName, state: value, action: onChange)
+                        gAction.enabled = environment.isEnabled
+                        actionMap.addAction(gAction)
+
+                        currentSection.appendItem(
+                            label: label,
+                            actionName: "\(actionNamespace).\(actionName)"
+                        )
+                    case .separator:
+                        // GTK[3] doesn't have explicit separators per se, but instead deals with
+                        // sections (actually quite similar to what you can do in SwiftUI with the
+                        // Section view). It'll automatically draw separators between sections.
+                        previousSections.append(currentSection)
+                        currentSection = GMenu()
+                    case .submenu(let submenu):
+                        currentSection.appendSubmenu(
+                            label: submenu.label,
+                            content: renderMenu(
+                                submenu.content,
+                                actionMap: actionMap,
+                                actionNamespace: actionNamespace,
+                                actionPrefix: actionName,
+                                environment: environment
+                            )
+                        )
+                    case .modifiedEnvironment(let item, let modification):
+                        render(item: item, environment: modification(environment))
+                }
             }
         }
 
@@ -387,7 +396,10 @@ public final class GtkBackend: AppBackend {
         }
     }
 
-    private func renderMenuBar(_ submenus: [ResolvedMenu.Submenu]) -> GMenu {
+    private func renderMenuBar(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) -> GMenu {
         let model = GMenu()
         for (i, submenu) in submenus.enumerated() {
             model.appendSubmenu(
@@ -396,7 +408,8 @@ public final class GtkBackend: AppBackend {
                     submenu.content,
                     actionMap: gtkApp,
                     actionNamespace: "app",
-                    actionPrefix: "\(i)"
+                    actionPrefix: "\(i)",
+                    environment: environment
                 )
             )
         }
@@ -404,8 +417,11 @@ public final class GtkBackend: AppBackend {
         return model
     }
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
-        let model = renderMenuBar(submenus)
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) {
+        let model = renderMenuBar(submenus, environment: environment)
         gtkApp.menuBarModel = model
 
         let showMenuBar = !submenus.isEmpty
@@ -1266,7 +1282,8 @@ public final class GtkBackend: AppBackend {
             content,
             actionMap: actionGroup,
             actionNamespace: "menu",
-            actionPrefix: nil
+            actionPrefix: nil,
+            environment: environment
         )
         menu.insertActionGroup("menu", actionGroup)
 

--- a/Sources/SwiftCrossUI/Backend/AppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/AppBackend.swift
@@ -299,8 +299,13 @@ public protocol AppBackend: Sendable {
     /// (such as macOS's menu bar), and others may render their own menu bar
     /// within the application.
     ///
-    /// - Parameter submenus: The submenus of the global menu.
-    func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu])
+    /// - Parameters:
+    ///   - submenus: The submenus of the global menu.
+    ///   - environment: The menu's environment.
+    func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    )
 
     /// Runs an action in the app's main thread if required to perform UI updates
     /// by the backend.
@@ -1552,7 +1557,10 @@ extension AppBackend {
 
     // MARK: Application
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environemnt: EnvironmentValues
+    ) {
         todo()
     }
 

--- a/Sources/SwiftCrossUI/Backend/AppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/AppBackend.swift
@@ -1559,7 +1559,7 @@ extension AppBackend {
 
     public func setApplicationMenu(
         _ submenus: [ResolvedMenu.Submenu],
-        environemnt: EnvironmentValues
+        environment: EnvironmentValues
     ) {
         todo()
     }

--- a/Sources/SwiftCrossUI/Backend/ResolvedMenu.swift
+++ b/Sources/SwiftCrossUI/Backend/ResolvedMenu.swift
@@ -37,6 +37,10 @@ public struct ResolvedMenu {
         case separator
         /// A named submenu.
         case submenu(Submenu)
+        indirect case modifiedEnvironment(
+            Item,
+            (EnvironmentValues) -> EnvironmentValues
+        )
     }
 
     /// A named submenu.

--- a/Sources/SwiftCrossUI/Backend/ResolvedMenu.swift
+++ b/Sources/SwiftCrossUI/Backend/ResolvedMenu.swift
@@ -37,9 +37,15 @@ public struct ResolvedMenu {
         case separator
         /// A named submenu.
         case submenu(Submenu)
+        /// A wrapper for a menu item that modifies its environment.
+        ///
+        /// - Parameters:
+        ///   - item: The item to modify the environment of.
+        ///   - modification: A function that modifies a given
+        ///     `EnvironmentValues` instance.
         indirect case modifiedEnvironment(
-            Item,
-            (EnvironmentValues) -> EnvironmentValues
+            _ item: Item,
+            _ modification: (EnvironmentValues) -> EnvironmentValues
         )
     }
 

--- a/Sources/SwiftCrossUI/Builders/MenuItemsBuilder.swift
+++ b/Sources/SwiftCrossUI/Builders/MenuItemsBuilder.swift
@@ -4,25 +4,11 @@ public struct MenuItemsBuilder {
     public static func buildBlock() -> [MenuItem] {
         []
     }
-
-    public static func buildPartialBlock(first: Button) -> [MenuItem] {
-        [.button(first)]
-    }
-
-    public static func buildPartialBlock(first: Text) -> [MenuItem] {
-        [.text(first)]
-    }
-
-    public static func buildPartialBlock(first: Toggle) -> [MenuItem] {
-        [.toggle(first)]
-    }
-
-    public static func buildPartialBlock(first: Divider) -> [MenuItem] {
-        [.separator(first)]
-    }
-
-    public static func buildPartialBlock(first: Menu) -> [MenuItem] {
-        [.submenu(first)]
+    
+    public static func buildPartialBlock(first: some View) -> [MenuItem] {
+        // For SwiftUI compatibility, we ignore any views that aren't MenuItemRepresentable.
+        guard let first = first as? any MenuItemRepresentable else { return [] }
+        return [first.asMenuItem]
     }
 
     public static func buildPartialBlock(first: Block) -> [MenuItem] {
@@ -37,35 +23,7 @@ public struct MenuItemsBuilder {
 
     public static func buildPartialBlock(
         accumulated: [MenuItem],
-        next: Button
-    ) -> [MenuItem] {
-        accumulated + buildPartialBlock(first: next)
-    }
-
-    public static func buildPartialBlock(
-        accumulated: [MenuItem],
-        next: Text
-    ) -> [MenuItem] {
-        accumulated + buildPartialBlock(first: next)
-    }
-
-    public static func buildPartialBlock(
-        accumulated: [MenuItem],
-        next: Toggle
-    ) -> [MenuItem] {
-        accumulated + buildPartialBlock(first: next)
-    }
-
-    public static func buildPartialBlock(
-        accumulated: [MenuItem],
-        next: Divider
-    ) -> [MenuItem] {
-        accumulated + buildPartialBlock(first: next)
-    }
-
-    public static func buildPartialBlock(
-        accumulated: [MenuItem],
-        next: Menu
+        next: some View
     ) -> [MenuItem] {
         accumulated + buildPartialBlock(first: next)
     }

--- a/Sources/SwiftCrossUI/Scenes/CommandMenu.swift
+++ b/Sources/SwiftCrossUI/Scenes/CommandMenu.swift
@@ -33,7 +33,7 @@ public struct CommandMenu: Sendable {
     func resolve() -> ResolvedMenu.Submenu {
         ResolvedMenu.Submenu(
             label: name,
-            content: Menu.resolveItems(content)
+            content: Menu.resolve(items: content)
         )
     }
 }

--- a/Sources/SwiftCrossUI/Scenes/CommandMenu.swift
+++ b/Sources/SwiftCrossUI/Scenes/CommandMenu.swift
@@ -1,5 +1,5 @@
 /// A command menu.
-public struct CommandMenu: Sendable {
+public struct CommandMenu {
     /// The menu's name.
     var name: String
     /// The menu's contents.

--- a/Sources/SwiftCrossUI/Scenes/Commands.swift
+++ b/Sources/SwiftCrossUI/Scenes/Commands.swift
@@ -1,7 +1,9 @@
 /// A set of menus to be displayed in a menu bar.
-public struct Commands: Sendable {
+public struct Commands {
     /// Represents an empty menu bar.
-    public static let empty = Commands(menus: [])
+    public static var empty: Commands {
+        Commands(menus: [])
+    }
 
     var menus: [CommandMenu]
 

--- a/Sources/SwiftCrossUI/Scenes/Graph/SceneNodeUpdateResult.swift
+++ b/Sources/SwiftCrossUI/Scenes/Graph/SceneNodeUpdateResult.swift
@@ -1,5 +1,5 @@
 /// The result of updating a scene graph node.
-public struct SceneNodeUpdateResult: Sendable {
+public struct SceneNodeUpdateResult {
     /// The preference values produced by the scene and its children.
     public var preferences: ScenePreferenceValues
 

--- a/Sources/SwiftCrossUI/Scenes/Graph/ScenePreferenceValues.swift
+++ b/Sources/SwiftCrossUI/Scenes/Graph/ScenePreferenceValues.swift
@@ -1,7 +1,9 @@
 /// A scene's preferences. Propagated up the scene hierarchy automatically.
-public struct ScenePreferenceValues: Sendable {
+public struct ScenePreferenceValues {
     /// The default preferences.
-    public static let `default` = ScenePreferenceValues(commands: .empty)
+    public static var `default`: ScenePreferenceValues {
+        ScenePreferenceValues(commands: .empty)
+    }
 
     /// The commands to be shown by the app.
     public var commands: Commands

--- a/Sources/SwiftCrossUI/Views/Menu.swift
+++ b/Sources/SwiftCrossUI/Views/Menu.swift
@@ -25,33 +25,36 @@ public struct Menu: Sendable {
     func resolve() -> ResolvedMenu.Submenu {
         ResolvedMenu.Submenu(
             label: label,
-            content: Self.resolveItems(items)
+            content: Self.resolve(items: items)
         )
+    }
+
+    @MainActor
+    static func resolve(item: MenuItem) -> ResolvedMenu.Item {
+        switch item {
+            case .button(let button):
+                .button(button.label, button.action)
+            case .text(let text):
+                .button(text.string, nil)
+            case .toggle(let toggle):
+                .toggle(
+                    toggle.label,
+                    toggle.active.wrappedValue,
+                    onChange: { toggle.active.wrappedValue = $0 }
+                )
+            case .separator:
+                .separator
+            case .submenu(let submenu):
+                .submenu(submenu.resolve())
+            case .modifiedEnvironment(let item, let modification):
+                .modifiedEnvironment(resolve(item: item), modification)
+        }
     }
 
     /// Resolves the menu's items to a representation used by backends.
     @MainActor
-    static func resolveItems(_ items: [MenuItem]) -> ResolvedMenu {
-        ResolvedMenu(
-            items: items.map { item in
-                switch item {
-                    case .button(let button):
-                        .button(button.label, button.action)
-                    case .text(let text):
-                        .button(text.string, nil)
-                    case .toggle(let toggle):
-                        .toggle(
-                            toggle.label,
-                            toggle.active.wrappedValue,
-                            onChange: { toggle.active.wrappedValue = $0 }
-                        )
-                    case .separator:
-                        .separator
-                    case .submenu(let submenu):
-                        .submenu(submenu.resolve())
-                }
-            }
-        )
+    static func resolve(items: [MenuItem]) -> ResolvedMenu {
+        ResolvedMenu(items: items.map(resolve(item:)))
     }
 }
 

--- a/Sources/SwiftCrossUI/Views/Menu.swift
+++ b/Sources/SwiftCrossUI/Views/Menu.swift
@@ -2,7 +2,7 @@
 ///
 /// Due to technical limitations, the minimum supported OS's for menu buttons in
 /// UIKitBackend are iOS 14 and tvOS 17.
-public struct Menu: Sendable {
+public struct Menu {
     /// The menu's label.
     public var label: String
     /// The menu's items.

--- a/Sources/SwiftCrossUI/Views/MenuItem.swift
+++ b/Sources/SwiftCrossUI/Views/MenuItem.swift
@@ -32,12 +32,12 @@ extension Text: MenuItemRepresentable {
     var asMenuItem: MenuItem { .text(self) }
 }
 
-extension Toggle: @MainActor MenuItemRepresentable {
-    var asMenuItem: MenuItem { .toggle(self) }
+extension Toggle: MenuItemRepresentable {
+    nonisolated var asMenuItem: MenuItem { .toggle(self) }
 }
 
-extension Divider: @MainActor MenuItemRepresentable {
-    var asMenuItem: MenuItem { .separator(self) }
+extension Divider: MenuItemRepresentable {
+    nonisolated var asMenuItem: MenuItem { .separator(self) }
 }
 
 @available(iOS 14, macCatalyst 14, tvOS 17, *)
@@ -49,8 +49,16 @@ extension TupleView1: MenuItemRepresentable where View0: MenuItemRepresentable {
     var asMenuItem: MenuItem { view0.asMenuItem }
 }
 
+#if compiler(>=6.2)
 extension EnvironmentModifier: @MainActor MenuItemRepresentable where Child: MenuItemRepresentable {
     var asMenuItem: MenuItem {
         .modifiedEnvironment(self.body.asMenuItem, self.modification)
     }
 }
+#else
+extension EnvironmentModifier: @preconcurrency MenuItemRepresentable where Child: MenuItemRepresentable {
+    var asMenuItem: MenuItem {
+        .modifiedEnvironment(self.body.asMenuItem, self.modification)
+    }
+}
+#endif

--- a/Sources/SwiftCrossUI/Views/MenuItem.swift
+++ b/Sources/SwiftCrossUI/Views/MenuItem.swift
@@ -1,5 +1,5 @@
 /// An item of a ``Menu`` or ``CommandMenu``.
-public enum MenuItem: Sendable {
+public enum MenuItem {
     /// A button.
     case button(Button)
     /// Text.
@@ -14,7 +14,7 @@ public enum MenuItem: Sendable {
     /// A menu item with an environment modifier.
     indirect case modifiedEnvironment(
         MenuItem,
-        @Sendable (EnvironmentValues) -> EnvironmentValues
+        (EnvironmentValues) -> EnvironmentValues
     )
 }
 

--- a/Sources/SwiftCrossUI/Views/MenuItem.swift
+++ b/Sources/SwiftCrossUI/Views/MenuItem.swift
@@ -40,6 +40,7 @@ extension Divider: @MainActor MenuItemRepresentable {
     var asMenuItem: MenuItem { .separator(self) }
 }
 
+@available(iOS 14, macCatalyst 14, tvOS 17, *)
 extension Menu: MenuItemRepresentable {
     var asMenuItem: MenuItem { .submenu(self) }
 }

--- a/Sources/SwiftCrossUI/Views/MenuItem.swift
+++ b/Sources/SwiftCrossUI/Views/MenuItem.swift
@@ -10,4 +10,46 @@ public enum MenuItem: Sendable {
     case separator(Divider)
     /// A submenu.
     case submenu(Menu)
+
+    /// A menu item with an environment modifier.
+    indirect case modifiedEnvironment(
+        MenuItem,
+        @Sendable (EnvironmentValues) -> EnvironmentValues
+    )
+}
+
+// MARK: Views that can be used as menu items
+
+protocol MenuItemRepresentable: View {
+    var asMenuItem: MenuItem { get }
+}
+
+extension Button: MenuItemRepresentable {
+    var asMenuItem: MenuItem { .button(self) }
+}
+
+extension Text: MenuItemRepresentable {
+    var asMenuItem: MenuItem { .text(self) }
+}
+
+extension Toggle: @MainActor MenuItemRepresentable {
+    var asMenuItem: MenuItem { .toggle(self) }
+}
+
+extension Divider: @MainActor MenuItemRepresentable {
+    var asMenuItem: MenuItem { .separator(self) }
+}
+
+extension Menu: MenuItemRepresentable {
+    var asMenuItem: MenuItem { .submenu(self) }
+}
+
+extension TupleView1: MenuItemRepresentable where View0: MenuItemRepresentable {
+    var asMenuItem: MenuItem { view0.asMenuItem }
+}
+
+extension EnvironmentModifier: @MainActor MenuItemRepresentable where Child: MenuItemRepresentable {
+    var asMenuItem: MenuItem {
+        .modifiedEnvironment(self.body.asMenuItem, self.modification)
+    }
 }

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -39,7 +39,10 @@ class _App<AppRoot: App> {
 
         if let sceneGraphRoot {
             let result = sceneGraphRoot.updateNode(app.body, environment: environment)
-            backend.setApplicationMenu(result.preferences.commands.resolve())
+            backend.setApplicationMenu(
+                result.preferences.commands.resolve(),
+                environment: environment
+            )
             sceneGraphRoot.update(
                 backend: backend,
                 environment: environment
@@ -99,7 +102,10 @@ class _App<AppRoot: App> {
             let result = rootNode.updateNode(nil, environment: environment)
 
             // Update application-wide menu
-            backend.setApplicationMenu(result.preferences.commands.resolve())
+            backend.setApplicationMenu(
+                result.preferences.commands.resolve(),
+                environment: environment
+            )
 
             rootNode.update(backend: backend, environment: environment)
             self.sceneGraphRoot = rootNode

--- a/Sources/UIKitBackend/UIKitBackend+Menu.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Menu.swift
@@ -14,35 +14,53 @@ extension UIKitBackend {
     static func buildMenu(
         content: ResolvedMenu,
         label: String,
-        identifier: UIMenu.Identifier? = nil
+        identifier: UIMenu.Identifier? = nil,
+        environment: EnvironmentValues
     ) -> UIMenu {
         var currentSection: [UIMenuElement] = []
         var previousSections: [[UIMenuElement]] = []
 
         for item in content.items {
-            switch item {
-                case .button(let label, let action):
-                    let uiAction =
-                        if let action {
+            func render(item: ResolvedMenu.Item, environment: EnvironmentValues) {
+                switch item {
+                    case .button(let label, let action):
+                        let uiAction =
+                        if let action, environment.isEnabled {
                             UIAction(title: label) { _ in action() }
                         } else {
                             UIAction(title: label, attributes: .disabled) { _ in }
                         }
-                    currentSection.append(uiAction)
-                case .toggle(let label, let value, let onChange):
-                    currentSection.append(
-                        UIAction(title: label, state: value ? .on : .off) { action in
-                            onChange(!action.state.isOn)
-                        }
-                    )
-                case .separator:
-                    // UIKit doesn't have explicit separators per se, but instead deals with
-                    // sections (actually quite similar to what you can do in SwiftUI with the
-                    // Section view). It'll automatically draw separators between sections.
-                    previousSections.append(currentSection)
-                    currentSection = []
-                case .submenu(let submenu):
-                    currentSection.append(buildMenu(content: submenu.content, label: submenu.label))
+                        currentSection.append(uiAction)
+                    case .toggle(let label, let value, let onChange):
+                        currentSection.append(
+                            UIAction(
+                                title: label,
+                                attributes: environment.isEnabled ? [] : .disabled,
+                                state: value ? .on : .off
+                            ) { action in
+                                onChange(!action.state.isOn)
+                            }
+                        )
+                    case .separator:
+                        // UIKit doesn't have explicit separators per se, but instead deals with
+                        // sections (actually quite similar to what you can do in SwiftUI with the
+                        // Section view). It'll automatically draw separators between sections.
+                        previousSections.append(currentSection)
+                        currentSection = []
+                    case .submenu(let submenu):
+                        currentSection.append(
+                            buildMenu(
+                                content: submenu.content,
+                                label: submenu.label,
+                                environment: environment
+                            )
+                        )
+                    case .modifiedEnvironment(let item, let modification):
+                        render(
+                            item: item,
+                            environment: modification(environment)
+                        )
+                }
             }
         }
 
@@ -64,10 +82,14 @@ extension UIKitBackend {
     public func updatePopoverMenu(
         _ menu: Menu,
         content: ResolvedMenu,
-        environment _: EnvironmentValues
+        environment: EnvironmentValues
     ) {
         if #available(iOS 14, macCatalyst 14, tvOS 17, *) {
-            menu.uiMenu = UIKitBackend.buildMenu(content: content, label: "")
+            menu.uiMenu = UIKitBackend.buildMenu(
+                content: content,
+                label: "",
+                environment: environment
+            )
         } else {
             preconditionFailure("Current OS is too old to support menu buttons.")
         }
@@ -98,10 +120,14 @@ extension UIKitBackend {
         }
     }
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) {
         #if targetEnvironment(macCatalyst)
             let appDelegate = UIApplication.shared.delegate as! ApplicationDelegate
             appDelegate.menu = submenus
+            appDelegate.environment = environment
         #else
             // Once keyboard shortcuts are implemented, it might be possible to do them on more
             // platforms than just Mac Catalyst. For now, this is a no-op.

--- a/Sources/UIKitBackend/UIKitBackend+Menu.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Menu.swift
@@ -10,6 +10,51 @@ extension UIKitBackend {
         return Menu()
     }
 
+    private enum RenderedMenuItem {
+        case item(UIMenuElement)
+        case separator
+    }
+
+    @available(tvOS 14, *)
+    private static func renderMenuItem(
+        _ item: ResolvedMenu.Item,
+        environment: EnvironmentValues
+    ) -> RenderedMenuItem {
+        switch item {
+            case .button(let label, let action):
+                if let action, environment.isEnabled {
+                    .item(UIAction(title: label) { _ in action() })
+                } else {
+                    .item(UIAction(title: label, attributes: .disabled) { _ in })
+                }
+            case .toggle(let label, let value, let onChange):
+                .item(
+                    UIAction(
+                        title: label,
+                        attributes: environment.isEnabled ? [] : .disabled,
+                        state: value ? .on : .off
+                    ) { action in
+                        onChange(!action.state.isOn)
+                    }
+                )
+            case .separator:
+                .separator
+            case .submenu(let submenu):
+                .item(
+                    buildMenu(
+                        content: submenu.content,
+                        label: submenu.label,
+                        environment: environment
+                    )
+                )
+            case .modifiedEnvironment(let item, let modification):
+                renderMenuItem(
+                    item,
+                    environment: modification(environment)
+                )
+        }
+    }
+
     @available(tvOS 14, *)
     static func buildMenu(
         content: ResolvedMenu,
@@ -21,46 +66,15 @@ extension UIKitBackend {
         var previousSections: [[UIMenuElement]] = []
 
         for item in content.items {
-            func render(item: ResolvedMenu.Item, environment: EnvironmentValues) {
-                switch item {
-                    case .button(let label, let action):
-                        let uiAction =
-                        if let action, environment.isEnabled {
-                            UIAction(title: label) { _ in action() }
-                        } else {
-                            UIAction(title: label, attributes: .disabled) { _ in }
-                        }
-                        currentSection.append(uiAction)
-                    case .toggle(let label, let value, let onChange):
-                        currentSection.append(
-                            UIAction(
-                                title: label,
-                                attributes: environment.isEnabled ? [] : .disabled,
-                                state: value ? .on : .off
-                            ) { action in
-                                onChange(!action.state.isOn)
-                            }
-                        )
-                    case .separator:
-                        // UIKit doesn't have explicit separators per se, but instead deals with
-                        // sections (actually quite similar to what you can do in SwiftUI with the
-                        // Section view). It'll automatically draw separators between sections.
-                        previousSections.append(currentSection)
-                        currentSection = []
-                    case .submenu(let submenu):
-                        currentSection.append(
-                            buildMenu(
-                                content: submenu.content,
-                                label: submenu.label,
-                                environment: environment
-                            )
-                        )
-                    case .modifiedEnvironment(let item, let modification):
-                        render(
-                            item: item,
-                            environment: modification(environment)
-                        )
-                }
+            switch renderMenuItem(item, environment: environment) {
+                case .item(let uiMenuElement):
+                    currentSection.append(uiMenuElement)
+                case .separator:
+                    // UIKit doesn't have explicit separators per se, but instead deals with
+                    // sections (actually quite similar to what you can do in SwiftUI with the
+                    // Section view). It'll automatically draw separators between sections.
+                    previousSections.append(currentSection)
+                    currentSection = []
             }
         }
 

--- a/Sources/UIKitBackend/UIKitBackend.swift
+++ b/Sources/UIKitBackend/UIKitBackend.swift
@@ -264,6 +264,7 @@ open class ApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
 
     var menu: [ResolvedMenu.Submenu] = []
+    var environment: EnvironmentValues?
 
     public required override init() {
         super.init()
@@ -356,7 +357,11 @@ open class ApplicationDelegate: UIResponder, UIApplicationDelegate {
         for submenu in menu {
             let menuIdentifier = mapMenuIdentifier(submenu.label)
             let menu = UIKitBackend.buildMenu(
-                content: submenu.content, label: submenu.label, identifier: menuIdentifier)
+                content: submenu.content,
+                label: submenu.label,
+                identifier: menuIdentifier,
+                environment: environment!
+            )
 
             if builder.menu(for: menuIdentifier) == nil {
                 builder.insertChild(menu, atEndOfMenu: .root)

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -329,44 +329,56 @@ public final class WinUIBackend: AppBackend {
 
     public func show(widget _: Widget) {}
 
-    private func renderItems(_ items: [ResolvedMenu.Item]) -> [MenuFlyoutItemBase] {
-        items.map { item in
-            switch item {
-                case .button(let label, let action):
-                    let widget = MenuFlyoutItem()
-                    widget.text = label
-                    widget.click.addHandler { _, _ in
-                        action?()
-                    }
-                    return widget
-                case .toggle(let label, let value, let onChange):
-                    let widget = ToggleMenuFlyoutItem()
-                    widget.text = label
-                    widget.isChecked = value
-                    widget.click.addHandler { [weak widget] _, _ in
-                        guard let widget else { return }
-                        onChange(widget.isChecked)
-                    }
-                    return widget
-                case .separator:
-                    return MenuFlyoutSeparator()
-                case .submenu(let submenu):
-                    let widget = MenuFlyoutSubItem()
-                    widget.text = submenu.label
-                    for subitem in renderItems(submenu.content.items) {
-                        widget.items.append(subitem)
-                    }
-                    return widget
-            }
+    private func renderMenuItem(
+        _ items: ResolvedMenu.Item,
+        environment: EnvironmentValues
+    ) -> MenuFlyoutItemBase {
+        switch item {
+            case .button(let label, let action):
+                let widget = MenuFlyoutItem()
+                widget.text = label
+                widget.click.addHandler { _, _ in
+                    action?()
+                }
+                widget.isEnabled = environment.isEnabled
+                return widget
+            case .toggle(let label, let value, let onChange):
+                let widget = ToggleMenuFlyoutItem()
+                widget.text = label
+                widget.isChecked = value
+                widget.click.addHandler { [weak widget] _, _ in
+                    guard let widget else { return }
+                    onChange(widget.isChecked)
+                }
+                widget.isEnabled = environment.isEnabled
+                return widget
+            case .separator:
+                return MenuFlyoutSeparator()
+            case .submenu(let submenu):
+                let widget = MenuFlyoutSubItem()
+                widget.text = submenu.label
+                for subitem in submenu.content.items {
+                    widget.items.append(
+                        renderMenuItem(subitem, environment: environment)
+                    )
+                }
+                return widget
+            case .modifiedEnvironment(let item, let modification):
+                return renderMenuItem(item, environment: modification(environment))
         }
     }
 
-    public func setApplicationMenu(_ submenus: [ResolvedMenu.Submenu]) {
+    public func setApplicationMenu(
+        _ submenus: [ResolvedMenu.Submenu],
+        environment: EnvironmentValues
+    ) {
         let items = submenus.map { submenu in
             let item = MenuBarItem()
             item.title = submenu.label
-            for subitem in renderItems(submenu.content.items) {
-                item.items.append(subitem)
+            for subitem in submenu.content.items {
+                item.items.append(
+                    renderMenuItem(subitem, environment: environment)
+                )
             }
             return item
         }
@@ -794,8 +806,8 @@ public final class WinUIBackend: AppBackend {
         environment: EnvironmentValues
     ) {
         menu.items.clear()
-        for item in renderItems(content.items) {
-            menu.items.append(item)
+        for item in content.items {
+            menu.items.append(renderMenuItem(item, environment: environment))
         }
     }
 

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -330,7 +330,7 @@ public final class WinUIBackend: AppBackend {
     public func show(widget _: Widget) {}
 
     private func renderMenuItem(
-        _ items: ResolvedMenu.Item,
+        _ item: ResolvedMenu.Item,
         environment: EnvironmentValues
     ) -> MenuFlyoutItemBase {
         switch item {


### PR DESCRIPTION
This PR allows `EnvironmentModifier` views (and, as a byproduct, `TupleView1`) to be used in menus, enabling things like the `disabled(_:)` modifier to work in menus. It also brings a minor refactor to the menu resolution code.

## Backend support
- [x] AppKitBackend
- [x] DummyBackend
- [x] GtkBackend
- [x] Gtk3Backend
- [x] UIKitBackend
- [x] WinUIBackend