### PR TITLE
feat(TextField): add numeric initializer with value binding

### DIFF
--- a/Sources/SwiftCrossUI/Views/TextField.swift
+++ b/Sources/SwiftCrossUI/Views/TextField.swift
@@ -45,7 +45,7 @@ public struct TextField: ElementaryView, View {
         self._text = Binding(
             get: { String(value.wrappedValue) },
             set: { newString in
-                if let parsed = V(newString) {
+                if let parsed = V(newString), parsed != value.wrappedValue {
                     value.wrappedValue = parsed
                 }
             }
@@ -71,7 +71,7 @@ public struct TextField: ElementaryView, View {
         self._text = Binding(
             get: { String(value.wrappedValue) },
             set: { newString in
-                if let parsed = V(newString) {
+                if let parsed = V(newString), parsed != value.wrappedValue {
                     value.wrappedValue = parsed
                 }
             }

--- a/Sources/SwiftCrossUI/Views/TextField.swift
+++ b/Sources/SwiftCrossUI/Views/TextField.swift
@@ -26,6 +26,58 @@ public struct TextField: ElementaryView, View {
         self._text = value ?? Binding(get: { dummy }, set: { dummy = $0 })
     }
 
+    /// Creates an editable text field bound to a binary integer value.
+    ///
+    /// The field's content is kept in sync with `value` via simple string
+    /// conversion. When the user enters text that cannot be parsed as the
+    /// target integer type, the binding is not updated (the previous value
+    /// is preserved), mirroring the behaviour of SwiftUI's
+    /// `TextField(_:value:formatter:)` when the formatter fails.
+    ///
+    /// - Parameters:
+    ///   - placeholder: The label to show when the field is empty.
+    ///   - value: A binding to the integer value to edit.
+    public init<V: BinaryInteger & LosslessStringConvertible>(
+        _ placeholder: String = "",
+        value: Binding<V>
+    ) {
+        self.placeholder = placeholder
+        self._text = Binding(
+            get: { String(value.wrappedValue) },
+            set: { newString in
+                if let parsed = V(newString) {
+                    value.wrappedValue = parsed
+                }
+            }
+        )
+    }
+
+    /// Creates an editable text field bound to a binary floating-point value.
+    ///
+    /// The field's content is kept in sync with `value` via simple string
+    /// conversion. When the user enters text that cannot be parsed as the
+    /// target floating-point type, the binding is not updated (the previous
+    /// value is preserved), mirroring the behaviour of SwiftUI's
+    /// `TextField(_:value:formatter:)` when the formatter fails.
+    ///
+    /// - Parameters:
+    ///   - placeholder: The label to show when the field is empty.
+    ///   - value: A binding to the floating-point value to edit.
+    public init<V: BinaryFloatingPoint & LosslessStringConvertible>(
+        _ placeholder: String = "",
+        value: Binding<V>
+    ) {
+        self.placeholder = placeholder
+        self._text = Binding(
+            get: { String(value.wrappedValue) },
+            set: { newString in
+                if let parsed = V(newString) {
+                    value.wrappedValue = parsed
+                }
+            }
+        )
+    }
+
     func asWidget<Backend: AppBackend>(backend: Backend) -> Backend.Widget {
         return backend.createTextField()
     }


### PR DESCRIPTION
## Summary

Closes #379. Adds two new `TextField` initializers that accept a numeric binding instead of a `Binding<String>`, mirroring SwiftUI's `TextField(_:value:formatter:)` convenience:

- `init<V: BinaryInteger & LosslessStringConvertible>(_:value:)`
- `init<V: BinaryFloatingPoint & LosslessStringConvertible>(_:value:)`

## Why this matters

SwiftUI's `TextField(_ title: value: formatter:)` lets you edit a non-String value (e.g. `Int`, `Double`) and hides the string/number conversion. SwiftCrossUI only had the `Binding<String>` form, which meant callers had to wire up their own string↔value conversion and handle bad-parse edge cases manually. The new initializers close that ergonomic gap for the common numeric case.

Why LosslessStringConvertible, not Formatter: SwiftUI's API relies on `Foundation.Formatter`, which isn't cross-platform ergonomic for every SwiftCrossUI backend. The issue author's linked SwiftUI docs use the formatter approach, but the numeric-focused use case they mentioned is well served by Swift's own `LosslessStringConvertible` constraint, which `Int`, `Int32`, `Double`, `Float`, etc. already satisfy. If a Formatter-based initializer is wanted, it's a natural follow-up PR.

## Behaviour

- Getter: `String(value.wrappedValue)` — standard numeric-to-string.
- Setter: `if let parsed = V(newString) { value.wrappedValue = parsed }` — on parse failure (user types a letter, `1.2.3`, etc.), the binding is not updated. Previous value is preserved. This matches SwiftUI's formatter-rejected behaviour.

## Usage

```swift
@State var minNum: Int = 0
@State var ratio: Double = 0.5

var body: some View {
    VStack {
        TextField("Minimum", value: $minNum)
        TextField("Ratio", value: $ratio)
    }
}
```

## Testing

- `swift build --target SwiftCrossUI` — passes cleanly on macOS with the change. Full `swift build` was partially blocked by an unrelated WinUI header (`ShObjIdl.h` not found on macOS); that's a pre-existing Windows-target build constraint, unrelated to this PR.
- No existing initializer was modified, so string-bound TextField usage is unaffected.
- No new imports. Both initializers use only `Binding` (already in scope) and standard-library protocol composition.

## Scope note

Didn't add a Formatter-based overload here — mentioned above as a natural follow-up. Also didn't touch the existing `TextField` examples in `Examples/` since they're all string-bound; a follow-up example PR could showcase the numeric binding.

Closes #379

This contribution was developed with AI assistance (Codex).
