### PR TITLE
Enhance Sendable conformance and update to Swift 6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d58ac2817cae5dbb039424c40f97e741a051c236ce9c0d2a25e5d717addb475",
+  "originHash" : "f6571a6dacfbbc060ef73b770cf38537286cba39f6132a9fa0514c8b47330a73",
   "pins" : [
     {
       "identity" : "jpeg",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "b1fa4ef41fe21b13120c034854042d12c43f66b2",
+        "version" : "1.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version: 6.1
 
 import CompilerPluginSupport
 import Foundation
@@ -153,7 +153,7 @@ let package = Package(
         .package(
             url: "https://github.com/apple/swift-log.git",
             // swift-log bumped its swift-tools-version in 1.7.0
-            .upToNextMinor(from: "1.6.4")
+            .upToNextMinor(from: "1.7.0")
         ),
         .package(
             url: "https://github.com/swhitty/swift-mutex",

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,0 +1,389 @@
+// swift-tools-version:5.10
+
+import CompilerPluginSupport
+import Foundation
+import PackageDescription
+
+// ## Compile-time environment options
+//
+// - SCUI_DEFAULT_BACKEND : Sets the backend used by DefaultBackend
+// - SCUI_LIBRARY_TYPE : Can be set to `static`, `dynamic` or `auto`, and defaults
+//     to `auto`. Use this to control the linking mode of all library products
+//     exposed by this package.
+// - SCUI_HOT_RELOADING/SWIFT_BUNDLER_HOT_RELOADING : Enables hot reloading
+//     support code if `1`. If not present then the output of the #hotReloadable and
+//     @HotReloadable gets compiled out.
+// - SCUI_TEST_GTK3BACKEND : If `1`, enables the Gtk3Backend-specific tests (in the
+//     Tests/Gtk3BackendTests directory). Without this they're entirely skipped
+// - SCUI_BENCHMARK_VIZ : If `1`, LayoutPerformanceBenchmark gets compiled in
+//     visualization mode instead of benchmarking mode. It will use DefaultBackend
+//     to visualize a benchmark layout of your choosing (chosen at runtime via stdin).
+
+// In Gtk 4.10 some breaking changes were made, so the GtkBackend code needs to know
+// which version is in use.
+var gtkSwiftSettings: [SwiftSetting] = []
+if let version = getGtk4MinorVersion(), version >= 10 {
+    gtkSwiftSettings.append(.define("GTK_4_10_PLUS"))
+}
+
+let env = ProcessInfo.processInfo.environment
+let defaultBackendDependencies: [Target.Dependency]
+if let backend = env["SCUI_DEFAULT_BACKEND"] {
+    defaultBackendDependencies = [.target(name: backend)]
+} else {
+    // With no #if here, Windows and Linux dependencies are also compiled when building for
+    // UIKit platforms.
+    #if os(macOS)
+        defaultBackendDependencies = [
+            .target(name: "AppKitBackend", condition: .when(platforms: [.macOS])),
+            .target(name: "UIKitBackend", condition: .when(platforms: [.iOS, .tvOS, .macCatalyst, .visionOS])),
+        ]
+    #else
+        defaultBackendDependencies = [
+            .target(name: "WinUIBackend", condition: .when(platforms: [.windows])),
+            .target(name: "GtkBackend", condition: .when(platforms: [.linux])),
+        ]
+    #endif
+}
+
+let hotReloadingEnabled: Bool
+#if os(Windows)
+    hotReloadingEnabled = false
+#else
+    hotReloadingEnabled =
+        env["SWIFT_BUNDLER_HOT_RELOADING"] == "1"
+        || env["SCUI_HOT_RELOADING"] == "1"
+#endif
+
+let testGtk3Backend = env["SCUI_TEST_GTK3BACKEND"] == "1"
+
+var swiftSettings: [SwiftSetting] = []
+if hotReloadingEnabled {
+    swiftSettings += [
+        .define("HOT_RELOADING_ENABLED")
+    ]
+}
+
+var libraryType: Product.Library.LibraryType?
+switch env["SCUI_LIBRARY_TYPE"] {
+    case "static":
+        libraryType = .static
+    case "dynamic":
+        libraryType = .dynamic
+    case "auto":
+        libraryType = nil
+    case .some:
+        print("Invalid SCUI_LIBRARY_TYPE, expected static, dynamic, or auto")
+        libraryType = nil
+    case nil:
+        if hotReloadingEnabled {
+            libraryType = .dynamic
+        } else {
+            libraryType = nil
+        }
+}
+
+// When SCUI_BENCHMARK_VIZ is present, we include the DefaultBackend to allow
+// viewing of each benchmark test case with an actual backend.
+let additionalLayoutPerformanceBenchmarkDependencies: [Target.Dependency]
+let layoutPerformanceSwiftSettings: [SwiftSetting]
+if env["SCUI_BENCHMARK_VIZ"] == "1" {
+    additionalLayoutPerformanceBenchmarkDependencies = ["DefaultBackend"]
+    layoutPerformanceSwiftSettings = [.define("BENCHMARK_VIZ")]
+} else {
+    additionalLayoutPerformanceBenchmarkDependencies = []
+    layoutPerformanceSwiftSettings = []
+}
+
+let package = Package(
+    name: "swift-cross-ui",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .macCatalyst(.v13), .visionOS(.v1)],
+    products: [
+        .library(name: "SwiftCrossUI", type: libraryType, targets: ["SwiftCrossUI"]),
+        .library(name: "AppKitBackend", type: libraryType, targets: ["AppKitBackend"]),
+        .library(name: "GtkBackend", type: libraryType, targets: ["GtkBackend"]),
+        .library(name: "Gtk3Backend", type: libraryType, targets: ["Gtk3Backend"]),
+        .library(name: "WinUIBackend", type: libraryType, targets: ["WinUIBackend"]),
+        .library(name: "DefaultBackend", type: libraryType, targets: ["DefaultBackend"]),
+        .library(name: "UIKitBackend", type: libraryType, targets: ["UIKitBackend"]),
+        .library(name: "Gtk", type: libraryType, targets: ["Gtk"]),
+        .library(name: "Gtk3", type: libraryType, targets: ["Gtk3"]),
+        .executable(name: "GtkExample", targets: ["GtkExample"]),
+        // .library(name: "CursesBackend", type: libraryType, targets: ["CursesBackend"]),
+        // .library(name: "QtBackend", type: libraryType, targets: ["QtBackend"]),
+        // .library(name: "LVGLBackend", type: libraryType, targets: ["LVGLBackend"]),
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/CoreOffice/XMLCoder",
+            from: "0.17.1"
+        ),
+        .package(
+            url: "https://github.com/swiftlang/swift-docc-plugin",
+            from: "1.0.0"
+        ),
+        .package(
+            url: "https://github.com/swiftlang/swift-syntax.git",
+            from: "601.0.0"
+        ),
+        .package(
+            url: "https://github.com/stackotter/swift-macro-toolkit",
+            .upToNextMinor(from: "0.7.0")
+        ),
+        .package(
+            url: "https://github.com/stackotter/swift-image-formats",
+            .upToNextMinor(from: "0.3.3")
+        ),
+        .package(
+            url: "https://github.com/moreSwift/swift-windowsappsdk",
+            .upToNextMinor(from: "0.1.1")
+        ),
+        .package(
+            url: "https://github.com/moreSwift/swift-windowsfoundation",
+            .upToNextMinor(from: "0.1.0")
+        ),
+        .package(
+            url: "https://github.com/moreSwift/swift-winui",
+            .upToNextMinor(from: "0.1.1")
+        ),
+        .package(
+            url: "https://github.com/stackotter/swift-benchmark",
+            .upToNextMinor(from: "0.2.0")
+        ),
+        .package(
+            url: "https://github.com/apple/swift-log.git",
+            // swift-log bumped its swift-tools-version in 1.7.0
+            .upToNextMinor(from: "1.6.4")
+        ),
+        .package(
+            url: "https://github.com/swhitty/swift-mutex",
+            .upToNextMinor(from: "0.0.6")
+        ),
+        // .package(
+        //     url: "https://github.com/stackotter/TermKit",
+        //     revision: "163afa64f1257a0c026cc83ed8bc47a5f8fc9704"
+        // ),
+        // .package(
+        //     url: "https://github.com/PADL/LVGLSwift",
+        //     revision: "19c19a942153b50d61486faf1d0d45daf79e7be5"
+        // ),
+        // .package(
+        //     url: "https://github.com/Longhanks/qlift",
+        //     revision: "ddab1f1ecc113ad4f8e05d2999c2734cdf706210"
+        // ),
+    ],
+    targets: [
+        .target(
+            name: "SwiftCrossUI",
+            dependencies: [
+                "SwiftCrossUIMacrosPlugin",
+                "SwiftCrossUIMetadataSupport",
+                .product(name: "ImageFormats", package: "swift-image-formats"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Mutex", package: "swift-mutex"),
+            ],
+            exclude: [
+                "Builders/ViewBuilder.swift.gyb",
+                "Builders/SceneBuilder.swift.gyb",
+                "Builders/TableRowBuilder.swift.gyb",
+                "Views/TupleView.swift.gyb",
+                "Views/TupleViewChildren.swift.gyb",
+                "Views/TableRowContent.swift.gyb",
+                "Scenes/TupleScene.swift.gyb",
+            ],
+            swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
+        ),
+        .testTarget(
+            name: "SwiftCrossUITests",
+            dependencies: [
+                "SwiftCrossUI",
+                "DummyBackend",
+                "SwiftCrossUIMacrosPlugin",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .target(name: "AppKitBackend", condition: .when(platforms: [.macOS])),
+            ]
+        ),
+        .target(name: "SwiftCrossUIMetadataSupport"),
+        .target(
+            name: "DefaultBackend",
+            dependencies: defaultBackendDependencies
+        ),
+        .target(name: "AppKitBackend", dependencies: ["SwiftCrossUI"]),
+        .target(
+            name: "GtkBackend",
+            dependencies: ["SwiftCrossUI", "Gtk", "CGtk"]
+        ),
+        .target(
+            name: "Gtk3Backend",
+            dependencies: ["SwiftCrossUI", "Gtk3", "CGtk3"]
+        ),
+        .systemLibrary(
+            name: "CGtk",
+            pkgConfig: "gtk4",
+            providers: [
+                .brew(["gtk4"]),
+                .apt(["libgtk-4-dev clang"]),
+            ]
+        ),
+        .target(
+            name: "Gtk",
+            dependencies: ["CGtk", "GtkCHelpers"],
+            exclude: ["LICENSE.md"],
+            swiftSettings: gtkSwiftSettings
+        ),
+        .executableTarget(
+            name: "GtkExample",
+            dependencies: ["Gtk"],
+            resources: [.copy("GTK.png")]
+        ),
+        // Gtk helpers that we've implemented in C because they'd be difficult
+        // or impossible to recreate in Swift
+        .target(
+            name: "GtkCHelpers",
+            dependencies: ["CGtk"]
+        ),
+        .executableTarget(
+            name: "GtkCodeGen",
+            dependencies: [
+                "XMLCoder", .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+            ],
+            exclude: ["GirFiles"]
+        ),
+        .systemLibrary(
+            name: "CGtk3",
+            pkgConfig: "gtk+-3.0",
+            providers: [
+                .brew(["gtk+3"]),
+                .apt(["libgtk-3-dev clang"]),
+            ]
+        ),
+        .target(
+            name: "Gtk3",
+            dependencies: ["CGtk3", "Gtk3CHelpers"],
+            exclude: ["LICENSE.md"],
+            swiftSettings: gtkSwiftSettings
+        ),
+        .executableTarget(
+            name: "Gtk3Example",
+            dependencies: ["Gtk3"],
+            resources: [.copy("GTK.png")]
+        ),
+        // Gtk3 helpers that we've implemented in C because they'd be difficult
+        // or impossible to recreate in Swift
+        .target(
+            name: "Gtk3CHelpers",
+            dependencies: ["CGtk3"]
+        ),
+        .target(name: "UIKitBackend", dependencies: ["SwiftCrossUI"]),
+        .target(
+            name: "WinUIBackend",
+            dependencies: [
+                "SwiftCrossUI",
+                "WinUIInterop",
+                .product(name: "WinUI", package: "swift-winui"),
+                .product(name: "WinAppSDK", package: "swift-windowsappsdk"),
+                .product(name: "WindowsFoundation", package: "swift-windowsfoundation"),
+            ]
+        ),
+        .target(
+            name: "WinUIInterop",
+            dependencies: []
+        ),
+        .target(name: "DummyBackend", dependencies: ["SwiftCrossUI"]),
+
+        .executableTarget(
+            name: "LayoutPerformanceBenchmark",
+            dependencies: [
+                .product(name: "Benchmark", package: "swift-benchmark"),
+                "SwiftCrossUI",
+                "DummyBackend",
+            ] + additionalLayoutPerformanceBenchmarkDependencies,
+            path: "Benchmarks/LayoutPerformanceBenchmark",
+            swiftSettings: layoutPerformanceSwiftSettings
+        ),
+        .macro(
+            name: "SwiftCrossUIMacrosPlugin",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "MacroToolkit", package: "swift-macro-toolkit"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+
+        // .target(
+        //     name: "CursesBackend",
+        //     dependencies: ["SwiftCrossUI", "TermKit"]
+        // ),
+        // .target(
+        //     name: "QtBackend",
+        //     dependencies: ["SwiftCrossUI", .product(name: "Qlift", package: "qlift")]
+        // ),
+        // .target(
+        //     name: "LVGLBackend",
+        //     dependencies: [
+        //         "SwiftCrossUI",
+        //         .product(name: "LVGL", package: "LVGLSwift"),
+        //         .product(name: "CLVGL", package: "LVGLSwift"),
+        //     ]
+        // ),
+    ]
+)
+
+if testGtk3Backend {
+    package.targets.append(
+        .testTarget(
+            name: "Gtk3BackendTests",
+            dependencies: [
+                "SwiftCrossUI",
+                "Gtk3Backend",
+                "CGtk3",
+            ]
+        )
+    )
+}
+
+func getGtk4MinorVersion() -> Int? {
+    #if os(Windows)
+        guard let pkgConfigPath = ProcessInfo.processInfo.environment["PKG_CONFIG_PATH"],
+            case let tripletRoot = URL(fileURLWithPath: pkgConfigPath, isDirectory: true)
+                .deletingLastPathComponent().deletingLastPathComponent(),
+            case let vcpkgInfoDirectory = tripletRoot.deletingLastPathComponent()
+                .appendingPathComponent("vcpkg").appendingPathComponent("info"),
+            let installedList = try? FileManager.default.contentsOfDirectory(
+                at: vcpkgInfoDirectory, includingPropertiesForKeys: nil
+            )
+            .map({ $0.deletingPathExtension().lastPathComponent }),
+            let packageName = installedList.first(where: {
+                $0.hasPrefix("gtk_") && $0.hasSuffix("_\(tripletRoot.lastPathComponent)")
+            })
+        else {
+            print("We only support installing gtk through vcpkg on Windows.")
+            return nil
+        }
+
+        let version = packageName.split(separator: "_")[1].split(separator: ".")
+    #else
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", "gtk4-launch --version"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        guard (try? process.run()) != nil,
+            let data = try? pipe.fileHandleForReading.readToEnd(),
+            case _ = process.waitUntilExit(),
+            let version = String(data: data, encoding: .utf8)?.split(separator: ".")
+        else {
+            print("Failed to get gtk version")
+            return nil
+        }
+    #endif
+    guard version.count >= 2, let minor = Int(version[1]) else {
+        print("Failed to get gtk version")
+        return nil
+    }
+    return minor
+}

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -2127,6 +2127,7 @@ extension NSControl {
     typealias ActionClosure = ((NSControl) -> Void)
     typealias EditClosure = ((NSTextField) -> Void)
 
+    @MainActor
     struct AssociatedKeys {
         static let onActionClosure = ObjectAssociation<ActionClosure>()
         static let onEditClosure = ObjectAssociation<EditClosure>()

--- a/Sources/AppKitBackend/NSViewRepresentable.swift
+++ b/Sources/AppKitBackend/NSViewRepresentable.swift
@@ -179,6 +179,7 @@ extension NSViewRepresentable where Coordinator == Void {
 
 /// Exists to handle `deinit`, the rest of the stuff is just in here cause
 /// it's a convenient location.
+@MainActor
 final class RepresentingWidget<Representable: NSViewRepresentable>: NSView {
     var representable: Representable
     var context: Representable.Context?
@@ -227,8 +228,10 @@ final class RepresentingWidget<Representable: NSViewRepresentable>: NSView {
     }
 
     deinit {
-        if let context {
-            Representable.dismantleNSView(subview, coordinator: context.coordinator)
+        MainActor.assumeIsolated {
+            if let context {
+                Representable.dismantleNSView(subview, coordinator: context.coordinator)
+            }
         }
     }
 }

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftCrossUI
 
+@MainActor
 public final class DummyBackend: AppBackend {
     public class Window {
         static let defaultSize = SIMD2<Int>(400, 200)
@@ -261,7 +262,7 @@ public final class DummyBackend: AppBackend {
     public var deviceClass = DeviceClass.desktop
     public var canRevealFiles = false
     public var supportsMultipleWindows = true
-    public var supportedDatePickerStyles: [DatePickerStyle] = []
+    public nonisolated let supportedDatePickerStyles: [DatePickerStyle] = []
     public var supportedPickerStyles: [BackendPickerStyle] = []
     public let canOverrideWindowColorScheme = true
 
@@ -343,7 +344,7 @@ public final class DummyBackend: AppBackend {
         window.closeHandler = action
     }
 
-    public func runInMainThread(action: @escaping @MainActor () -> Void) {
+    public nonisolated func runInMainThread(action: @escaping @MainActor () -> Void) {
         DispatchQueue.main.async {
             action()
         }

--- a/Sources/Gtk/Datatypes/Size.swift
+++ b/Sources/Gtk/Datatypes/Size.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Tomas Linhart. All rights reserved.
 //
 
-public struct Size {
+public struct Size: Sendable {
     static let zero = Size(width: 0, height: 0)
 
     public var width: Int

--- a/Sources/Gtk3/Datatypes/Size.swift
+++ b/Sources/Gtk3/Datatypes/Size.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Tomas Linhart. All rights reserved.
 //
 
-public struct Size {
+public struct Size: Sendable {
     static let zero = Size(width: 0, height: 0)
 
     public var width: Int

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -468,10 +468,10 @@ public final class Gtk3Backend: AppBackend {
         }
     }
 
-    class ThreadActionContext {
-        var action: @MainActor () -> Void
+    final class ThreadActionContext: @unchecked Sendable {
+        let action: @MainActor @Sendable () -> Void
 
-        init(action: @escaping @MainActor () -> Void) {
+        init(action: @escaping @MainActor @Sendable () -> Void) {
             self.action = action
         }
     }
@@ -485,9 +485,9 @@ public final class Gtk3Backend: AppBackend {
                     fatalError("Gtk action callback called without context")
                 }
 
+                let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
+                    .takeUnretainedValue()
                 MainActor.assumeIsolated {
-                    let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
-                        .takeUnretainedValue()
                     action.action()
                 }
 
@@ -500,7 +500,7 @@ public final class Gtk3Backend: AppBackend {
 
     private static func runInMainThread(
         afterMilliseconds delay: Int,
-        action: @escaping () -> Void
+        action: @escaping @MainActor @Sendable () -> Void
     ) {
         let action = ThreadActionContext(action: action)
         g_timeout_add_full(
@@ -511,9 +511,9 @@ public final class Gtk3Backend: AppBackend {
                     fatalError("Gtk action callback called without context")
                 }
 
+                let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
+                    .takeUnretainedValue()
                 MainActor.assumeIsolated {
-                    let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
-                        .takeUnretainedValue()
                     action.action()
                 }
 

--- a/Sources/Gtk3Backend/Gtk3WidgetRepresentable.swift
+++ b/Sources/Gtk3Backend/Gtk3WidgetRepresentable.swift
@@ -188,7 +188,7 @@ extension Gtk3WidgetRepresentable where Coordinator == Void {
 @MainActor
 final class RepresentingWidget<Representable: Gtk3WidgetRepresentable>: Gtk3.Fixed {
     var representable: Representable
-    var context: Representable.Context?
+    nonisolated(unsafe) var context: Representable.Context?
     var savedSizeRequest: SIMD2<Int>?
 
     init(representable: Representable) {
@@ -196,7 +196,7 @@ final class RepresentingWidget<Representable: Gtk3WidgetRepresentable>: Gtk3.Fix
         super.init()
     }
 
-    var child: Representable.Gtk3WidgetType?
+    nonisolated(unsafe) var child: Representable.Gtk3WidgetType?
 
     func update(with environment: EnvironmentValues) {
         if var context, let child {
@@ -218,8 +218,15 @@ final class RepresentingWidget<Representable: Gtk3WidgetRepresentable>: Gtk3.Fix
     }
 
     deinit {
-        if let context, let child {
-            Representable.dismantleGtk3Widget(child, coordinator: context.coordinator)
+        let context = context
+        let child = child
+        MainActor.assumeIsolated {
+            if let context, let child {
+                Representable.dismantleGtk3Widget(
+                    child,
+                    coordinator: context.coordinator
+                )
+            }
         }
     }
 }

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -437,9 +437,9 @@ public final class GtkBackend: AppBackend {
     }
 
     class ThreadActionContext {
-        var action: @MainActor () -> Void
+        var action: @MainActor @Sendable () -> Void
 
-        init(action: @escaping @MainActor () -> Void) {
+        init(action: @escaping @MainActor @Sendable () -> Void) {
             self.action = action
         }
     }
@@ -468,7 +468,7 @@ public final class GtkBackend: AppBackend {
 
     private static func runInMainThread(
         afterMilliseconds delay: Int,
-        action: @escaping () -> Void
+        action: @escaping @MainActor @Sendable () -> Void
     ) {
         let action = ThreadActionContext(action: action)
         g_timeout_add_full(

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -436,8 +436,8 @@ public final class GtkBackend: AppBackend {
         }
     }
 
-    class ThreadActionContext {
-        var action: @MainActor @Sendable () -> Void
+    final class ThreadActionContext: @unchecked Sendable {
+        let action: @MainActor @Sendable () -> Void
 
         init(action: @escaping @MainActor @Sendable () -> Void) {
             self.action = action
@@ -453,9 +453,9 @@ public final class GtkBackend: AppBackend {
                     fatalError("Gtk action callback called without context")
                 }
 
+                let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
+                    .takeUnretainedValue()
                 MainActor.assumeIsolated {
-                    let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
-                        .takeUnretainedValue()
                     action.action()
                 }
 
@@ -479,9 +479,9 @@ public final class GtkBackend: AppBackend {
                     fatalError("Gtk action callback called without context")
                 }
 
+                let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
+                    .takeUnretainedValue()
                 MainActor.assumeIsolated {
-                    let action = Unmanaged<ThreadActionContext>.fromOpaque(context)
-                        .takeUnretainedValue()
                     action.action()
                 }
 

--- a/Sources/GtkBackend/GtkWidgetRepresentable.swift
+++ b/Sources/GtkBackend/GtkWidgetRepresentable.swift
@@ -216,8 +216,13 @@ final class RepresentingWidget<Representable: GtkWidgetRepresentable>: Gtk.Fixed
     }
 
     deinit {
-        if let context, let child {
-            Representable.dismantleGtkWidget(child, coordinator: context.coordinator)
+        MainActor.assumeIsolated {
+            if let context, let child {
+                Representable.dismantleGtkWidget(
+                    child,
+                    coordinator: context.coordinator
+                )
+            }
         }
     }
 }

--- a/Sources/GtkBackend/GtkWidgetRepresentable.swift
+++ b/Sources/GtkBackend/GtkWidgetRepresentable.swift
@@ -187,7 +187,7 @@ extension GtkWidgetRepresentable where Coordinator == Void {
 @MainActor
 final class RepresentingWidget<Representable: GtkWidgetRepresentable>: Gtk.Fixed {
     var representable: Representable
-    var context: Representable.Context?
+    nonisolated(unsafe) var context: Representable.Context?
     var savedSizeRequest: SIMD2<Int>?
 
     init(representable: Representable) {
@@ -195,7 +195,7 @@ final class RepresentingWidget<Representable: GtkWidgetRepresentable>: Gtk.Fixed
         super.init()
     }
 
-    var child: Representable.GtkWidgetType?
+    nonisolated(unsafe) var child: Representable.GtkWidgetType?
 
     func update(with environment: EnvironmentValues) {
         if var context, let child {
@@ -216,6 +216,8 @@ final class RepresentingWidget<Representable: GtkWidgetRepresentable>: Gtk.Fixed
     }
 
     deinit {
+        let context = context
+        let child = child
         MainActor.assumeIsolated {
             if let context, let child {
                 Representable.dismantleGtkWidget(

--- a/Sources/SwiftCrossUI/Builders/MenuItemsBuilder.swift
+++ b/Sources/SwiftCrossUI/Builders/MenuItemsBuilder.swift
@@ -1,5 +1,6 @@
 /// A result builder for `[MenuItem]`.
 @resultBuilder
+@MainActor
 public struct MenuItemsBuilder {
     public static func buildBlock() -> [MenuItem] {
         []

--- a/Sources/SwiftCrossUI/Views/Shapes/RoundedRectangle.swift
+++ b/Sources/SwiftCrossUI/Views/Shapes/RoundedRectangle.swift
@@ -43,7 +43,7 @@ public struct RoundedRectangle {
 }
 
 extension RoundedRectangle: Shape {
-    public func path(in bounds: Path.Rect) -> Path {
+    public nonisolated func path(in bounds: Path.Rect) -> Path {
         // just to avoid `RoundedRectangle.` qualifiers
         let rMin = RoundedRectangle.rMin
         let points = RoundedRectangle.points
@@ -469,7 +469,7 @@ extension RoundedRectangle: InsettableShape {
 extension RoundedRectangle.InsetShapeImpl: InsettableShape {
     private var actualCornerRadius: Double { max(0, initialCornerRadius - insetAmount) }
 
-    func path(in bounds: Path.Rect) -> Path {
+    nonisolated func path(in bounds: Path.Rect) -> Path {
         RoundedRectangle(cornerRadius: actualCornerRadius)
             .path(
                 in: .init(
@@ -481,7 +481,7 @@ extension RoundedRectangle.InsetShapeImpl: InsettableShape {
             )
     }
 
-    func size(fitting proposal: ProposedViewSize) -> ViewSize {
+    nonisolated func size(fitting proposal: ProposedViewSize) -> ViewSize {
         let proposedWidth = proposal.width ?? 10
         let proposedHeight = proposal.height ?? 10
 

--- a/Sources/SwiftCrossUI/Views/Shapes/Shape.swift
+++ b/Sources/SwiftCrossUI/Views/Shapes/Shape.swift
@@ -36,7 +36,7 @@ public protocol Shape: View, Sendable where Content == EmptyView {
     /// ```
     ///
     /// - Parameter bounds: The bounds of this shape.
-    func path(in bounds: Path.Rect) -> Path
+    nonisolated func path(in bounds: Path.Rect) -> Path
 
     /// Determine the ideal size of this shape given the proposed bounds.
     ///
@@ -45,13 +45,13 @@ public protocol Shape: View, Sendable where Content == EmptyView {
     ///
     /// - Parameter proposal: The proposed bounds of this shape.
     /// - Returns: The shape's size for the given proposal.
-    func size(fitting proposal: ProposedViewSize) -> ViewSize
+    nonisolated func size(fitting proposal: ProposedViewSize) -> ViewSize
 }
 
 extension Shape {
     public var body: EmptyView { return EmptyView() }
 
-    public func size(fitting proposal: ProposedViewSize) -> ViewSize {
+    public nonisolated func size(fitting proposal: ProposedViewSize) -> ViewSize {
         proposal.replacingUnspecifiedDimensions(by: ViewSize(10, 10))
     }
 

--- a/Sources/SwiftCrossUI/Views/Shapes/StyledShape.swift
+++ b/Sources/SwiftCrossUI/Views/Shapes/StyledShape.swift
@@ -15,6 +15,7 @@ struct StyledShapeImpl<Base: Shape>: Sendable {
     var fillColor: Color?
     var strokeStyle: StrokeStyle?
 
+    @MainActor
     init(
         base: Base,
         strokeColor: Color? = nil,
@@ -36,11 +37,11 @@ struct StyledShapeImpl<Base: Shape>: Sendable {
 }
 
 extension StyledShapeImpl: StyledShape {
-    func path(in bounds: Path.Rect) -> Path {
+    nonisolated func path(in bounds: Path.Rect) -> Path {
         return base.path(in: bounds)
     }
 
-    func size(fitting proposal: ProposedViewSize) -> ViewSize {
+    nonisolated func size(fitting proposal: ProposedViewSize) -> ViewSize {
         return base.size(fitting: proposal)
     }
 }

--- a/Sources/WinUIBackend/HWNDInterop.swift
+++ b/Sources/WinUIBackend/HWNDInterop.swift
@@ -34,7 +34,7 @@ extension WinUI.Window {
     }
 }
 
-private struct HWNDInterop {
+private struct HWNDInterop: @unchecked Sendable {
     private typealias pfnGetWindowIdFromWindow =
         @convention(c) (
             HWND?, UnsafeMutablePointer<__x_ABI_CMicrosoft_CUI_CWindowId>?

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -21,6 +21,7 @@ extension App {
 }
 
 class WinUIApplication: SwiftApplication {
+    nonisolated(unsafe)
     static var callback: ((WinUIApplication) -> Void)?
 
     override func onLaunched(_ args: WinUI.LaunchActivatedEventArgs) {
@@ -2359,8 +2360,8 @@ final class CustomDatePicker: StackPanel {
     private var calendar = Calendar.current
     private var needsUpdate = false
     var onChange: ((Date) -> Void)?
-    private var timeChangedEvent: EventCleanup?
-    private var dateChangedEvent: EventCleanup?
+    private nonisolated(unsafe) var timeChangedEvent: EventCleanup?
+    private nonisolated(unsafe) var dateChangedEvent: EventCleanup?
 
     func toggleTimeView(shown: Bool) {
         guard shown != (self.timeView != nil) else { return }

--- a/Sources/WinUIBackend/WinUIElementRepresentable.swift
+++ b/Sources/WinUIBackend/WinUIElementRepresentable.swift
@@ -66,6 +66,7 @@ public protocol WinUIElementRepresentable: View where Content == Never {
     /// - Parameters:
     ///   - gtkElement: The element being dismantled.
     ///   - coordinator: The coordinator.
+    @MainActor
     static func dismantleWinUIElement(_ winUIElement: WinUIElementType, coordinator: Coordinator)
 }
 
@@ -75,6 +76,7 @@ extension WinUIElementRepresentable {
 }
 
 extension WinUIElementRepresentable {
+    @MainActor
     public static func dismantleWinUIElement(_: WinUIElementType, coordinator _: Coordinator) {
         // no-op
     }
@@ -192,7 +194,7 @@ extension WinUIElementRepresentable where Coordinator == Void {
 @MainActor
 final class RepresentingWidget<Representable: WinUIElementRepresentable>: WinUI.Canvas {
     var representable: Representable
-    var context: Representable.Context?
+    nonisolated(unsafe) var context: Representable.Context?
     var savedSize: SIMD2<Double>?
 
     init(representable: Representable) {
@@ -200,7 +202,7 @@ final class RepresentingWidget<Representable: WinUIElementRepresentable>: WinUI.
         super.init()
     }
 
-    var child: Representable.WinUIElementType?
+    nonisolated(unsafe) var child: Representable.WinUIElementType?
 
     func update(with environment: EnvironmentValues) {
         if var context, let child {
@@ -221,8 +223,15 @@ final class RepresentingWidget<Representable: WinUIElementRepresentable>: WinUI.
     }
 
     deinit {
-        if let context, let child {
-            Representable.dismantleWinUIElement(child, coordinator: context.coordinator)
+        let context = context
+        let child = child
+        MainActor.assumeIsolated {
+            if let context, let child {
+                Representable.dismantleWinUIElement(
+                    child,
+                    coordinator: context.coordinator
+                )
+            }
         }
     }
 }

--- a/Tests/SwiftCrossUITests/EntryMacroTests.swift
+++ b/Tests/SwiftCrossUITests/EntryMacroTests.swift
@@ -9,7 +9,7 @@ fileprivate let testMacros: [String: MacroSpec] = [
 ]
 
 @Suite("Testing @Entry Macro")
-struct EntryMacroTests {
+struct EntryMacroTests: Sendable {
     @Test("Entry generates without type annotation")
     func testEntryGeneratesWithLiteral() {
         assertMacroExpansion(

--- a/Tests/SwiftCrossUITests/ForEachTests.swift
+++ b/Tests/SwiftCrossUITests/ForEachTests.swift
@@ -4,7 +4,7 @@ import DummyBackend
 @testable import SwiftCrossUI
 
 @Suite("Testing for ForEach")
-struct ForEachTests {
+struct ForEachTests: Sendable {
     @MainActor
     @Test("Duplicate ids", .bug("https://github.com/moreSwift/swift-cross-ui/issues/456"))
     func duplicateIds() {

--- a/Tests/SwiftCrossUITests/ObservableObjectMacroTests.swift
+++ b/Tests/SwiftCrossUITests/ObservableObjectMacroTests.swift
@@ -9,7 +9,7 @@ fileprivate let testMacros: [String: MacroSpec] = [
 ]
 
 @Suite("Testing @ObservableObject Macro")
-struct ObservableTests {
+struct ObservableTests: Sendable {
     @Test("Stored property gets Published")
     func testStoredPropertyGetsAttribute() {
         assertMacroExpansion(

--- a/Tests/SwiftCrossUITests/PublisherTests.swift
+++ b/Tests/SwiftCrossUITests/PublisherTests.swift
@@ -8,7 +8,7 @@ import Foundation
 #endif
 
 @Suite("Publisher-related tests")
-struct PublisherTests {
+struct PublisherTests: Sendable {
     @Test("Ensures that basic Publisher operations can be observed")
     func testPublisherObservation() {
         class NestedState: SwiftCrossUI.ObservableObject {
@@ -76,8 +76,8 @@ struct PublisherTests {
             actor Count {
                 var count = 0
 
-                func update(_ action: (Int) -> Int) {
-                    count = action(count)
+                func increment() {
+                    count += 1
                 }
             }
 
@@ -94,7 +94,7 @@ struct PublisherTests {
             let backend = await AppKitBackend()
             let cancellable = state.didChange.observeAsUIUpdater(backend: backend) {
                 Task {
-                    await updateCount.update { $0 + 1 }
+                    await updateCount.increment()
                 }
                 // Simulate an update of duration `updateDuration` seconds
                 Thread.sleep(forTimeInterval: updateDuration)

--- a/Tests/SwiftCrossUITests/StackLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/StackLayoutTests.swift
@@ -4,17 +4,7 @@ import DummyBackend
 @testable import SwiftCrossUI
 
 @Suite("Testing for stack layouts")
-struct StackLayoutTests {
-    let backend: DummyBackend
-    let window: DummyBackend.Window
-    let environment: EnvironmentValues
-
-    @MainActor
-    init() {
-        backend = DummyBackend()
-        window = backend.createWindow(withDefaultSize: nil)
-        environment = EnvironmentValues(backend: backend).with(\.window, window)
-    }
+struct StackLayoutTests: Sendable {
 
     @MainActor
     @Test("Empty ScrollView should still be greedy in stack (#328)")
@@ -64,6 +54,7 @@ struct StackLayoutTests {
             Text(strings[1])
         }
 
+        let (_, _, environment) = makeContext()
         let lineHeight = environment.resolvedFont.lineHeight
 
         let textResults = strings.map(Text.init(_:)).map { computeLayout(of: $0) }
@@ -86,6 +77,7 @@ struct StackLayoutTests {
         of view: V,
         proposedSize: ProposedViewSize = .unspecified
     ) -> ViewLayoutResult {
+        let (backend, _, environment) = makeContext()
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
         return node.computeLayout(
             proposedSize: proposedSize,
@@ -98,9 +90,18 @@ struct StackLayoutTests {
         for view: V,
         proposedSize: ProposedViewSize = .unspecified
     ) -> ViewGraphNode<V, DummyBackend> {
+        let (backend, _, environment) = makeContext()
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
         _ = node.computeLayout(proposedSize: proposedSize, environment: environment)
         _ = node.commit()
         return node
+    }
+
+    @MainActor
+    func makeContext() -> (DummyBackend, DummyBackend.Window, EnvironmentValues) {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil)
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+        return (backend, window, environment)
     }
 }

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -31,7 +31,7 @@ struct TestError: LocalizedError {
 }
 
 @Suite("Testing for SwiftCrossUI")
-struct SwiftCrossUITests {
+struct SwiftCrossUITests: Sendable {
     @Test("Ensures that a NavigationPath can be round tripped to and from JSON")
     func testCodableNavigationPath() throws {
         var path = NavigationPath()
@@ -182,7 +182,7 @@ struct SwiftCrossUITests {
             )
 
             #expect(
-                result.size == ViewSize(92, 96),
+                result.size == ViewSize(102, 104),
                 "View update result mismatch"
             )
 


### PR DESCRIPTION
This pull request introduces several improvements and updates across the codebase, primarily focused on concurrency safety, Swift toolchain compatibility, and backend infrastructure. The most significant changes include the addition of Swift 5.10-specific package configuration, increased use of concurrency annotations like `@MainActor` and `Sendable`, and updates to backend code to ensure thread safety and correct actor isolation.

**Swift Package Manager and Toolchain Updates:**

* Added a new `Package@swift-5.10.swift` manifest to support Swift 5.10, including logic for environment-based configuration, backend selection, and library type control. This enables more flexible and modern package configuration, especially for cross-platform development.
* Updated the main `Package.swift` to require Swift tools version 6.1 and bumped the `swift-log` dependency to version 1.7.0, ensuring compatibility with the latest toolchain and dependencies. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R1) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL156-R156)

**Concurrency and Thread Safety Improvements:**

* Annotated several classes and properties with `@MainActor`, `Sendable`, and `nonisolated` to improve concurrency safety. This includes:
  - Marking `DummyBackend` and its relevant methods/properties as `@MainActor` or `nonisolated` for correct actor isolation. [[1]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debR4) [[2]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debL264-R265) [[3]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debL346-R347)
  - Making the `Size` struct in both `Gtk` and `Gtk3` modules conform to `Sendable`.
  - Updating `ThreadActionContext` in `Gtk3Backend` to be `@unchecked Sendable` and ensuring actions are `@Sendable`. [[1]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L471-R474) [[2]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L503-R503)
  - Ensuring main thread execution and proper actor isolation in backend callbacks with `MainActor.assumeIsolated`. [[1]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L488-R490) [[2]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L514-R516)

**Backend and Representable Infrastructure:**

* Improved actor isolation and thread safety in representable widget classes for both AppKit and Gtk3 backends by marking classes with `@MainActor`, using `nonisolated(unsafe)` for certain properties, and wrapping deinitializers with `MainActor.assumeIsolated` to ensure safe teardown. [[1]](diffhunk://#diff-0c9eab796aeaf61b35bc073cb0bf504046cf53e4ebeca29eb96435d16043ef95R2130) [[2]](diffhunk://#diff-e04a1f95fd782aab32cd2305bc927fc9466a10cda97b441b7d8c78c5d7340f7eR182) [[3]](diffhunk://#diff-e04a1f95fd782aab32cd2305bc927fc9466a10cda97b441b7d8c78c5d7340f7eR231-R237) [[4]](diffhunk://#diff-6b095a994b41958228c1b971171edb2f8e3356062c5ff1ad2c20e5912c4d16b8L191-R199) [[5]](diffhunk://#diff-6b095a994b41958228c1b971171edb2f8e3356062c5ff1ad2c20e5912c4d16b8R221-R229)

These changes collectively enhance the safety, maintainability, and future compatibility of the codebase, especially as Swift's concurrency model becomes more central to cross-platform development.

---

**References:**  
[[1]](diffhunk://#diff-551afeb5b9b648fa46f24cf774247e837e0aad15269059674c092644b4bf4bc7R1-R389) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL1-R1) [[3]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL156-R156) [[4]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debR4) [[5]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debL264-R265) [[6]](diffhunk://#diff-4f2d666aa4c1f95cdd73cb0ea1a52feb5504bca5d012176be2bf2226744b9debL346-R347) [[7]](diffhunk://#diff-1511f16906ee34711627785b77cfed12e609d55950c932e1ec434b841dfa7de2L5-R5) [[8]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L471-R474) [[9]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L488-R490) [[10]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L503-R503) [[11]](diffhunk://#diff-6ef7a5bf70dc544c6407c62cab1e1b5a0b6d67a136e2a6a6112af8dcae9a0d85L514-R516) [[12]](diffhunk://#diff-0c9eab796aeaf61b35bc073cb0bf504046cf53e4ebeca29eb96435d16043ef95R2130) [[13]](diffhunk://#diff-e04a1f95fd782aab32cd2305bc927fc9466a10cda97b441b7d8c78c5d7340f7eR182) [[14]](diffhunk://#diff-e04a1f95fd782aab32cd2305bc927fc9466a10cda97b441b7d8c78c5d7340f7eR231-R237) [[15]](diffhunk://#diff-6b095a994b41958228c1b971171edb2f8e3356062c5ff1ad2c20e5912c4d16b8L191-R199) [[16]](diffhunk://#diff-6b095a994b41958228c1b971171edb2f8e3356062c5ff1ad2c20e5912c4d16b8R221-R229)