### PR TITLE
Fix AppKit menu pickers

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,6 +1,69 @@
 {
-  "originHash" : "b16f5ed87f8ee3560e03aa22270b97057512d43da2e496e2fa272f048bba8a39",
+  "originHash" : "ae277877a5fa3bf94d38ad6fec0446528fdf195ce247894e1352408de4df18f6",
   "pins" : [
+    {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
+      }
+    },
+    {
+      "identity" : "androidkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/moreSwift/AndroidKit",
+      "state" : {
+        "revision" : "ef885e5d6248397b520327799dec1d3ddc808819",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "async-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/async-collections.git",
+      "state" : {
+        "revision" : "726af96095a19df6b8053ddbaed0a727aa70ccb2",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "asyncprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gregcotten/AsyncProcess",
+      "state" : {
+        "revision" : "3a506bb36e4aa54eb3f1b13f15e636c68ee3eb19",
+        "version" : "0.0.5"
+      }
+    },
+    {
+      "identity" : "csprogress",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gregcotten/CSProgress",
+      "state" : {
+        "revision" : "b831bb234a8a2af02ccc04d6e91a62f7dabb7de4",
+        "version" : "0.0.1"
+      }
+    },
+    {
+      "identity" : "errorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/ErrorKit",
+      "state" : {
+        "revision" : "1c30f90abe4118773e89b819d6b5db91432a81a5",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox",
+      "state" : {
+        "revision" : "f9d9a180fca7a1783f4da30a4f0a73533a75b4fd",
+        "version" : "0.26.1"
+      }
+    },
     {
       "identity" : "jpeg",
       "kind" : "remoteSourceControl",
@@ -8,6 +71,15 @@
       "state" : {
         "revision" : "a27e47f49479993b2541bc5f5c95d9354ed567a0",
         "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "jsonutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/JSONUtilities.git",
+      "state" : {
+        "revision" : "128d2ffc22467f69569ef8ff971683e2393191a0",
+        "version" : "4.2.0"
       }
     },
     {
@@ -29,6 +101,113 @@
       }
     },
     {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "rainbow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Rainbow",
+      "state" : {
+        "revision" : "cdf146ae671b2624917648b61c908d1244b98ca1",
+        "version" : "4.2.1"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-android-native",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
+      "state" : {
+        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "6c050d5ef8e1aa6342528460db614e9770d7f804",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-bundler",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/moreSwift/swift-bundler",
+      "state" : {
+        "revision" : "6527cb29084f79cb4d2300f98acd7c057abb4a67"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates",
+      "state" : {
+        "revision" : "7d5f6124c91a2d06fb63a811695a3400d15a100e",
+        "version" : "1.17.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
       "identity" : "swift-cwinrt",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-cwinrt",
@@ -38,12 +217,57 @@
       }
     },
     {
+      "identity" : "swift-filestreamer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sersoft-gmbh/swift-filestreamer",
+      "state" : {
+        "revision" : "b01ff214cc629718a8729f33d2a8b88e47532dbd",
+        "version" : "0.6.0"
+      }
+    },
+    {
+      "identity" : "swift-ico",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-ico",
+      "state" : {
+        "revision" : "033883c75b92af91c9b010b629ad6e0135aa3d64",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "swift-image-formats",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-image-formats",
       "state" : {
         "revision" : "d735e0ed3d4a4aed50f4042494e7c769b5b70229",
         "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-inotify",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sersoft-gmbh/swift-inotify",
+      "state" : {
+        "revision" : "aaaaff43d5ddfe05f18c373fd811cc45f9301c86",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-java",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-java",
+      "state" : {
+        "revision" : "3d52a15db42c4d5ef322fde074626106b9bf82d7",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-java-jni-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-java-jni-core",
+      "state" : {
+        "revision" : "b440a0be98381550cf189c903782e817619ffa05",
+        "version" : "0.5.1"
       }
     },
     {
@@ -74,12 +298,48 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "4a9a97111099376854a7f8f0f9f88b9d61f52eff",
+        "version" : "2.92.2"
+      }
+    },
+    {
+      "identity" : "swift-parsing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-parsing",
+      "state" : {
+        "revision" : "f51d409e7a9571b67112fde55a5250d5d49ed8bc",
+        "version" : "0.15.0"
+      }
+    },
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "13d087685b95d64d6aac9b94500d347bbe84c39b",
+        "version" : "0.4.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
         "version" : "603.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {
@@ -125,6 +385,96 @@
       "state" : {
         "revision" : "73d5d19c39c523c92355027dd13aee445fc627a7",
         "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "swiftcli",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jakeheis/SwiftCLI.git",
+      "state" : {
+        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+        "version" : "6.0.3"
+      }
+    },
+    {
+      "identity" : "swiftjavalang",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftJavaLang.git",
+      "state" : {
+        "revision" : "b60871fd650b81b142a1d6a62d7d440ea1e9bff7",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "swiftkotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftKotlin.git",
+      "state" : {
+        "revision" : "f408b73ebb86a33411f27a668e2d843a10f007c2",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "tomlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/TOMLKit",
+      "state" : {
+        "revision" : "fc32cb1b94aa2f8721c1585341ef723a0b4a6ab8",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version",
+      "state" : {
+        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
+        "version" : "2.2.0"
+      }
+    },
+    {
+      "identity" : "xcodegen",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/XcodeGen",
+      "state" : {
+        "revision" : "21ac9944b0ab546a07422dbed86f33dd2ebd76f8",
+        "version" : "2.44.1"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj",
+      "state" : {
+        "revision" : "b1caa062d4aaab3e3d2bed5fe0ac5f8ce9bf84f4",
+        "version" : "8.27.7"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CoreOffice/XMLCoder",
+      "state" : {
+        "revision" : "5e1ada828d2618ecb79c974e03f79c8f4df90b71",
+        "version" : "0.18.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
+      }
+    },
+    {
+      "identity" : "zipfoundationmodern",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gregcotten/ZIPFoundationModern",
+      "state" : {
+        "revision" : "649393f312e1cd0e6dabc1e28cacaaaf7204c766",
+        "version" : "0.0.5"
       }
     },
     {

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -246,7 +246,6 @@ public final class AppKitBackend: AppBackend {
                 return NSCustomMenuItem.separator()
             case .submenu(let submenu):
                 return renderSubmenu(submenu, environment: environment)
-
             case .modifiedEnvironment(let item, let modification):
                 return renderMenuItem(
                     item,
@@ -772,12 +771,25 @@ public final class AppKitBackend: AppBackend {
     ) {
         if let picker = picker as? NSPopUpButton {
             picker.isEnabled = environment.isEnabled
-            picker.menu?.removeAllItems()
-            for option in options {
-                let item = NSMenuItem()
+            
+            let menu = picker.menu!
+            
+            for (item, option) in zip(menu.items, options) {
                 item.attributedTitle = Self.attributedString(for: option, in: environment)
-                picker.menu?.addItem(item)
             }
+            
+            if menu.numberOfItems < options.count {
+                for i in menu.numberOfItems..<options.count {
+                    let item = NSMenuItem()
+                    item.attributedTitle = Self.attributedString(for: options[i], in: environment)
+                    menu.addItem(item)
+                }
+            } else {
+                for i in (options.count..<menu.numberOfItems).reversed() {
+                    menu.removeItem(at: i)
+                }
+            }
+            
             picker.onAction = { picker in
                 let picker = picker as! NSPopUpButton
                 onChange(picker.indexOfSelectedItem)


### PR DESCRIPTION
Fixes #535 

This PR applies the behavior that other backends were already doing -- instead of throwing out and recreating the menu on every update, update the menu items in place, and only delete or add menu items when necessary.