### PR TITLE
fix: change frame dimensions from Int to Double for SwiftUI compatibility

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
@@ -8,6 +8,19 @@ extension View {
     ///   - height: The frame's exact height. `nil` lets the view choose its own
     ///     height instead.
     ///   - alignment: How to align the view within its container.
+    @available(*, deprecated, renamed: "frame(width:height:alignment:)")
+    public func frame(
+        width: Int? = nil,
+        height: Int? = nil,
+        alignment: Alignment = .center
+    ) -> some View {
+        return frame(
+            width: width.map(Double.init),
+            height: height.map(Double.init),
+            alignment: alignment
+        )
+    }
+
     public func frame(
         width: Double? = nil,
         height: Double? = nil,
@@ -38,6 +51,27 @@ extension View {
     ///   - maxHeight: The frame's maximum height. `nil` means the frame inherits
     ///     the maximum height of its content
     ///   - alignment: How to align the view within its container.
+    @available(*, deprecated, renamed: "frame(minWidth:idealWidth:maxWidth:minHeight:idealHeight:maxHeight:alignment:)")
+    public func frame(
+        minWidth: Int? = nil,
+        idealWidth: Int? = nil,
+        maxWidth: Int? = nil,
+        minHeight: Int? = nil,
+        idealHeight: Int? = nil,
+        maxHeight: Int? = nil,
+        alignment: Alignment = .center
+    ) -> some View {
+        return frame(
+            minWidth: minWidth.map(Double.init),
+            idealWidth: idealWidth.map(Double.init),
+            maxWidth: maxWidth.map(Double.init),
+            minHeight: minHeight.map(Double.init),
+            idealHeight: idealHeight.map(Double.init),
+            maxHeight: maxHeight.map(Double.init),
+            alignment: alignment
+        )
+    }
+
     public func frame(
         minWidth: Double? = nil,
         idealWidth: Double? = nil,

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
@@ -9,6 +9,7 @@ extension View {
     ///     height instead.
     ///   - alignment: How to align the view within its container.
     @available(*, deprecated, renamed: "frame(width:height:alignment:)")
+    @_disfavoredOverload
     public func frame(
         width: Int? = nil,
         height: Int? = nil,
@@ -52,6 +53,7 @@ extension View {
     ///     the maximum height of its content
     ///   - alignment: How to align the view within its container.
     @available(*, deprecated, renamed: "frame(minWidth:idealWidth:maxWidth:minHeight:idealHeight:maxHeight:alignment:)")
+    @_disfavoredOverload
     public func frame(
         minWidth: Int? = nil,
         idealWidth: Int? = nil,

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
@@ -9,8 +9,8 @@ extension View {
     ///     height instead.
     ///   - alignment: How to align the view within its container.
     public func frame(
-        width: Int? = nil,
-        height: Int? = nil,
+        width: Double? = nil,
+        height: Double? = nil,
         alignment: Alignment = .center
     ) -> some View {
         return StrictFrameView(
@@ -39,11 +39,11 @@ extension View {
     ///     the maximum height of its content
     ///   - alignment: How to align the view within its container.
     public func frame(
-        minWidth: Int? = nil,
-        idealWidth: Int? = nil,
+        minWidth: Double? = nil,
+        idealWidth: Double? = nil,
         maxWidth: Double? = nil,
-        minHeight: Int? = nil,
-        idealHeight: Int? = nil,
+        minHeight: Double? = nil,
+        idealHeight: Double? = nil,
         maxHeight: Double? = nil,
         alignment: Alignment = .center
     ) -> some View {
@@ -65,14 +65,14 @@ struct StrictFrameView<Child: View>: TypeSafeView {
     var body: TupleView1<Child>
 
     /// The exact width to make the view.
-    var width: Int?
+    var width: Double?
     /// The exact height to make the view.
-    var height: Int?
+    var height: Double?
     /// The alignment of the child within the frame.
     var alignment: Alignment
 
     /// Wraps a child view with size constraints.
-    init(_ child: Child, width: Int?, height: Int?, alignment: Alignment) {
+    init(_ child: Child, width: Double?, height: Double?, alignment: Alignment) {
         body = TupleView1(child)
         self.width = width
         self.height = height
@@ -103,8 +103,8 @@ struct StrictFrameView<Child: View>: TypeSafeView {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        let width = width.map(Double.init)
-        let height = height.map(Double.init)
+        let width = width
+        let height = height
 
         let childResult = children.child0.computeLayout(
             with: body.view0,
@@ -150,11 +150,11 @@ struct StrictFrameView<Child: View>: TypeSafeView {
 struct FlexibleFrameView<Child: View>: TypeSafeView {
     var body: TupleView1<Child>
 
-    var minWidth: Int?
-    var idealWidth: Int?
+    var minWidth: Double?
+    var idealWidth: Double?
     var maxWidth: Double?
-    var minHeight: Int?
-    var idealHeight: Int?
+    var minHeight: Double?
+    var idealHeight: Double?
     var maxHeight: Double?
     /// The alignment of the child within the frame.
     var alignment: Alignment
@@ -162,11 +162,11 @@ struct FlexibleFrameView<Child: View>: TypeSafeView {
     /// Wraps a child view with size constraints.
     init(
         _ child: Child,
-        minWidth: Int?,
-        idealWidth: Int?,
+        minWidth: Double?,
+        idealWidth: Double?,
         maxWidth: Double?,
-        minHeight: Int?,
-        idealHeight: Int?,
+        minHeight: Double?,
+        idealHeight: Double?,
         maxHeight: Double?,
         alignment: Alignment
     ) {
@@ -207,7 +207,7 @@ struct FlexibleFrameView<Child: View>: TypeSafeView {
     func clampHeight(_ height: Double) -> Double {
         LayoutSystem.clamp(
             height,
-            minimum: minHeight.map(Double.init),
+            minimum: minHeight,
             maximum: maxHeight
         )
     }
@@ -215,7 +215,7 @@ struct FlexibleFrameView<Child: View>: TypeSafeView {
     func clampWidth(_ width: Double) -> Double {
         LayoutSystem.clamp(
             width,
-            minimum: minWidth.map(Double.init),
+            minimum: minWidth,
             maximum: maxWidth
         )
     }
@@ -238,11 +238,11 @@ struct FlexibleFrameView<Child: View>: TypeSafeView {
         }
 
         if let idealWidth, proposedSize.width == nil {
-            proposedFrameSize.width = Double(idealWidth)
+            proposedFrameSize.width = idealWidth
         }
 
         if let idealHeight, proposedSize.height == nil {
-            proposedFrameSize.height = Double(idealHeight)
+            proposedFrameSize.height = idealHeight
         }
 
         let childResult = children.child0.computeLayout(

--- a/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift
@@ -55,19 +55,19 @@ extension View {
     public func frame(
         minWidth: Int? = nil,
         idealWidth: Int? = nil,
-        maxWidth: Int? = nil,
+        maxWidth: Double? = nil,
         minHeight: Int? = nil,
         idealHeight: Int? = nil,
-        maxHeight: Int? = nil,
+        maxHeight: Double? = nil,
         alignment: Alignment = .center
     ) -> some View {
         return frame(
             minWidth: minWidth.map(Double.init),
             idealWidth: idealWidth.map(Double.init),
-            maxWidth: maxWidth.map(Double.init),
+            maxWidth: maxWidth,
             minHeight: minHeight.map(Double.init),
             idealHeight: idealHeight.map(Double.init),
-            maxHeight: maxHeight.map(Double.init),
+            maxHeight: maxHeight,
             alignment: alignment
         )
     }

--- a/Sources/UIKitBackend/KeyboardToolbar.swift
+++ b/Sources/UIKitBackend/KeyboardToolbar.swift
@@ -127,7 +127,7 @@ extension Spacer: ToolbarItem {
 @available(visionOS, unavailable)
 struct FixedWidthToolbarItem<Base: ToolbarItem>: ToolbarItem {
     var base: Base
-    var width: Int?
+    var width: Double?
 
     func createBarButtonItem(in environment: EnvironmentValues) -> Base.ItemType {
         let item = base.createBarButtonItem(in: environment)
@@ -150,7 +150,7 @@ struct FixedWidthToolbarItem<Base: ToolbarItem>: ToolbarItem {
 @available(tvOS, unavailable, introduced: 14)
 @available(visionOS, unavailable)
 struct FixedWidthSpacerItem: ToolbarItem {
-    var width: Int?
+    var width: Double?
 
     func createBarButtonItem(in environment: EnvironmentValues) -> UIBarButtonItem {
         if let width {
@@ -190,7 +190,7 @@ extension ToolbarItem {
     ///
     /// If `width` is positive, the item will have that exact width. If `width` is zero or
     /// nil, the item will have its natural size.
-    public func frame(width: Int?) -> any ToolbarItem {
+    public func frame(width: Double?) -> any ToolbarItem {
         if #available(iOS 14, macCatalyst 14, *),
             self is Spacer || self is FixedWidthSpacerItem
         {

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -81,7 +81,7 @@ struct SwiftCrossUITests {
 
         let blueRectangleHeight = Double(100)
         let view = ScrollView {
-            Color.blue.frame(height: Int(blueRectangleHeight))
+            Color.blue.frame(height: blueRectangleHeight)
         }
 
         let viewGraph = ViewGraph(


### PR DESCRIPTION
## Summary

SwiftUI uses `CGFloat` (aliased to `Double`) for frame dimensions, but SwiftCrossUI used `Int`. This made it impossible to pass `GeometryProxy` sizes directly to `.frame(width:height:)`.

Changes `width`, `height`, `minWidth`, `idealWidth`, `minHeight`, and `idealHeight` parameters from `Int?` to `Double?` across both `frame()` overloads, their backing view structs, and the `KeyboardToolbar` frame helper. Removes the now-unnecessary `.map(Double.init)` conversions that existed internally.

## Changes

- `Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift`: Both `frame()` functions, `StrictFrameView`, and `FlexibleFrameView` updated from `Int?` to `Double?`
- `Sources/UIKitBackend/KeyboardToolbar.swift`: `frame(width:)` updated from `Int?` to `Double?`

## Breaking change

Callers passing integer literals (`.frame(width: 100)`) continue to work since Swift auto-promotes `Int` literals to `Double`. Callers storing `Int` variables and passing them will need to convert to `Double`.

Fixes #356

This contribution was developed with AI assistance (Codex).