### PR TITLE
Implement toggles on Android

### DIFF
--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -75,30 +75,32 @@ struct ControlsApp: App {
                                     }
                                 }
                             }
+                        #endif
 
-                            #if !canImport(UIKitBackend)
-                                VStack {
-                                    Text("Toggle button")
-                                    Toggle("Toggle me!", isOn: $exampleButtonState)
-                                        .toggleStyle(.button)
-                                    Text("Currently enabled: \(exampleButtonState)")
-                                }
-                            #endif
-
+                        #if !canImport(UIKitBackend)
                             VStack {
-                                Text("Toggle switch")
-                                Toggle("Toggle me:", isOn: $exampleSwitchState)
-                                    .toggleStyle(.switch)
-                                Text("Currently enabled: \(exampleSwitchState)")
+                                Text("Toggle button")
+                                Toggle("Toggle me!", isOn: $exampleButtonState)
+                                    .toggleStyle(.button)
+                                Text("Currently enabled: \(exampleButtonState)")
                             }
+                        #endif
 
-                            VStack {
-                                Text("Checkbox")
-                                Toggle("Toggle me:", isOn: $exampleCheckboxState)
-                                    .toggleStyle(.checkbox)
-                                Text("Currently enabled: \(exampleCheckboxState)")
-                            }
+                        VStack {
+                            Text("Toggle switch")
+                            Toggle("Toggle me:", isOn: $exampleSwitchState)
+                                .toggleStyle(.switch)
+                            Text("Currently enabled: \(exampleSwitchState)")
+                        }
 
+                        VStack {
+                            Text("Checkbox")
+                            Toggle("Toggle me:", isOn: $exampleCheckboxState)
+                                .toggleStyle(.checkbox)
+                            Text("Currently enabled: \(exampleCheckboxState)")
+                        }
+
+                        #if !canImport(AndroidBackend)
                             #if !os(tvOS)
                                 VStack {
                                     Text("Slider")
@@ -184,10 +186,8 @@ struct ControlsApp: App {
                         #endif
                     }.padding().disabled(!enabled)
 
-                    #if !canImport(AndroidBackend)
-                        Toggle(enabled ? "Disable all" : "Enable all", isOn: $enabled)
-                            .padding()
-                    #endif
+                    Toggle(enabled ? "Disable all" : "Enable all", isOn: $enabled)
+                        .padding()
                 }
             }
         }.defaultSize(width: 400, height: 600)

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -92,8 +92,6 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     //    public let defaultTableCellVerticalPadding = 0
     public let defaultPaddingAmount = 10
     public let scrollBarWidth = 0
-    public let requiresToggleSwitchSpacer = false
-    public let defaultToggleStyle = ToggleStyle.checkbox
     public let requiresImageUpdateOnScaleFactorChange = false
     //    public let menuImplementationStyle = MenuImplementationStyle.menuButton
     public let supportsMultipleWindows = false
@@ -475,5 +473,96 @@ extension AndroidBackend: BackendFeatures.Pickers {
         } else {
             fatalError("Unexpected picker class")
         }
+    }
+}
+
+// MARK: Toggles
+extension AndroidBackend: BackendFeatures.ToggleButtons, BackendFeatures.Checkboxes, BackendFeatures.Switches {
+    public var requiresToggleSwitchSpacer: Bool { false }
+
+    public func createToggle() -> Widget {
+        AndroidKit.ToggleButton(
+            Self.activity,
+            environment: Self.env
+        )
+    }
+
+    public func createCheckbox() -> Widget {
+        AndroidKit.CheckBox(
+            Self.activity,
+            environment: Self.env
+        )
+    }
+
+    public func createSwitch() -> Widget {
+        AndroidKit.Switch(
+            Self.activity,
+            environment: Self.env
+        )
+    }
+
+    private func updateCompoundButton(
+        _ button: AndroidKit.CompoundButton,
+        environment: EnvironmentValues,
+        onChange: @escaping (Bool) -> Void
+    ) {
+        button.setEnabled(environment.isEnabled)
+
+        let action = SwiftAction(environment: Self.env) {
+            let checked = button.isChecked()
+            onChange(checked)
+        }
+        let listener = CustomOnCheckedChangeListener(action, environment: Self.env)
+
+        button.setOnCheckedChangeListener(
+            listener.as(AndroidKit.CompoundButton.OnCheckedChangeListener.self)!
+        )
+    }
+
+    public func updateToggle(
+        _ toggle: Widget,
+        label: String,
+        environment: EnvironmentValues,
+        onChange: @escaping (Bool) -> Void
+    ) {
+        let toggle = toggle.as(AndroidKit.ToggleButton.self)!
+        updateCompoundButton(toggle, environment: environment, onChange: onChange)
+
+        let charSequence = charSequence(from: label)
+        toggle.setTextOn(charSequence)
+        toggle.setTextOff(charSequence)
+    }
+
+    public func updateCheckbox(
+        _ checkboxWidget: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (Bool) -> Void
+    ) {
+        let checkboxWidget = checkboxWidget.as(AndroidKit.CompoundButton.self)!
+        updateCompoundButton(checkboxWidget, environment: environment, onChange: onChange)
+    }
+
+    public func updateSwitch(
+        _ switchWidget: Widget,
+        environment: EnvironmentValues,
+        onChange: @escaping (Bool) -> Void
+    ) {
+        let switchWidget = switchWidget.as(AndroidKit.CompoundButton.self)!
+        updateCompoundButton(switchWidget, environment: environment, onChange: onChange)
+    }
+
+    public func setState(ofToggle toggle: Widget, to state: Bool) {
+        let toggle = toggle.as(AndroidKit.CompoundButton.self)!
+        toggle.setChecked(state)
+    }
+
+    public func setState(ofCheckbox checkboxWidget: Widget, to state: Bool) {
+        let checkboxWidget = checkboxWidget.as(AndroidKit.CompoundButton.self)!
+        checkboxWidget.setChecked(state)
+    }
+
+    public func setState(ofSwitch switchWidget: Widget, to state: Bool) {
+        let switchWidget = switchWidget.as(AndroidKit.CompoundButton.self)!
+        switchWidget.setChecked(state)
     }
 }

--- a/Sources/AndroidBackend/CustomOnCheckedChangeListener.swift
+++ b/Sources/AndroidBackend/CustomOnCheckedChangeListener.swift
@@ -1,0 +1,14 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomOnCheckedChangeListener",
+    implements: AndroidKit.CompoundButton.OnCheckedChangeListener.self
+)
+class CustomOnCheckedChangeListener: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ action: SwiftAction?,
+        environment: JNIEnvironment? = nil
+    )
+}

--- a/Sources/AndroidBackend/Kotlin/CustomOnCheckedChangeListener.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomOnCheckedChangeListener.kt
@@ -1,0 +1,14 @@
+package dev.swiftcrossui.androidbackend
+
+import android.widget.CompoundButton
+
+class CustomOnCheckedChangeListener(
+    private val action: SwiftAction
+): CompoundButton.OnCheckedChangeListener {
+    override fun onCheckedChanged(
+        buttonView: CompoundButton,
+        isChecked: Boolean
+    ) {
+        action.call()
+    }
+}


### PR DESCRIPTION
Without XML styling, the default toggle button component shows no visual difference between the checked and unchecked states. I also removed the `defaultToggleStyle` property, which never actually existed.