### PR TITLE
CI: Use custom Swift DocC build to support WebP images

### DIFF
--- a/.github/actions/compile-docs/action.yml
+++ b/.github/actions/compile-docs/action.yml
@@ -88,8 +88,9 @@ runs:
         swift build -c release --product docc
         cp .build/release/docc $checkout/docc
 
-    - name: Restore docc build cache
+    - name: Cache DocC
       id: cache-docc
+      if: steps.restore-docc-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       with:
         path: ./docc
@@ -110,7 +111,8 @@ runs:
           symbol_graph_dir="$TARGET-symbol-graphs"
         fi
         echo $symbol_graph_dir
-        DOCC_HTML_DIR="$(xcrun --find docc)/../share/docc/render" ./docc convert "$catalog" \
+        DOCC_HTML_DIR="$(dirname -- $(xcrun --find docc))/../share/docc/render" ./docc \
+          convert "$catalog" \
           --additional-symbol-graph-dir $symbol_graph_dir \
           --transform-for-static-hosting \
           --hosting-base-path swift-cross-ui \

--- a/.github/actions/compile-docs/action.yml
+++ b/.github/actions/compile-docs/action.yml
@@ -68,6 +68,25 @@ runs:
         command: x
         files: ./${{ inputs.target }}-symbol-graphs.tar.gz
 
+    - name: Restore docc build cache
+      id: cache-docc
+      uses: actions/cache@v5
+      with:
+        path: ../docc
+        key: docc-tool-771f704083804760db2dd19692fa2c13a3dd20d0
+
+    - name: Build docc
+      if: steps.cache-docc.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -eux
+        cd ../
+        git clone https://github.com/stackotter/swift-docc
+        cd swift-docc
+        git checkout 771f704083804760db2dd19692fa2c13a3dd20d0
+        swift build -c release
+        cp .build/release/docc ..
+
     - name: Compile documentation (with DocC)
       if: ${{ inputs.use-swiftpm != 'true' }}
       shell: bash
@@ -83,7 +102,7 @@ runs:
           symbol_graph_dir="$TARGET-symbol-graphs"
         fi
         echo $symbol_graph_dir
-        xcrun docc convert "$catalog" \
+        DOCC_HTML_DIR="$(xcrun --find docc)/../share/docc/render" ../docc convert "$catalog" \
           --additional-symbol-graph-dir $symbol_graph_dir \
           --transform-for-static-hosting \
           --hosting-base-path swift-cross-ui \

--- a/.github/actions/compile-docs/action.yml
+++ b/.github/actions/compile-docs/action.yml
@@ -69,14 +69,14 @@ runs:
         files: ./${{ inputs.target }}-symbol-graphs.tar.gz
 
     - name: Restore docc build cache
-      id: cache-docc
-      uses: actions/cache@v5
+      id: restore-docc-cache
+      uses: actions/cache/restore@v5
       with:
         path: ../docc
         key: docc-tool-771f704083804760db2dd19692fa2c13a3dd20d0
 
     - name: Build docc
-      if: steps.cache-docc.outputs.cache-hit != 'true'
+      if: steps.restore-docc-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -eux
@@ -86,6 +86,13 @@ runs:
         git checkout 771f704083804760db2dd19692fa2c13a3dd20d0
         swift build -c release --product docc
         cp .build/release/docc ..
+
+    - name: Restore docc build cache
+      id: cache-docc
+      uses: actions/cache/save@v5
+      with:
+        path: ../docc
+        key: ${{ steps.restore-docc-cache.outputs.cache-primary-key }}
 
     - name: Compile documentation (with DocC)
       if: ${{ inputs.use-swiftpm != 'true' }}

--- a/.github/actions/compile-docs/action.yml
+++ b/.github/actions/compile-docs/action.yml
@@ -84,7 +84,7 @@ runs:
         git clone https://github.com/stackotter/swift-docc
         cd swift-docc
         git checkout 771f704083804760db2dd19692fa2c13a3dd20d0
-        swift build -c release
+        swift build -c release --product docc
         cp .build/release/docc ..
 
     - name: Compile documentation (with DocC)

--- a/.github/actions/compile-docs/action.yml
+++ b/.github/actions/compile-docs/action.yml
@@ -72,7 +72,7 @@ runs:
       id: restore-docc-cache
       uses: actions/cache/restore@v5
       with:
-        path: ../docc
+        path: ./docc
         key: docc-tool-771f704083804760db2dd19692fa2c13a3dd20d0
 
     - name: Build docc
@@ -80,18 +80,19 @@ runs:
       shell: bash
       run: |
         set -eux
+        checkout="$(pwd)"
         cd ../
         git clone https://github.com/stackotter/swift-docc
         cd swift-docc
         git checkout 771f704083804760db2dd19692fa2c13a3dd20d0
         swift build -c release --product docc
-        cp .build/release/docc ..
+        cp .build/release/docc $checkout/docc
 
     - name: Restore docc build cache
       id: cache-docc
       uses: actions/cache/save@v5
       with:
-        path: ../docc
+        path: ./docc
         key: ${{ steps.restore-docc-cache.outputs.cache-primary-key }}
 
     - name: Compile documentation (with DocC)
@@ -109,7 +110,7 @@ runs:
           symbol_graph_dir="$TARGET-symbol-graphs"
         fi
         echo $symbol_graph_dir
-        DOCC_HTML_DIR="$(xcrun --find docc)/../share/docc/render" ../docc convert "$catalog" \
+        DOCC_HTML_DIR="$(xcrun --find docc)/../share/docc/render" ./docc convert "$catalog" \
           --additional-symbol-graph-dir $symbol_graph_dir \
           --transform-for-static-hosting \
           --hosting-base-path swift-cross-ui \

--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -338,7 +338,6 @@ jobs:
   assemble-docs:
     runs-on: macos-15
     needs: [macos, uikit, windows, linux]
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
     steps:
     - name: Setup Xcode version

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ DerivedData/
 vcpkg_installed/
 *.trace
 notes.json
+/Tools
+.docc-build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@
 - 7\. [Code formatting](#7-code-formatting)
 - 8\. [Comments](#8-comments)
 - 9\. [Documentation](#9-documentation)
-  - 9.5\. [Documentation formatting](#95-documentation-formatting)
+  - 9.5\. [Previewing documentation](#96-previewing-documentation)
+  - 9.6\. [Documentation formatting](#95-documentation-formatting)
 - 10\. [Referencing/attribution](#10-referencingattribution)
 
 ## 1. Environment setup
@@ -160,7 +161,20 @@ moreSwift’s projects use DocC to document code, and to author documentation ar
 
 If using Xcode, pressing option+cmd+/ generates a template documentation comment for the declaration that your cursor is currently on. If using another code editor with Sourcekit LSP, similar functionality is generally available as a code action.
 
-### 9.5. Documentation formatting
+### 9.5. Previewing documentation
+
+To preview documentation, run `./Scripts/preview_docs.sh` from the root of the repository.
+
+```sh
+# Preview docs (builds SwiftCrossUI first to obtain symbol graphs, and then
+# previews Sources/SwiftCrossUI/SwiftCrossUI.docc)
+./Scripts/preview_docs.sh
+
+# Preview docs without symbol graphs (faster if just working on articles/tutorials)
+SKIP_SYMBOL_GRAPHS=1 ./Scripts/preview_docs.sh
+```
+
+### 9.6. Documentation formatting
 
 1. Documentations comments should be punctuated as proper sentences (which generally means ending with a period).
 2. Use sentence case

--- a/Scripts/ensure_docc.sh
+++ b/Scripts/ensure_docc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")"
+
+# This script ensures that a build of DocC is available at ./Tools/docc. By default
+# it builds stackotter's fork of DocC which supports WebP image files.
+
+COMMIT=771f704083804760db2dd19692fa2c13a3dd20d0
+
+cd ..
+
+if [ -f ./Tools/docc ];
+then
+  exit 0
+fi
+
+mkdir -p Tools
+cd Tools
+
+# Clone and build required commit
+git clone https://github.com/stackotter/swift-docc
+cd swift-docc
+git checkout $COMMIT
+swift build -c release --product docc
+
+# Save compiled binary
+cp .build/release/docc ..
+cd ..
+
+# Clean up
+rm -rf swift-docc

--- a/Scripts/preview_docs.sh
+++ b/Scripts/preview_docs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")"
+
+# This script previews SwiftCrossUI's documentation locally. Changes to
+# Sources/SwiftCrossUI/SwiftCrossUI.docc should be refected live, but
+# changes to source documentation require running the script again.
+#
+# To skip symbol graph generation (when you don't care about symbol
+# links or source documentation) set SKIP_SYMBOL_GRAPHS=1.
+
+./ensure_docc.sh
+
+cd ..
+
+if [ -z "$DOCC_HTML_DIR"]; then
+    docc_path=""
+    if command -v xcrun >/dev/null 2>&1; then
+        # If on macOS, use xcrun to find the real docc executable
+        docc_path="$(xcrun --find docc)"
+    else
+        # If not on macOS use 'command' to discover the path of docc
+        docc_path="$(command -v docc)"
+
+        # If docc is a symlink to swiftly, then use swiftly to find the real
+        # docc executable
+        docc_path="$(realpath "$docc_path")"
+        docc_filename="$(basename "$docc_path")"
+        if [[ "$docc_filename" == "swiftly" ]]; then
+            swiftly_path="$docc_path"
+            docc_path="$(exec "$swiftly_path" run which docc)"
+        fi
+    fi
+
+    # The DocC HTML template should always be at the same location relative to
+    # the DocC executable as far as I know
+    export DOCC_HTML_DIR="$(dirname -- $docc_path)/../share/docc/render"
+fi
+
+if [[ "$SKIP_SYMBOL_GRAPHS" != "1" ]]; then
+    # Generate symbol graphs so that symbol links work
+    mkdir -p .build/symbol-graphs
+    swift build --target SwiftCrossUI \
+        -Xswiftc -emit-symbol-graph \
+        -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+fi
+
+./Tools/docc preview ./Sources/SwiftCrossUI/SwiftCrossUI.docc \
+    --additional-symbol-graph-dir .build/symbol-graphs \
+    --transform-for-static-hosting \
+    --source-service github \
+    --source-service-base-url https://github.com/moreSwift/swift-cross-ui/blob/main \
+    --checkout-path .


### PR DESCRIPTION
This updates the CI to compile documentation with my custom fork of swift-docc that supports WebP.