### PR TITLE
Update View.overlay modifier to support alignment

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/OverlayModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/OverlayModifier.swift
@@ -1,9 +1,14 @@
 extension View {
     /// Overlays another view on top of this view.
     ///
+    /// - Parameter alignment: The alignment that the modifier uses to position
+    ///   the overlay relative to the underlying content.
     /// - Parameter content: The view to overlay this view with.
-    public func overlay(@ViewBuilder content: () -> some View) -> some View {
-        OverlayModifier(content: self, overlay: content())
+    public func overlay(
+        alignment: Alignment = .center,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        OverlayModifier(content: self, overlay: content(), alignment: alignment)
     }
 }
 
@@ -11,9 +16,11 @@ struct OverlayModifier<Content: View, Overlay: View>: TypeSafeView {
     typealias Children = TupleView2<Content, Overlay>.Children
 
     var body: TupleView2<Content, Overlay>
+    var alignment: Alignment
 
-    init(content: Content, overlay: Overlay) {
+    init(content: Content, overlay: Overlay, alignment: Alignment) {
         body = TupleView2(content, overlay)
+        self.alignment = alignment
     }
 
     func children<Backend: AppBackend>(
@@ -83,8 +90,8 @@ struct OverlayModifier<Content: View, Overlay: View>: TypeSafeView {
         let contentSize = children.child0.commit().size.vector
         let overlaySize = children.child1.commit().size.vector
 
-        let contentPosition = Alignment.center.position(ofChild: contentSize, in: frameSize)
-        let overlayPosition = Alignment.center.position(ofChild: overlaySize, in: frameSize)
+        let contentPosition = alignment.position(ofChild: contentSize, in: frameSize)
+        let overlayPosition = alignment.position(ofChild: overlaySize, in: frameSize)
 
         backend.setPosition(ofChildAt: 0, in: widget, to: contentPosition)
         backend.setPosition(ofChildAt: 1, in: widget, to: overlayPosition)


### PR DESCRIPTION
This is a relatively simple change. Just adds an 'alignment' parameter to the `View.overlay` modifier, and updates the corresponding view commit implementation to use that alignment instead of its previous default alignment of `center`.