### PR TITLE
Implement basic drag and drop APIs

### DIFF
--- a/Examples/Bundler.toml
+++ b/Examples/Bundler.toml
@@ -94,3 +94,8 @@ identifier = 'dev.swiftcrossui.MusicPlayerExample'
 product = 'MusicPlayerExample'
 version = '0.1.0'
 icon = 'Icons/MusicPlayerExample.png'
+
+[apps.DragAndDropExample]
+identifier = 'dev.swiftcrossui.DragAndDropExample'
+product = 'DragAndDropExample'
+version = '0.1.0'

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -108,6 +108,10 @@ let package = Package(
             dependencies: [
                 .product(name: "MiniAudio", package: "swift-miniaudio")
             ] + exampleDependencies
-        )
+        ),
+        .executableTarget(
+            name: "DragAndDropExample",
+            dependencies: exampleDependencies
+        ),
     ]
 )

--- a/Examples/Sources/DragAndDropExample/DragAndDropApp.swift
+++ b/Examples/Sources/DragAndDropExample/DragAndDropApp.swift
@@ -1,0 +1,71 @@
+import DefaultBackend
+import Foundation
+import SwiftCrossUI
+import ImageFormats
+
+#if canImport(SwiftBundlerRuntime)
+    import SwiftBundlerRuntime
+#endif
+
+extension AppStorageValues {
+    @Entry var images: [URL] = []
+}
+
+@main
+@HotReloadable
+struct DragAndDropApp: App {
+    @Environment(\.chooseFile) var chooseFile
+
+    @AppStorage(\.images) var images
+
+    var body: some Scene {
+        WindowGroup("Drag and Drop") {
+            #hotReloadable {
+                VStack {
+                    Color.gray
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .overlay {
+                            Text("Drop image files here")
+                                .foregroundColor(.black)
+                        }
+                        .dropDestination(for: .fileURL) { items, _ in
+                            for item in items {
+                                guard
+                                    let urlString = String(data: item.data, encoding: .utf8),
+                                    let url = URL(string: urlString)
+                                else {
+                                    continue
+                                }
+                                images.append(url)
+                            }
+                        }
+
+                    GeometryReader { proxy in
+                        ScrollView([.horizontal]) {
+                            HStack {
+                                ForEach(Array(images.enumerated().reversed()), id: \.offset) { _, image in
+                                    Image(image)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .draggable(TransferrableData(url: image))
+                                }
+
+                                if images.isEmpty {
+                                    Text("No images").italic()
+                                        .frame(minWidth: proxy.size.width)
+                                }
+                            }
+                        }.frame(height: proxy.size.height)
+                    }.frame(height: 100)
+                        .overlay(alignment: .topTrailing) {
+                            if !images.isEmpty {
+                                Button("Clear all") {
+                                    images = []
+                                }
+                            }
+                        }
+                }.padding()
+            }
+        }
+    }
+}

--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -258,6 +258,8 @@ struct WindowingApp: App {
                     Image(bannerImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
+                        .frame(minHeight: 40)
+                        .draggable(TransferrableData(url: bannerImage))
 
                     Divider()
 

--- a/Sources/AppKitBackend/AppKitBackend+DragAndDrop.swift
+++ b/Sources/AppKitBackend/AppKitBackend+DragAndDrop.swift
@@ -1,0 +1,168 @@
+import AppKit
+import Foundation
+import SwiftCrossUI
+
+extension AppKitBackend {
+    public func createDragSource(wrapping child: Widget) -> Widget {
+        let container = NSDraggableContainer()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(child)
+        child.translatesAutoresizingMaskIntoConstraints = false
+        child.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            .isActive = true
+        child.topAnchor.constraint(equalTo: container.topAnchor)
+            .isActive = true
+
+        return container
+    }
+
+    public func updateDragSource(
+        _ dragSource: Widget,
+        prepareData: @escaping () -> TransferrableData
+    ) {
+        let container = dragSource as! NSDraggableContainer
+        container.prepareData = prepareData
+    }
+
+    public func createDropDestination(wrapping child: Widget) -> Widget {
+        let container = NSDropDestinationContainer()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(child)
+        child.translatesAutoresizingMaskIntoConstraints = false
+        child.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+            .isActive = true
+        child.topAnchor.constraint(equalTo: container.topAnchor)
+            .isActive = true
+
+        container.registerForDraggedTypes([.fileURL])
+        return container
+    }
+
+    public func updateDropDestination(
+        _ dropDestination: Widget,
+        isEnabled: Bool,
+        action: @escaping ([TransferrableData]) -> Void
+    ) {
+        let container = dropDestination as! NSDropDestinationContainer
+        container.isEnabled = isEnabled
+        container.action = action
+    }
+}
+
+class NSDropDestinationContainer: NSView {
+    var isEnabled = false
+    var action: (([TransferrableData]) -> Void)?
+
+    override func wantsPeriodicDraggingUpdates() -> Bool {
+        false
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        return .copy
+    }
+
+    override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        isEnabled && action != nil
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard let action else {
+            logger.warning("Received drop without handler")
+            return false
+        }
+
+        let pasteboard = sender.draggingPasteboard
+        var urls: [URL] = []
+        for item in pasteboard.pasteboardItems ?? [] {
+            guard let urlData = item.data(forType: .fileURL) else {
+                logger.warning("Skipping non-file URL drop")
+                continue
+            }
+
+            guard
+                let urlString = String(data: urlData, encoding: .utf8),
+                let url = URL(string: urlString)
+            else {
+                logger.warning("Invalid file URL")
+                continue
+            }
+
+            urls.append(url)
+        }
+
+        action(urls.map(TransferrableData.init(url:)))
+        return true
+    }
+}
+
+class NSDraggableContainer: NSView, NSPasteboardItemDataProvider, NSDraggingSource {
+    var prepareData: (() -> TransferrableData)?
+    var data: TransferrableData?
+
+    override func mouseDown(with event: NSEvent) {
+        let pasteboardItem = NSPasteboardItem()
+
+        guard let prepareData else {
+            logger.debug("No payload present when drag began")
+            return
+        }
+
+        let data = prepareData()
+        self.data = data
+        let type = Self.pasteboardType(for: data)
+        pasteboardItem.setDataProvider(
+            self,
+            forTypes: [type]
+        )
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        do {
+            let preview = try AppKitBackend.snapshotView(self)
+            draggingItem.setDraggingFrame(self.bounds, contents: preview)
+        } catch {
+            logger.warning(
+                "Failed to render drag and drop preview: \(error.localizedDescription)"
+            )
+        }
+
+        beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    nonisolated func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        [.copy]
+    }
+
+    nonisolated func pasteboard(
+        _ pasteboard: NSPasteboard?,
+        item: NSPasteboardItem,
+        provideDataForType type: NSPasteboard.PasteboardType
+    ) {
+        guard let data else {
+            return
+        }
+
+        let type = Self.pasteboardType(for: data)
+        item.setData(
+            data.data,
+            forType: type
+        )
+    }
+
+    static func pasteboardType(
+        for data: TransferrableData
+    ) -> NSPasteboard.PasteboardType {
+        let identifier = data.contentType.utType
+        // let identifier = UTTypeCreatePreferredIdentifierForTag(
+        //     kUTTagClassMIMEType,
+        //     contentType as CFString,
+        //     nil
+        // )?.takeRetainedValue() as String?
+
+        return NSPasteboard.PasteboardType(identifier)
+    }
+}

--- a/Sources/AppKitBackend/AppKitBackend+ViewSnapshotting.swift
+++ b/Sources/AppKitBackend/AppKitBackend+ViewSnapshotting.swift
@@ -1,0 +1,25 @@
+import Foundation
+import AppKit
+
+// This is not a standard backend feature yet; we only use it internally
+// within the backend to generate drag and drop previews.
+extension AppKitBackend {
+    static func snapshotView(_ view: NSView) throws -> NSImage {
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            throw SnapshottingError(message: "Failed to create bitmap backing")
+        }
+
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+
+        guard let cgImage = bitmap.cgImage else {
+            throw SnapshottingError(message: "Failed to convert snapshot to CGImage")
+        }
+
+        return NSImage(cgImage: cgImage, size: bitmap.size)
+    }
+
+    struct SnapshottingError: LocalizedError {
+        var message: String
+        var errorDescription: String? { message }
+    }
+}

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/DragAndDrop.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/DragAndDrop.swift
@@ -1,0 +1,20 @@
+extension BackendFeatures {
+    /// Backend methods related to drag-and-drop functionality.
+    @MainActor
+    public protocol DragAndDrop: Core {
+        func createDragSource(wrapping child: Widget) -> Widget
+
+        func updateDragSource(
+            _ dragSource: Widget,
+            prepareData: @escaping () -> TransferrableData
+        )
+
+        func createDropDestination(wrapping child: Widget) -> Widget
+
+        func updateDropDestination(
+            _ dropDestination: Widget,
+            isEnabled: Bool,
+            action: @escaping ([TransferrableData]) -> Void
+        )
+    }
+}

--- a/Sources/SwiftCrossUI/Backend/FullAppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/FullAppBackend.swift
@@ -22,6 +22,7 @@
 /// - ``BackendFeatures/Colors``
 /// - ``BackendFeatures/DatePickers``
 /// - ``BackendFeatures/Windowing``
+/// - ``BackendFeatures/DragAndDrop``
 public typealias FullAppBackend =
     BaseAppBackend
     & BackendFeatures.MenuButtons
@@ -41,6 +42,7 @@ public typealias FullAppBackend =
     & BackendFeatures.Colors
     & BackendFeatures.DatePickers
     & BackendFeatures.Windowing
+    & BackendFeatures.DragAndDrop
 
 /// A typealias for ``FullAppBackend``.
 ///

--- a/Sources/SwiftCrossUI/Values/ContentType.swift
+++ b/Sources/SwiftCrossUI/Values/ContentType.swift
@@ -3,12 +3,32 @@ public struct ContentType: Sendable {
     /// The HTML content type.
     public static let html = ContentType(
         name: "HTML",
+        utType: "public.html",
         mimeTypes: ["text/html"],
         fileExtensions: ["html", "htm"]
     )
 
+    /// The special file URL content type, used for file URLs being transferred
+    /// via drag and drop or other means such as the clipboard.
+    public static let fileURL = ContentType(
+        name: "File URL",
+        utType: "public.file-url",
+        mimeTypes: [],
+        fileExtensions: []
+    )
+
+    /// The data content type, representing any generic byte stream or bytes container.
+    public static let data = ContentType(
+        name: "Data",
+        utType: "public.data",
+        mimeTypes: [],
+        fileExtensions: []
+    )
+
     /// The name of this content type.
     public var name: String
+    /// The Apple Uniform Type Identifier associated with this content type.
+    public var utType: String
     /// An array of MIME types associated with this content type.
     public var mimeTypes: [String]
     /// An array of file extensions associated with this content type.
@@ -21,8 +41,14 @@ public struct ContentType: Sendable {
     ///   - mimeTypes: An array of MIME types associated with this content type.
     ///   - fileExtensions: An array of file extensions associated with this
     ///     content type.
-    public init(name: String, mimeTypes: [String], fileExtensions: [String]) {
+    public init(
+        name: String,
+        utType: String,
+        mimeTypes: [String],
+        fileExtensions: [String]
+    ) {
         self.name = name
+        self.utType = utType
         self.mimeTypes = mimeTypes
         self.fileExtensions = fileExtensions
     }

--- a/Sources/SwiftCrossUI/Values/DropSession.swift
+++ b/Sources/SwiftCrossUI/Values/DropSession.swift
@@ -1,0 +1,3 @@
+/// Information about a drag and drop session. Currently just an empty
+/// placeholder struct.
+public struct DropSession {}

--- a/Sources/SwiftCrossUI/Values/TransferrableData.swift
+++ b/Sources/SwiftCrossUI/Values/TransferrableData.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct TransferrableData {
+    public var data: Data
+    public var contentType: ContentType
+
+    public init(data: Data, contentType: ContentType?) {
+        self.data = data
+        self.contentType = contentType ?? .data
+    }
+
+    public init(url: URL) {
+        data = Data(url.absoluteString.utf8)
+        contentType = .fileURL
+    }
+}

--- a/Sources/SwiftCrossUI/Views/Modifiers/DraggableModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/DraggableModifier.swift
@@ -1,0 +1,64 @@
+extension View {
+    public func draggable(
+        _ payload: @autoclosure @escaping () -> TransferrableData
+    ) -> some View {
+        DraggableModifier(body: TupleView1(self), payload: payload)
+    }
+}
+
+struct DraggableModifier<Content: View>: TypeSafeView {
+    typealias Children = TupleView1<Content>.Children
+
+    var body: TupleView1<Content>
+    var payload: () -> TransferrableData
+
+    func children<Backend: BaseAppBackend>(
+        backend: Backend,
+        snapshots: [ViewGraphSnapshotter.NodeSnapshot]?,
+        environment: EnvironmentValues
+    ) -> Children {
+        body.children(
+            backend: backend,
+            snapshots: snapshots,
+            environment: environment
+        )
+    }
+
+    @CastBackend<BackendFeatures.DragAndDrop>(returnsWidget: true)
+    func asWidget<Backend: BaseAppBackend>(
+        _ children: Children,
+        backend: Backend
+    ) -> Backend.Widget {
+        backend.createDragSource(wrapping: children.child0.widget.into())
+    }
+
+    func computeLayout<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: Children,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) -> ViewLayoutResult {
+        children.child0.computeLayout(
+            with: body.view0,
+            proposedSize: proposedSize,
+            environment: environment
+        )
+    }
+
+    @CastBackend<BackendFeatures.DragAndDrop>
+    func commit<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: TupleView1<Content>.Children,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        let size = children.child0.commit().size
+        backend.setSize(of: widget, to: size.vector)
+        backend.updateDragSource(
+            widget,
+            prepareData: payload
+        )
+    }
+}

--- a/Sources/SwiftCrossUI/Views/Modifiers/DropDestinationModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/DropDestinationModifier.swift
@@ -1,0 +1,74 @@
+extension View {
+    public func dropDestination(
+        for type: ContentType,
+        isEnabled: Bool = true,
+        action: @escaping ([TransferrableData], DropSession) -> Void
+    ) -> some View {
+        DropDestinationModifier(
+            body: TupleView1(self),
+            isEnabled: isEnabled,
+            action: action
+        )
+    }
+}
+
+struct DropDestinationModifier<Content: View>: TypeSafeView {
+    typealias Children = TupleView1<Content>.Children
+
+    var body: TupleView1<Content>
+    var isEnabled: Bool
+    var action: ([TransferrableData], DropSession) -> Void
+
+    func children<Backend: BaseAppBackend>(
+        backend: Backend,
+        snapshots: [ViewGraphSnapshotter.NodeSnapshot]?,
+        environment: EnvironmentValues
+    ) -> Children {
+        body.children(
+            backend: backend,
+            snapshots: snapshots,
+            environment: environment
+        )
+    }
+
+    @CastBackend<BackendFeatures.DragAndDrop>(returnsWidget: true)
+    func asWidget<Backend: BaseAppBackend>(
+        _ children: Children,
+        backend: Backend
+    ) -> Backend.Widget {
+        backend.createDropDestination(wrapping: children.child0.widget.into())
+    }
+
+    func computeLayout<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: Children,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) -> ViewLayoutResult {
+        children.child0.computeLayout(
+            with: body.view0,
+            proposedSize: proposedSize,
+            environment: environment
+        )
+    }
+
+    @CastBackend<BackendFeatures.DragAndDrop>
+    func commit<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: TupleView1<Content>.Children,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        let size = children.child0.commit().size
+        backend.setSize(of: widget, to: size.vector)
+        backend.updateDropDestination(
+            widget,
+            isEnabled: isEnabled,
+            action: { items in
+                action(items, DropSession())
+            }
+        )
+    }
+}

--- a/Sources/SwiftCrossUI/Views/ScrollView.swift
+++ b/Sources/SwiftCrossUI/Views/ScrollView.swift
@@ -74,7 +74,7 @@ public struct ScrollView<Content: View>: TypeSafeView, View {
             proposedSize: childProposal,
             environment: environment.with(
                 \.allowLayoutCaching,
-                !willEarlyExit || environment.allowLayoutCaching
+                environment.allowLayoutCaching
             )
         )
 


### PR DESCRIPTION
This PR introduces basic versions of SwiftUI's Transferrable-based drag and drop APIs. A proper Transferrable implementation is left for a future PR, as it would be rather involved. For now we're using a simple TransferrableData struct that caries data (bytes) along with a content type.

This resolves #546

## Remaining tasks

- [ ] Include a comprehensive set of built-in file types. I'm still trying to figure out the best shape for ContentType, but I think I'm getting close to a good design. I think we can automatically generate our file type declarations from macOS's UTType database (see the uttype CLI and the UniformTypeIdentifier's library)
- [ ] Actually listen to file types during transfers
- [ ] Check underlying file types of fileURL's? fileURL transfers are what you get when dragging from the system file explorer usually, but if applications have to manually open the files and determine their content type to filter out invalid drops, then that's not very ergonomic. If an application requests 'ContentType.png' and the dragged item is a fileURL to a PNG, then we should convert the dragged item to in-memory PNG content by reading the file into memory.
- [ ] Allow applications to not care about fileURL content when importing data from a drop operation. If the application requests the dragged item's data we should just read the file on the application's behalf, if the file exists.
- [ ] Support WinUIBackend
- [ ] Support GtkBackend
- [ ] Support UIKitBackend