### PR TITLE
Observe outside changes to `AppStorage` values

### DIFF
--- a/Sources/SwiftCrossUI/Environment/AppStorageProvider.swift
+++ b/Sources/SwiftCrossUI/Environment/AppStorageProvider.swift
@@ -18,44 +18,25 @@ public protocol AppStorageProvider: Sendable {
     /// - Returns: The persisted value for `key`, if it exists and is of the
     ///   expected type; otherwise, `nil`.
     func retrieveValue<Value: Codable>(ofType type: Value.Type, forKey key: String) -> Value?
-}
-
-/// A simple app storage provider that uses `UserDefaults` to persist
-/// data.
-///
-/// This works on all supported platforms.
-public struct UserDefaultsAppStorageProvider: AppStorageProvider {
-    public func persistValue<Value: Codable>(_ value: Value, forKey key: String) throws {
-        let jsonData = try JSONEncoder().encode(value)
-        let jsonString = String.init(data: jsonData, encoding: .utf8)
-        UserDefaults.standard.set(jsonString, forKey: key)
-
-        // NB: The UserDefaults store isn't automatically synced to disk on
-        // Linux and Windows.
-        // https://github.com/swiftlang/swift-corelibs-foundation/issues/4837
-        #if os(Linux) || os(Windows)
-            UserDefaults.standard.synchronize()
-        #endif
-    }
-
-    public func retrieveValue<Value: Codable>(ofType: Value.Type, forKey key: String) -> Value? {
-        guard let string = UserDefaults.standard.string(forKey: key),
-            let data = string.data(using: .utf8),
-            let value = try? JSONDecoder().decode(Value.self, from: data)
-        else {
-            return nil
-        }
-        return value
-    }
+    /// Listens for changes to app storage.
+    ///
+    /// This should call `action` when any of the app's persisted values changes.
+    /// This is called early in app startup.
+    ///
+    /// - Parameters:
+    ///   - action: The action to perform when a persisted value changes, taking
+    ///     the key that changed as a parameter.
+    func listenToChanges(_ action: @MainActor @Sendable @escaping (String) -> Void)
 }
 
 extension AppStorageProvider {
     public func getValue<T: Codable & Sendable>(key: String, defaultValue: T) -> T {
         return appStorageCache.withLock { cache in
-            // If this is the very first time we're reading from this key, it won't
-            // be in the cache yet. In that case, we return the already-persisted value
-            // if it exists, or the default value otherwise; either way, we add it to the
-            // cache so subsequent accesses of `value` won't have to read from disk again.
+            // If this is the very first time we're reading from this key (or if a change was
+            // detected and the provider invalidated the cache), it won't be in the cache yet.
+            // In that case, we return the already-persisted value if it exists, or the default
+            // value otherwise; either way, we add it to the cache so subsequent accesses of
+            // `value` won't have to read from disk again.
             guard let cachedValue = cache[key] else {
                 let value =
                     self.retrieveValue(ofType: T.self, forKey: key) ?? defaultValue

--- a/Sources/SwiftCrossUI/Environment/UserDefaultsAppStorageProvider.swift
+++ b/Sources/SwiftCrossUI/Environment/UserDefaultsAppStorageProvider.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Mutex
+
+/// A simple app storage provider that uses `UserDefaults` to persist
+/// data.
+///
+/// This works on all supported platforms.
+public final class UserDefaultsAppStorageProvider: AppStorageProvider {
+    private let observer = Mutex(UserDefaultsObserver())
+    private final class UserDefaultsObserver: NSObject {
+        var knownKeys: Set<String> = []
+        var onChange: (@MainActor @Sendable (String) -> Void)? = nil
+
+        func addObserver(forKey key: String) {
+            if knownKeys.insert(key).inserted {
+                UserDefaults.standard.addObserver(self, forKeyPath: key, context: nil)
+            }
+        }
+
+        override func observeValue(
+            forKeyPath keyPath: String?,
+            of object: Any?,
+            change: [NSKeyValueChangeKey : Any]?,
+            context: UnsafeMutableRawPointer?
+        ) {
+            guard let key = keyPath, let onChange else { return }
+            Task { @MainActor in onChange(key) }
+        }
+
+        deinit {
+            for key in knownKeys {
+               UserDefaults.standard.removeObserver(self, forKeyPath: key, context: nil)
+            }
+        }
+    }
+
+    public func persistValue<Value: Codable>(_ value: Value, forKey key: String) throws {
+        observer.withLock { $0.addObserver(forKey: key) }
+
+        let jsonData = try JSONEncoder().encode(value)
+        let jsonString = String.init(data: jsonData, encoding: .utf8)
+        UserDefaults.standard.set(jsonString, forKey: key)
+
+        // NB: The UserDefaults store isn't automatically synced to disk on
+        // Linux and Windows.
+        // https://github.com/swiftlang/swift-corelibs-foundation/issues/4837
+        #if os(Linux) || os(Windows)
+            UserDefaults.standard.synchronize()
+        #endif
+    }
+
+    public func retrieveValue<Value: Codable>(ofType: Value.Type, forKey key: String) -> Value? {
+        observer.withLock { $0.addObserver(forKey: key) }
+
+        guard let string = UserDefaults.standard.string(forKey: key),
+            let data = string.data(using: .utf8),
+            let value = try? JSONDecoder().decode(Value.self, from: data)
+        else {
+            return nil
+        }
+        return value
+    }
+
+    public func listenToChanges(_ action: @MainActor @Sendable @escaping (String) -> Void) {
+        observer.withLock { $0.onChange = action }
+    }
+}

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorage.swift
@@ -40,7 +40,6 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
                             // property on initialization, we're returning the default value instead.
                             return defaultValue
                         }
-                        print("Reading AppStorage value")
                         return provider.getValue(key: key, defaultValue: defaultValue)
                     case .path(let keyPath):
                         return AppStorageValues(provider: provider)[keyPath: keyPath]
@@ -59,7 +58,6 @@ public struct AppStorage<Value: Codable & Sendable>: ObservableProperty {
                 }
                 switch mode {
                     case .key(let key, _):
-                        print("Writing AppStorage value")
                         provider.setValue(key: key, newValue: newValue)
                     case .path(let keyPath):
                         var values = AppStorageValues(provider: provider)

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorageKey.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorageKey.swift
@@ -2,7 +2,7 @@
 /// to ``EnvironmentKey``.
 /// Properties can be accessed using the ``AppStorage`` property wrapper.
 public protocol AppStorageKey<Value> {
-    associatedtype Value: Codable
+    associatedtype Value: Codable, Sendable
 
     /// The name to use when persisting the key.
     static var name: String { get }

--- a/Sources/SwiftCrossUI/State/AppStorage/AppStorageValues.swift
+++ b/Sources/SwiftCrossUI/State/AppStorage/AppStorageValues.swift
@@ -7,12 +7,12 @@ public struct AppStorageValues {
         self.provider = provider
     }
 
-    public func getValue<T: Codable & Sendable>(_ key: any AppStorageKey<T>.Type) -> T {
+    public func getValue<Key: AppStorageKey>(_ key: Key.Type) -> Key.Value {
         guard let provider else { return key.defaultValue }
         return provider.getValue(key: key.name, defaultValue: key.defaultValue)
     }
 
-    public func setValue<T: Codable & Sendable>(_ key: any AppStorageKey<T>.Type, newValue: T) {
+    public func setValue<Key: AppStorageKey>(_ key: Key.Type, newValue: Key.Value) {
         provider?.setValue(key: key.name, newValue: newValue)
     }
 }

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -95,6 +95,11 @@ class _App<AppRoot: App> {
                 )
                 self.refreshSceneGraph()
             }
+            environment.appStorageProvider.listenToChanges { [weak self] key in
+                // invalidate the cached value, then update the views
+                appStorageCache.withLock { $0[key] = nil }
+                self?.refreshSceneGraph()
+            }
 
             let result = rootNode.updateNode(nil, environment: environment)
 


### PR DESCRIPTION
The title says it all.

Backend-agnostic (~~and thus works on all backends~~ just realized that `UserDefaults` does not feature KVO on non-Apple platforms, I’ll have to figure something else out over there).

- Adds a new requirement to `AppStorageProvider`:
  ```swift
  func listenToChanges(_ action: @MainActor @Sendable @escaping (String) -> Void)
  ```