### PR TITLE
Android picker support

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-cwinrt",
       "state" : {
-        "revision" : "f0900d61c863ced3a230d757d5dbda7de7043deb",
-        "version" : "0.1.1"
+        "revision" : "601287a2a89e8e56e8aa53782b6054db8be0bce8",
+        "version" : "0.1.2"
       }
     },
     {

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -21,6 +21,11 @@ enum BuiltInPickerStyle: CaseIterable, Equatable {
     }
 }
 
+#if canImport(AndroidBackend)
+// TODO(bbrk24): Update this once AndroidBackend supports scrolling
+typealias ScrollView = VStack
+#endif
+
 @main
 @HotReloadable
 struct ControlsApp: App {
@@ -56,6 +61,7 @@ struct ControlsApp: App {
                             Text("Count: \(count)")
                         }
 
+                        #if !canImport(AndroidBackend)
                         VStack {
                             Text("Menu button")
                             Menu("Menu") {
@@ -125,6 +131,7 @@ struct ControlsApp: App {
                                     .frame(width: progressViewSize, height: progressViewSize)
                             }
                         #endif
+                        #endif
 
                         #if !canImport(Gtk3Backend)
                             VStack {
@@ -154,7 +161,7 @@ struct ControlsApp: App {
                                 Text("You chose: \(flavor ?? "Nothing yet!")")
                             }
 
-                            #if !os(tvOS)
+                            #if !os(tvOS) && !canImport(AndroidBackend)
                                 VStack {
                                     Text("Selected date: \(date)")
 
@@ -177,8 +184,10 @@ struct ControlsApp: App {
                         #endif
                     }.padding().disabled(!enabled)
 
+                    #if !canImport(AndroidBackend)
                     Toggle(enabled ? "Disable all" : "Enable all", isOn: $enabled)
                         .padding()
+                    #endif
                 }
             }
         }.defaultSize(width: 400, height: 600)

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -22,8 +22,8 @@ enum BuiltInPickerStyle: CaseIterable, Equatable {
 }
 
 #if canImport(AndroidBackend)
-// TODO(bbrk24): Update this once AndroidBackend supports scrolling
-typealias ScrollView = VStack
+    // TODO(bbrk24): Update this once AndroidBackend supports scrolling
+    typealias ScrollView = VStack
 #endif
 
 @main
@@ -62,75 +62,75 @@ struct ControlsApp: App {
                         }
 
                         #if !canImport(AndroidBackend)
-                        VStack {
-                            Text("Menu button")
-                            Menu("Menu") {
-                                Button("Button item") {
-                                    print("Button item clicked")
+                            VStack {
+                                Text("Menu button")
+                                Menu("Menu") {
+                                    Button("Button item") {
+                                        print("Button item clicked")
+                                    }
+                                    Toggle("Toggle item", isOn: $menuToggleState)
+                                    Menu("Submenu") {
+                                        Text("Text item 1")
+                                        Text("Text item 2")
+                                    }
                                 }
-                                Toggle("Toggle item", isOn: $menuToggleState)
-                                Menu("Submenu") {
-                                    Text("Text item 1")
-                                    Text("Text item 2")
+                            }
+
+                            #if !canImport(UIKitBackend)
+                                VStack {
+                                    Text("Toggle button")
+                                    Toggle("Toggle me!", isOn: $exampleButtonState)
+                                        .toggleStyle(.button)
+                                    Text("Currently enabled: \(exampleButtonState)")
                                 }
-                            }
-                        }
+                            #endif
 
-                        #if !canImport(UIKitBackend)
                             VStack {
-                                Text("Toggle button")
-                                Toggle("Toggle me!", isOn: $exampleButtonState)
-                                    .toggleStyle(.button)
-                                Text("Currently enabled: \(exampleButtonState)")
+                                Text("Toggle switch")
+                                Toggle("Toggle me:", isOn: $exampleSwitchState)
+                                    .toggleStyle(.switch)
+                                Text("Currently enabled: \(exampleSwitchState)")
                             }
-                        #endif
 
-                        VStack {
-                            Text("Toggle switch")
-                            Toggle("Toggle me:", isOn: $exampleSwitchState)
-                                .toggleStyle(.switch)
-                            Text("Currently enabled: \(exampleSwitchState)")
-                        }
-
-                        VStack {
-                            Text("Checkbox")
-                            Toggle("Toggle me:", isOn: $exampleCheckboxState)
-                                .toggleStyle(.checkbox)
-                            Text("Currently enabled: \(exampleCheckboxState)")
-                        }
-
-                        #if !os(tvOS)
                             VStack {
-                                Text("Slider")
-                                Slider(value: $sliderValue, in: 0...10)
-                                    .frame(maxWidth: 200)
-                                Text("Value: \(String(format: "%.02f", sliderValue))")
+                                Text("Checkbox")
+                                Toggle("Toggle me:", isOn: $exampleCheckboxState)
+                                    .toggleStyle(.checkbox)
+                                Text("Currently enabled: \(exampleCheckboxState)")
                             }
-                        #endif
 
-                        VStack {
-                            Text("Text field")
-                            TextField("Text field", text: $text)
-                            Text("Value: \(text)")
-                        }
+                            #if !os(tvOS)
+                                VStack {
+                                    Text("Slider")
+                                    Slider(value: $sliderValue, in: 0...10)
+                                        .frame(maxWidth: 200)
+                                    Text("Value: \(String(format: "%.02f", sliderValue))")
+                                }
+                            #endif
 
-                        VStack {
-                            Text("Secure text field")
-                            SecureField("Secure text field", text: $secureText)
-                            Text("Value: \(secureText)")
-                        }
-
-                        #if !os(tvOS)
                             VStack {
-                                Toggle(
-                                    "Enable ProgressView resizability",
-                                    isOn: $isProgressViewResizable)
-                                Slider(value: $progressViewSize, in: 10...100)
-                                ProgressView()
-                                    .resizable(isProgressViewResizable)
-                                    .frame(width: progressViewSize, height: progressViewSize)
+                                Text("Text field")
+                                TextField("Text field", text: $text)
+                                Text("Value: \(text)")
                             }
-                        #endif
+
+                            VStack {
+                                Text("Secure text field")
+                                SecureField("Secure text field", text: $secureText)
+                                Text("Value: \(secureText)")
+                            }
+
+                            #if !os(tvOS)
+                                VStack {
+                                    Toggle(
+                                        "Enable ProgressView resizability",
+                                        isOn: $isProgressViewResizable)
+                                    Slider(value: $progressViewSize, in: 10...100)
+                                    ProgressView()
+                                        .resizable(isProgressViewResizable)
+                                        .frame(width: progressViewSize, height: progressViewSize)
+                                }
+                            #endif
                         #endif
 
                         #if !canImport(Gtk3Backend)
@@ -185,8 +185,8 @@ struct ControlsApp: App {
                     }.padding().disabled(!enabled)
 
                     #if !canImport(AndroidBackend)
-                    Toggle(enabled ? "Disable all" : "Enable all", isOn: $enabled)
-                        .padding()
+                        Toggle(enabled ? "Disable all" : "Enable all", isOn: $enabled)
+                            .padding()
                     #endif
                 }
             }

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -97,7 +97,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     public let requiresImageUpdateOnScaleFactorChange = false
 //    public let menuImplementationStyle = MenuImplementationStyle.menuButton
     public let supportsMultipleWindows = false
-    public let supportedPickerStyles: [BackendPickerStyle] = []
+    public let supportedPickerStyles: [BackendPickerStyle] = [.menu, .radioGroup, .wheel]
     public let canOverrideWindowColorScheme = false
 //    public nonisolated let supportedDatePickerStyles: [DatePickerStyle] = [.automatic]
 
@@ -393,5 +393,82 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let width = widget.getMeasuredWidth()
         let height = widget.getMeasuredHeight()
         return SIMD2(Int(width), Int(height))
+    }
+    
+    // MARK: Picker
+    public func createPicker(style: BackendPickerStyle) -> Widget {
+        switch style {
+        case .radioGroup:
+            return CustomRadioGroup(
+                Self.activity,
+                environment: Self.env
+            ).as(AndroidKit.View.self)!
+        case .menu:
+            return CustomSpinner(
+                Self.activity,
+                environment: Self.env
+            ).as(AndroidKit.View.self)!
+        case .wheel:
+            return CustomNumberPicker(
+                Self.activity,
+                environment: Self.env
+            ).as(AndroidKit.View.self)!
+        default:
+            // TODO(bbrk24): Implement .segmented using MaterialButtonToggleGroup
+            fatalError("Unsupported picker style \(style)")
+        }
+    }
+    
+    public func updatePicker(
+        _ picker: Widget,
+        options: [String],
+        environment: EnvironmentValues,
+        onChange: @escaping (Int?) -> Void
+    ) {
+        if let picker = picker.as(CustomRadioGroup.self) {
+            let action = SwiftAction(environment: Self.env) {
+                let selectedOption = picker.getSelectedOption()
+                onChange(selectedOption < 0 ? nil : Int(selectedOption))
+            }
+            picker.update(action, options, environment.isEnabled)
+        } else if let picker = picker.as(CustomSpinner.self) {
+            let action = SwiftAction(environment: Self.env) {
+                let selectedOption = picker.getSelectedItemPosition()
+                let invalidPosition: Int32 = try! JavaClass<AndroidKit.AdapterView>().INVALID_POSITION
+                
+                onChange(selectedOption == invalidPosition ? nil : Int(selectedOption))
+            }
+            picker.update(action, options, environment.isEnabled)
+        } else if let picker = picker.as(CustomNumberPicker.self) {
+            let action = SwiftAction(environment: Self.env) {
+                let selectedOption = picker.getValue()
+                onChange(selectedOption == 0 ? nil : Int(selectedOption - 1))
+            }
+            picker.update(action, options, environment.isEnabled)
+        } else {
+            fatalError("Unexpected picker class")
+        }
+    }
+    
+    public func setSelectedOption(ofPicker picker: Widget, to selectedOption: Int?) {
+        if let picker = picker.as(CustomRadioGroup.self) {
+            picker.selectOption(Int32(selectedOption ?? -1))
+        } else if let picker = picker.as(CustomSpinner.self) {
+            if let selectedOption {
+                picker.selectOption(Int32(selectedOption))
+            } else {
+                let invalidPosition: Int32 = try! JavaClass<AndroidKit.AdapterView>().INVALID_POSITION
+                
+                picker.selectOption(invalidPosition)
+            }
+        } else if let picker = picker.as(AndroidKit.NumberPicker.self) {
+            if let selectedOption {
+                picker.setValue(Int32(selectedOption + 1))
+            } else {
+                picker.setValue(0)
+            }
+        } else {
+            fatalError("Unexpected picker class")
+        }
     }
 }

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -77,96 +77,95 @@ extension App {
 public final class AndroidBackend: BackendFeatures.BaseStubs {
     public typealias Window = Void
     public typealias Widget = AndroidKit.View
-//    public typealias Menu = Never
-//    public typealias Alert = Never
-//    public typealias Path = Never
-//    public typealias Sheet = Never
-
+    //    public typealias Menu = Never
+    //    public typealias Alert = Never
+    //    public typealias Path = Never
+    //    public typealias Sheet = Never
+    
     static let stdoutPipe = Pipe()
     static let stderrPipe = Pipe()
-
+    
     // TODO(stackotter): Dynamically determine the device class
     public let deviceClass = DeviceClass.phone
-
-//    public let defaultTableRowContentHeight = 0
-//    public let defaultTableCellVerticalPadding = 0
+    
+    //    public let defaultTableRowContentHeight = 0
+    //    public let defaultTableCellVerticalPadding = 0
     public let defaultPaddingAmount = 10
     public let scrollBarWidth = 0
     public let requiresToggleSwitchSpacer = false
     public let defaultToggleStyle = ToggleStyle.checkbox
     public let requiresImageUpdateOnScaleFactorChange = false
-//    public let menuImplementationStyle = MenuImplementationStyle.menuButton
+    //    public let menuImplementationStyle = MenuImplementationStyle.menuButton
     public let supportsMultipleWindows = false
-    public let supportedPickerStyles: [BackendPickerStyle] = [.menu, .radioGroup, .wheel]
     public let canOverrideWindowColorScheme = false
-//    public nonisolated let supportedDatePickerStyles: [DatePickerStyle] = [.automatic]
-
+    //    public nonisolated let supportedDatePickerStyles: [DatePickerStyle] = [.automatic]
+    
     /// A reference used to keep the tickler alive.
     var tickler: MainRunLoopTickler?
-
+    
     /// The JNI environment pointer. Set by ``entrypoint``.
     static var env: UnsafeMutablePointer<JNIEnv?>!
     /// The main activity. Set by ``entrypoint``.
     static var activity: Activity!
-
+    
     var helpers: AndroidBackendHelpers
-
+    
     public init() {
         helpers = AndroidBackendHelpers(environment: Self.env)
     }
-
+    
     public func runMainLoop(
         _ callback: @escaping @MainActor () -> Void
     ) {
         let tickler = MainRunLoopTickler(environment: Self.env)
         tickler.start()
         self.tickler = tickler
-
+        
         // We just fall through to return control to Java when we're done
         // setting up the initial view hierarchy.
         callback()
     }
-
+    
     public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
         // TODO(stackotter): Properly support multiple calls to createWindow
     }
-
+    
     public func updateWindow(_ window: Window, environment: EnvironmentValues) {
         // TODO(stackotter): Update window theme?
     }
-
-//    public func setCloseHandler(ofWindow window: Window, to action: @escaping () -> Void) {
-//        // TODO(stackotter): Set close handler?
-//    }
-
+    
+    //    public func setCloseHandler(ofWindow window: Window, to action: @escaping () -> Void) {
+    //        // TODO(stackotter): Set close handler?
+    //    }
+    
     public func setTitle(ofWindow window: Window, to title: String) {
         // TODO(stackotter): Handle navigation titles.
     }
-
+    
     public func setResizability(ofWindow window: Window, to resizable: Bool) {}
-
+    
     public func setChild(ofWindow window: Window, to child: Widget) {
         Self.activity.setContentView(child)
     }
-
+    
     public func size(ofWindow window: Window) -> SIMD2<Int> {
         let width = Int(helpers.getWindowWidth(Self.activity))
         let height = Int(helpers.getWindowHeight(Self.activity))
         return SIMD2(Int(width), Int(height))
     }
-
+    
     public func isWindowProgrammaticallyResizable(_ window: Window) -> Bool {
         false
     }
-
+    
     public func setSize(ofWindow window: Window, to newSize: SIMD2<Int>) {
         log("warning: Attempted to set size of Android window")
     }
-
+    
     public func setSizeLimits(ofWindow window: Void, minimum minimumSize: SIMD2<Int>, maximum maximumSize: SIMD2<Int>?) {}
-
-//    public func setBehaviors(ofWindow window: Void, closable: Bool, minimizable: Bool, resizable: Bool) {}
-
+    
+    //    public func setBehaviors(ofWindow window: Void, closable: Bool, minimizable: Bool, resizable: Bool) {}
+    
     public func setResizeHandler(
         ofWindow window: Window,
         to action: @escaping (_ newSize: SIMD2<Int>) -> Void
@@ -174,40 +173,40 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         // TODO(stackotter): Handle orientation changes and other changes such
         //   as density changes
     }
-
+    
     public func show(window: Window) {
         log("Show window")
     }
-
+    
     public func activate(window: Window) {}
-
-//    public func setApplicationMenu(
-//        _ submenus: [ResolvedMenu.Submenu],
-//        environment: EnvironmentValues
-//    ) {
-//        // TODO(stackotter): Register app menu items as shortcuts when we support keyboard
-//        //   shortcuts.
-//    }
-
-//    public func setIncomingURLHandler(to action: @escaping (Foundation.URL) -> Void) {
-//        // TODO(stackotter): Handle incoming URLs
-//    }
-
+    
+    //    public func setApplicationMenu(
+    //        _ submenus: [ResolvedMenu.Submenu],
+    //        environment: EnvironmentValues
+    //    ) {
+    //        // TODO(stackotter): Register app menu items as shortcuts when we support keyboard
+    //        //   shortcuts.
+    //    }
+    
+    //    public func setIncomingURLHandler(to action: @escaping (Foundation.URL) -> Void) {
+    //        // TODO(stackotter): Handle incoming URLs
+    //    }
+    
     public func runInMainThread(action: @escaping @MainActor () -> Void) {
         Task { @MainActor in
             action()
         }
     }
-
+    
     public func computeRootEnvironment(defaultEnvironment: EnvironmentValues) -> EnvironmentValues {
         // TODO(stackotter): React to system theme
         defaultEnvironment
     }
-
+    
     public func setRootEnvironmentChangeHandler(to action: @escaping @Sendable @MainActor () -> Void) {
         // TODO(stackotter): Listen for system theme changes
     }
-
+    
     public func computeWindowEnvironment(
         window: Window,
         rootEnvironment: EnvironmentValues
@@ -218,7 +217,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         //   case we may need to handle per-window pixel density.
         rootEnvironment
     }
-
+    
     public func setWindowEnvironmentChangeHandler(
         of window: Window,
         to action: @escaping @Sendable @MainActor () -> Void
@@ -226,24 +225,24 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         // TODO(stackotter): React to per-window environment changes. See
         //   computeWindowEnvironment
     }
-
+    
     public func show(widget: Widget) {}
-
+    
     public func createContainer() -> Widget {
         RelativeLayout(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-
+    
     public func removeAllChildren(of container: Widget) {
         let container = container.as(ViewGroup.self)!
         container.removeAllViews()
     }
-
+    
     public func insert(_ child: Widget, into container: Widget, at index: Int) {
         let container = container.as(ViewGroup.self)!
         container.addView(child, Int32(index))
     }
-
+    
     public func setPosition(
         ofChildAt index: Int,
         in container: Widget,
@@ -251,19 +250,19 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     ) {
         let container = container.as(ViewGroup.self)!
         let child = container.getChildAt(Int32(index))!
-
+        
         let layoutParams = child.getLayoutParams().as(RelativeLayout.LayoutParams.self)!
         layoutParams.leftMargin = Int32(position.x)
         layoutParams.topMargin = Int32(position.y)
-
+        
         child.setLayoutParams(layoutParams.as(ViewGroup.LayoutParams.self))
     }
-
+    
     public func remove(childAt index: Int, from container: Widget) {
         let container = container.as(RelativeLayout.self)!
         container.removeViewAt(Int32(index))
     }
-
+    
     public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
         let container = container.as(ViewGroup.self)!
         let largerIndex = Int32(max(firstIndex, secondIndex))
@@ -275,7 +274,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         container.addView(view2, smallerIndex)
         container.addView(view1, largerIndex)
     }
-
+    
     public func naturalSize(of widget: Widget) -> SIMD2<Int> {
         let measureSpecClass = try! JavaClass<AndroidKit.View.MeasureSpec>(
             environment: Self.env
@@ -288,27 +287,27 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let height = widget.getMeasuredHeight()
         return SIMD2(Int(width), Int(height))
     }
-
+    
     public func setSize(of widget: Widget, to size: SIMD2<Int>) {
         let layoutParams = widget.getLayoutParams()!
         layoutParams.width = Int32(size.x)
         layoutParams.height = Int32(size.y)
         widget.setLayoutParams(layoutParams)
-
+        
         // TODO(stackotter): Use density-adaptive units everywhere
     }
-
+    
     public func createButton() -> Widget {
         AndroidKit.Button(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-
+    
     /// Converts a Swift String to a Java CharSequence.
     private func charSequence(from string: String) -> CharSequence {
         let jstring = JavaString(string, environment: Self.env)
         return jstring.as(CharSequence.self)!
     }
-
+    
     public func updateButton(
         _ button: Widget,
         label: String,
@@ -321,12 +320,12 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let listener = ViewOnClickListener(action: action, environment: Self.env)
         button.setOnClickListener(listener.as(AndroidView.View.OnClickListener.self))
     }
-
+    
     public func createTextField() -> Widget {
         CustomEditText(activity: Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-
+    
     public func updateTextField(
         _ textField: Widget,
         placeholder: String,
@@ -350,22 +349,22 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         )
         textField.setOnSubmit(SwiftAction(environment: Self.env, action: onSubmit))
     }
-
+    
     public func setContent(ofTextField textField: Widget, to content: String) {
         let textField = textField.as(AndroidKit.TextView.self)!
         textField.setText(charSequence(from: content))
     }
-
+    
     public func getContent(ofTextField textField: Widget) -> String {
         let textField = textField.as(AndroidKit.TextView.self)!
         return textField.getText().toString()
     }
-
+    
     public func createTextView() -> Widget {
         AndroidKit.TextView(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-
+    
     public func updateTextView(
         _ textView: Widget,
         content: String,
@@ -376,7 +375,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         textView.setText(content.as(CharSequence.self))
         // TODO: Handle environment
     }
-
+    
     public func size(
         of text: String,
         whenDisplayedIn widget: Widget,
@@ -394,8 +393,14 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let height = widget.getMeasuredHeight()
         return SIMD2(Int(width), Int(height))
     }
+}
     
-    // MARK: Picker
+// MARK: Picker
+extension AndroidBackend: BackendFeatures.Pickers {
+    public var supportedPickerStyles: [BackendPickerStyle] {
+        [.menu, .radioGroup, .wheel]
+    }
+
     public func createPicker(style: BackendPickerStyle) -> Widget {
         switch style {
         case .radioGroup:

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -81,13 +81,13 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     //    public typealias Alert = Never
     //    public typealias Path = Never
     //    public typealias Sheet = Never
-    
+
     static let stdoutPipe = Pipe()
     static let stderrPipe = Pipe()
-    
+
     // TODO(stackotter): Dynamically determine the device class
     public let deviceClass = DeviceClass.phone
-    
+
     //    public let defaultTableRowContentHeight = 0
     //    public let defaultTableCellVerticalPadding = 0
     public let defaultPaddingAmount = 10
@@ -99,21 +99,21 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     public let supportsMultipleWindows = false
     public let canOverrideWindowColorScheme = false
     //    public nonisolated let supportedDatePickerStyles: [DatePickerStyle] = [.automatic]
-    
+
     /// A reference used to keep the tickler alive.
     var tickler: MainRunLoopTickler?
-    
+
     /// The JNI environment pointer. Set by ``entrypoint``.
     static var env: UnsafeMutablePointer<JNIEnv?>!
     /// The main activity. Set by ``entrypoint``.
     static var activity: Activity!
-    
+
     var helpers: AndroidBackendHelpers
-    
+
     public init() {
         helpers = AndroidBackendHelpers(environment: Self.env)
     }
-    
+
     public func runMainLoop(
         _ callback: @escaping @MainActor () -> Void
     ) {
@@ -125,47 +125,47 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         // setting up the initial view hierarchy.
         callback()
     }
-    
+
     public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
         // TODO(stackotter): Properly support multiple calls to createWindow
     }
-    
+
     public func updateWindow(_ window: Window, environment: EnvironmentValues) {
         // TODO(stackotter): Update window theme?
     }
-    
+
     //    public func setCloseHandler(ofWindow window: Window, to action: @escaping () -> Void) {
     //        // TODO(stackotter): Set close handler?
     //    }
-    
+
     public func setTitle(ofWindow window: Window, to title: String) {
         // TODO(stackotter): Handle navigation titles.
     }
-    
+
     public func setResizability(ofWindow window: Window, to resizable: Bool) {}
-    
+
     public func setChild(ofWindow window: Window, to child: Widget) {
         Self.activity.setContentView(child)
     }
-    
+
     public func size(ofWindow window: Window) -> SIMD2<Int> {
         let width = Int(helpers.getWindowWidth(Self.activity))
         let height = Int(helpers.getWindowHeight(Self.activity))
         return SIMD2(Int(width), Int(height))
     }
-    
+
     public func isWindowProgrammaticallyResizable(_ window: Window) -> Bool {
         false
     }
-    
+
     public func setSize(ofWindow window: Window, to newSize: SIMD2<Int>) {
         log("warning: Attempted to set size of Android window")
     }
-    
+
     public func setSizeLimits(ofWindow window: Void, minimum minimumSize: SIMD2<Int>, maximum maximumSize: SIMD2<Int>?) {}
-    
+
     //    public func setBehaviors(ofWindow window: Void, closable: Bool, minimizable: Bool, resizable: Bool) {}
-    
+
     public func setResizeHandler(
         ofWindow window: Window,
         to action: @escaping (_ newSize: SIMD2<Int>) -> Void
@@ -173,13 +173,13 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         // TODO(stackotter): Handle orientation changes and other changes such
         //   as density changes
     }
-    
+
     public func show(window: Window) {
         log("Show window")
     }
-    
+
     public func activate(window: Window) {}
-    
+
     //    public func setApplicationMenu(
     //        _ submenus: [ResolvedMenu.Submenu],
     //        environment: EnvironmentValues
@@ -187,26 +187,26 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     //        // TODO(stackotter): Register app menu items as shortcuts when we support keyboard
     //        //   shortcuts.
     //    }
-    
+
     //    public func setIncomingURLHandler(to action: @escaping (Foundation.URL) -> Void) {
     //        // TODO(stackotter): Handle incoming URLs
     //    }
-    
+
     public func runInMainThread(action: @escaping @MainActor () -> Void) {
         Task { @MainActor in
             action()
         }
     }
-    
+
     public func computeRootEnvironment(defaultEnvironment: EnvironmentValues) -> EnvironmentValues {
         // TODO(stackotter): React to system theme
         defaultEnvironment
     }
-    
+
     public func setRootEnvironmentChangeHandler(to action: @escaping @Sendable @MainActor () -> Void) {
         // TODO(stackotter): Listen for system theme changes
     }
-    
+
     public func computeWindowEnvironment(
         window: Window,
         rootEnvironment: EnvironmentValues
@@ -217,7 +217,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         //   case we may need to handle per-window pixel density.
         rootEnvironment
     }
-    
+
     public func setWindowEnvironmentChangeHandler(
         of window: Window,
         to action: @escaping @Sendable @MainActor () -> Void
@@ -225,24 +225,24 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         // TODO(stackotter): React to per-window environment changes. See
         //   computeWindowEnvironment
     }
-    
+
     public func show(widget: Widget) {}
-    
+
     public func createContainer() -> Widget {
         RelativeLayout(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-    
+
     public func removeAllChildren(of container: Widget) {
         let container = container.as(ViewGroup.self)!
         container.removeAllViews()
     }
-    
+
     public func insert(_ child: Widget, into container: Widget, at index: Int) {
         let container = container.as(ViewGroup.self)!
         container.addView(child, Int32(index))
     }
-    
+
     public func setPosition(
         ofChildAt index: Int,
         in container: Widget,
@@ -257,12 +257,12 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         
         child.setLayoutParams(layoutParams.as(ViewGroup.LayoutParams.self))
     }
-    
+
     public func remove(childAt index: Int, from container: Widget) {
         let container = container.as(RelativeLayout.self)!
         container.removeViewAt(Int32(index))
     }
-    
+
     public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
         let container = container.as(ViewGroup.self)!
         let largerIndex = Int32(max(firstIndex, secondIndex))
@@ -274,7 +274,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         container.addView(view2, smallerIndex)
         container.addView(view1, largerIndex)
     }
-    
+
     public func naturalSize(of widget: Widget) -> SIMD2<Int> {
         let measureSpecClass = try! JavaClass<AndroidKit.View.MeasureSpec>(
             environment: Self.env
@@ -287,7 +287,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let height = widget.getMeasuredHeight()
         return SIMD2(Int(width), Int(height))
     }
-    
+
     public func setSize(of widget: Widget, to size: SIMD2<Int>) {
         let layoutParams = widget.getLayoutParams()!
         layoutParams.width = Int32(size.x)
@@ -296,18 +296,18 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         
         // TODO(stackotter): Use density-adaptive units everywhere
     }
-    
+
     public func createButton() -> Widget {
         AndroidKit.Button(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-    
+
     /// Converts a Swift String to a Java CharSequence.
     private func charSequence(from string: String) -> CharSequence {
         let jstring = JavaString(string, environment: Self.env)
         return jstring.as(CharSequence.self)!
     }
-    
+
     public func updateButton(
         _ button: Widget,
         label: String,
@@ -320,12 +320,12 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         let listener = ViewOnClickListener(action: action, environment: Self.env)
         button.setOnClickListener(listener.as(AndroidView.View.OnClickListener.self))
     }
-    
+
     public func createTextField() -> Widget {
         CustomEditText(activity: Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-    
+
     public func updateTextField(
         _ textField: Widget,
         placeholder: String,
@@ -349,22 +349,22 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         )
         textField.setOnSubmit(SwiftAction(environment: Self.env, action: onSubmit))
     }
-    
+
     public func setContent(ofTextField textField: Widget, to content: String) {
         let textField = textField.as(AndroidKit.TextView.self)!
         textField.setText(charSequence(from: content))
     }
-    
+
     public func getContent(ofTextField textField: Widget) -> String {
         let textField = textField.as(AndroidKit.TextView.self)!
         return textField.getText().toString()
     }
-    
+
     public func createTextView() -> Widget {
         AndroidKit.TextView(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
-    
+
     public func updateTextView(
         _ textView: Widget,
         content: String,
@@ -375,7 +375,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         textView.setText(content.as(CharSequence.self))
         // TODO: Handle environment
     }
-    
+
     public func size(
         of text: String,
         whenDisplayedIn widget: Widget,
@@ -403,24 +403,24 @@ extension AndroidBackend: BackendFeatures.Pickers {
 
     public func createPicker(style: BackendPickerStyle) -> Widget {
         switch style {
-        case .radioGroup:
-            return CustomRadioGroup(
-                Self.activity,
-                environment: Self.env
-            ).as(AndroidKit.View.self)!
-        case .menu:
-            return CustomSpinner(
-                Self.activity,
-                environment: Self.env
-            ).as(AndroidKit.View.self)!
-        case .wheel:
-            return CustomNumberPicker(
-                Self.activity,
-                environment: Self.env
-            ).as(AndroidKit.View.self)!
-        default:
-            // TODO(bbrk24): Implement .segmented using MaterialButtonToggleGroup
-            fatalError("Unsupported picker style \(style)")
+            case .radioGroup:
+                return CustomRadioGroup(
+                    Self.activity,
+                    environment: Self.env
+                ).as(AndroidKit.View.self)!
+            case .menu:
+                return CustomSpinner(
+                    Self.activity,
+                    environment: Self.env
+                ).as(AndroidKit.View.self)!
+            case .wheel:
+                return CustomNumberPicker(
+                    Self.activity,
+                    environment: Self.env
+                ).as(AndroidKit.View.self)!
+            default:
+                // TODO(bbrk24): Implement .segmented using MaterialButtonToggleGroup
+                fatalError("Unsupported picker style \(style)")
         }
     }
     

--- a/Sources/AndroidBackend/CustomNumberPicker.swift
+++ b/Sources/AndroidBackend/CustomNumberPicker.swift
@@ -1,0 +1,21 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomNumberPicker",
+    extends: AndroidKit.NumberPicker.self
+)
+class CustomNumberPicker: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: Activity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func update(_ onChange: SwiftAction?, _ options: [String], _ isEnabled: Bool)
+    
+    // Inheritied from NumberPicker; only present to avoid the extra as() call Swift-side.
+    @JavaMethod
+    func getValue() -> Int32
+}

--- a/Sources/AndroidBackend/CustomRadioGroup.swift
+++ b/Sources/AndroidBackend/CustomRadioGroup.swift
@@ -1,0 +1,23 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomRadioGroup",
+    extends: AndroidKit.RadioGroup.self
+)
+class CustomRadioGroup: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: Activity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func update(_ onChange: SwiftAction?, _ options: [String], _ isEnabled: Bool)
+    
+    @JavaMethod
+    func getSelectedOption() -> Int32
+    
+    @JavaMethod
+    func selectOption(_ index: Int32)
+}

--- a/Sources/AndroidBackend/CustomSpinner.swift
+++ b/Sources/AndroidBackend/CustomSpinner.swift
@@ -1,0 +1,24 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomSpinner",
+    extends: AndroidKit.Spinner.self
+)
+class CustomSpinner: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: Activity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func update(_ onChange: SwiftAction?, _ options: [String], _ isEnabled: Bool)
+    
+    // Inheritied from Spinner; only present to avoid the extra as() call Swift-side.
+    @JavaMethod
+    func getSelectedItemPosition() -> Int32
+    
+    @JavaMethod
+    func selectOption(_ selectedOption: Int32)
+}

--- a/Sources/AndroidBackend/Kotlin/CustomNumberPicker.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomNumberPicker.kt
@@ -1,0 +1,21 @@
+package dev.swiftcrossui.androidbackend
+
+import android.app.Activity
+import android.widget.NumberPicker
+
+class CustomNumberPicker(activity: Activity): NumberPicker(activity) {
+    init {
+        minValue = 0
+    }
+    
+    fun update(onChange: SwiftAction, options: Array<String>, isEnabled: Boolean) {
+        maxValue = options.size
+        displayedValues = arrayOf("") + options
+        
+        setOnValueChangedListener { _, _, _ ->
+            onChange.call()
+        }
+        
+        setEnabled(isEnabled)
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/CustomRadioGroup.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomRadioGroup.kt
@@ -1,0 +1,58 @@
+package dev.swiftcrossui.androidbackend
+
+import android.app.Activity
+import android.widget.RadioButton
+import android.widget.RadioGroup
+
+class CustomRadioGroup(activity: Activity): RadioGroup(activity) {
+    fun getSelectedOption() = getCheckedRadioButtonId()
+    
+    fun update(onChange: SwiftAction, options: Array<String>, isEnabled: Boolean) {
+        val optionCount = childCount
+        if (optionCount < options.size) {
+            for (i in 0..<childCount) {
+                val button = getChildAt(i) as RadioButton
+                button.text = options[i]
+                button.setEnabled(isEnabled)
+            }
+            
+            for (i in optionCount..<options.size) {
+                val button = RadioButton(context)
+                button.text = options[i]
+                button.id = i
+                button.setEnabled(isEnabled)
+                addView(button)
+            }
+        } else {
+            for (i in 0..<options.size) {
+                val button = getChildAt(i) as RadioButton
+                button.text = options[i]
+                button.setEnabled(isEnabled)
+            }
+            
+                    
+            for (i in (options.size..<optionCount).reversed()) {
+                removeViewAt(i)
+            }
+        }
+        
+        setOnCheckedChangeListener { _, _ ->
+            onChange.call()
+        }
+    }
+    
+    fun selectOption(index: Int) {
+        val oldIndex = getCheckedRadioButtonId()
+        if (oldIndex == index) return
+        
+        if (oldIndex >= 0) {
+            val oldButton = getChildAt(oldIndex) as RadioButton
+            oldButton.isChecked = false
+        }
+        
+        if (index >= 0) {
+            val newButton = getChildAt(index) as RadioButton
+            newButton.isChecked = true
+        }
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/CustomSpinner.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomSpinner.kt
@@ -1,0 +1,48 @@
+package dev.swiftcrossui.androidbackend
+
+import android.R
+import android.app.Activity
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+
+class CustomSpinner(activity: Activity): Spinner(activity, Spinner.MODE_DROPDOWN) {
+    // I'm not 100% sure why, but without this (and the check in onItemSelected),
+    // update() was being spammed, making it impossible for the user to select anything.
+    private var oldSelectedPosition = AdapterView.INVALID_POSITION
+    
+    fun update(onChange: SwiftAction, options: Array<String>, isEnabled: Boolean) {
+        setAdapter(ArrayAdapter(context, R.layout.simple_list_item_1, options))
+        
+        setOnItemSelectedListener(object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(
+                parent: AdapterView<*>,
+                view: View?,
+                position: Int,
+                id: Long
+            ) {
+                if (position != oldSelectedPosition) {
+                    onChange.call()
+                }
+                oldSelectedPosition = position
+            }
+            
+            override fun onNothingSelected(parent: AdapterView<*>) {
+                onItemSelected(
+                    parent,
+                    null,
+                    AdapterView.INVALID_POSITION,
+                    AdapterView.INVALID_ROW_ID
+                )
+            }
+        })
+        
+        setEnabled(isEnabled)
+    }
+    
+    fun selectOption(index: Int) {
+        setSelection(index)
+        oldSelectedPosition = index
+    }
+}


### PR DESCRIPTION
Gets the ControlsExample running on Android, and adds support for menu, radio button, and wheel-style pickers. Segmented picker support is possible in the future if we can import Material.