### PR TITLE
Cache window size

### DIFF
--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -9,6 +9,8 @@ final class WindowReference<SceneType: WindowingScene> {
     let window: Any
     /// `false` after the first scene update.
     private var isFirstUpdate = true
+    /// The cached window size. Nil on first run or after a window is resized.
+    private var cachedWindowSize: SIMD2<Int>?
     /// The environment most recently provided by this node's parent scene.
     private var parentEnvironment: EnvironmentValues
     /// The container used to center the root view in the window.
@@ -97,7 +99,7 @@ final class WindowReference<SceneType: WindowingScene> {
             proposedWindowSize = environment.defaultWindowSize
             usedDefaultSize = true
         } else {
-            proposedWindowSize = backend.size(ofWindow: window)
+            proposedWindowSize = cachedWindowSize ?? backend.size(ofWindow: window)
             usedDefaultSize = false
         }
 
@@ -158,6 +160,7 @@ final class WindowReference<SceneType: WindowingScene> {
             )
             .with(\.onResize) { [weak self] _ in
                 guard let self else { return }
+                self.cachedWindowSize = nil
                 // TODO: Figure out whether this would still work if we didn't recompute the
                 //   scene's body. I have a vague feeling that it wouldn't work in all cases?
                 //   But I don't have the time to come up with a counterexample right now.
@@ -267,6 +270,7 @@ final class WindowReference<SceneType: WindowingScene> {
         if needsWindowSizeCommit {
             backend.setSize(ofWindow: window, to: proposedWindowSize)
         }
+        cachedWindowSize = proposedWindowSize
 
         if let backend = backend as? any BackendFeatures.WindowBehaviors {
             func setBehaviors<NewBackend: BackendFeatures.WindowBehaviors>(backend: NewBackend) {


### PR DESCRIPTION
Performance improvement. Primarily motivated by the fact that window measurement can take ~70ms on Android due to blocking on ioctls, but it should have a small performance boost on all platforms.