### PR TITLE
Implement check boxes in UIKit

### DIFF
--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -116,10 +116,10 @@ jobs:
             buildtarget WebViewExample
             buildtarget HoverExample
             buildtarget AdvancedCustomizationExample
+            buildtarget ControlsExample
 
             if [ $device_type != TV ]; then
               # Slider is not implemented for tvOS
-              buildtarget ControlsExample
               buildtarget RandomNumberGeneratorExample
             fi
 

--- a/Examples/Bundler.toml
+++ b/Examples/Bundler.toml
@@ -5,9 +5,9 @@ identifier = 'dev.swiftcrossui.ControlsExample'
 product = 'ControlsExample'
 version = '0.1.0'
 
- [[apps.ControlsExample.overlays]]
- condition = 'platform(macCatalyst)'
- interface_idiom = 'mac'
+[[apps.ControlsExample.overlays]]
+condition = 'platform(macCatalyst)'
+interface_idiom = 'mac'
 
 [apps.CounterExample]
 identifier = 'dev.swiftcrossui.CounterExample'

--- a/Examples/Bundler.toml
+++ b/Examples/Bundler.toml
@@ -5,6 +5,10 @@ identifier = 'dev.swiftcrossui.ControlsExample'
 product = 'ControlsExample'
 version = '0.1.0'
 
+ [[apps.ControlsExample.overlays]]
+ condition = 'platform(macCatalyst)'
+ interface_idiom = 'mac'
+
 [apps.CounterExample]
 identifier = 'dev.swiftcrossui.CounterExample'
 product = 'CounterExample'

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -86,14 +86,12 @@ struct ControlsApp: App {
                             Text("Currently enabled: \(exampleSwitchState)")
                         }
 
-                        #if !canImport(UIKitBackend)
-                            VStack {
-                                Text("Checkbox")
-                                Toggle("Toggle me:", isOn: $exampleCheckboxState)
-                                    .toggleStyle(.checkbox)
-                                Text("Currently enabled: \(exampleCheckboxState)")
-                            }
-                        #endif
+                        VStack {
+                            Text("Checkbox")
+                            Toggle("Toggle me:", isOn: $exampleCheckboxState)
+                                .toggleStyle(.checkbox)
+                            Text("Currently enabled: \(exampleCheckboxState)")
+                        }
 
                         #if !os(tvOS)
                             VStack {

--- a/Sources/UIKitBackend/UIKitBackend+Checkbox.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Checkbox.swift
@@ -1,0 +1,117 @@
+import UIKit
+import SwiftCrossUI
+
+protocol CheckboxWidget: WidgetProtocol {
+    var state: Bool { get set }
+    
+    func update(environment: EnvironmentValues, onChange: @escaping (Bool) -> Void)
+}
+
+#if targetEnvironment(macCatalyst)
+@available(macCatalyst 14, *)
+final class UISwitchCheckbox: WrapperWidget<UISwitch>, CheckboxWidget {
+    private var onChange: ((Bool) -> Void)?
+    
+    init() {
+        let child = UISwitch()
+        child.preferredStyle = .checkbox
+        
+        super.init(child: child)
+        
+        child.addTarget(self, action: #selector(switchChanged(sender:)), for: .valueChanged)
+    }
+    
+    var state: Bool {
+        get { child.isOn }
+        set { child.isOn = newValue }
+    }
+    
+    func update(environment: EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        child.isEnabled = environment.isEnabled
+        self.onChange = onChange
+    }
+    
+    @objc func switchChanged(sender: UISwitch) {
+        onChange?(sender.isOn)
+    }
+}
+#endif
+
+final class UIButtonCheckbox: WrapperWidget<UIButton>, CheckboxWidget {
+    private static let image = UIImage(systemName: "checkmark")
+
+    var state = false {
+        didSet {
+            if state {
+                child.setImage(Self.image, for: .normal)
+            } else {
+                child.setImage(nil, for: .normal)
+            }
+            
+            #if !os(tvOS)
+            child.backgroundColor = child.isEnabled && state ? .systemBlue : .secondarySystemFill
+            #endif
+        }
+    }
+    
+    private var onChange: ((Bool) -> Void)?
+    
+    override var intrinsicContentSize: CGSize {
+        let buttonSize = child.intrinsicContentSize
+        let size = max(buttonSize.width, buttonSize.height)
+        return CGSize(width: size, height: size)
+    }
+    
+    init() {
+        let child = UIButton(type: .system)
+        child.contentEdgeInsets = .zero
+        
+        super.init(child: child)
+        
+        let event: UIControl.Event
+        #if os(tvOS)
+            event = .primaryActionTriggered
+        #else
+            event = .touchUpInside
+            child.layer.cornerRadius = 10.0
+        #endif
+        child.addTarget(self, action: #selector(tapped), for: event)
+    }
+    
+    func update(environment: EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        child.isEnabled = environment.isEnabled
+        child.imageView?.tintColor =
+            environment.suggestedForegroundColor.resolve(in: environment).uiColor
+        self.onChange = onChange
+    }
+    
+    @objc func tapped() {
+        state.toggle()
+        onChange?(state)
+    }
+}
+
+extension UIKitBackend {
+    public func createCheckbox() -> any WidgetProtocol {
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14, *),
+           UIDevice.current.userInterfaceIdiom == .mac
+        {
+            return UISwitchCheckbox()
+        }
+        #endif
+        
+        return UIButtonCheckbox()
+    }
+    
+    public func updateCheckbox(_ checkboxWidget: any WidgetProtocol, environment: EnvironmentValues, onChange: @escaping (Bool) -> Void) {
+        let widget = checkboxWidget as! any CheckboxWidget
+        widget.update(environment: environment, onChange: onChange)
+    }
+    
+    public func setState(ofCheckbox checkboxWidget: any WidgetProtocol, to state: Bool) {
+        let widget = checkboxWidget as! any CheckboxWidget
+        
+        widget.state = state
+    }
+}

--- a/Sources/UIKitBackend/UIKitBackend+Checkbox.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Checkbox.swift
@@ -94,11 +94,11 @@ final class UIButtonCheckbox: WrapperWidget<UIButton>, CheckboxWidget {
 extension UIKitBackend {
     public func createCheckbox() -> any WidgetProtocol {
         #if targetEnvironment(macCatalyst)
-        if #available(macCatalyst 14, *),
-           UIDevice.current.userInterfaceIdiom == .mac
-        {
-            return UISwitchCheckbox()
-        }
+            if #available(macCatalyst 14, *),
+                UIDevice.current.userInterfaceIdiom == .mac
+            {
+                return UISwitchCheckbox()
+            }
         #endif
         
         return UIButtonCheckbox()


### PR DESCRIPTION
Uses the built-in checkbox component on Mac Catalyst when the user interface idiom is "mac". When the user interface idiom is "pad", and on iOS and visionOS, it renders as a switch, and the component doesn't exist on tvOS; so in all those situations, I use a custom component built on top of `UIButton` instead.

See: #180 