### PR TITLE
AndroidBackend: Switch to custom container (RelativeLayout too slow)

### DIFF
--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -163,7 +163,9 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
         let leftInset = Int(helpers.getSafeAreaLeftInset(Self.activity))
         let topInset = Int(helpers.getSafeAreaTopInset(Self.activity))
+        let windowSize = size(ofWindow: window)
         setPosition(ofChildAt: 0, in: container, to: SIMD2(leftInset, topInset))
+        setSize(of: container, to: windowSize)
     }
 
     public func size(ofWindow window: Window) -> SIMD2<Int> {
@@ -247,17 +249,17 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     public func show(widget: Widget) {}
 
     public func createContainer() -> Widget {
-        RelativeLayout(Self.activity, environment: Self.env)
+        CustomContainer(Self.activity, environment: Self.env)
             .as(AndroidKit.View.self)!
     }
 
     public func removeAllChildren(of container: Widget) {
-        let container = container.as(ViewGroup.self)!
+        let container = container.as(CustomContainer.self)!
         container.removeAllViews()
     }
 
     public func insert(_ child: Widget, into container: Widget, at index: Int) {
-        let container = container.as(ViewGroup.self)!
+        let container = container.as(CustomContainer.self)!
         container.addView(child, Int32(index))
     }
 
@@ -266,23 +268,23 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         in container: Widget,
         to position: SIMD2<Int>
     ) {
-        let container = container.as(ViewGroup.self)!
+        let container = container.as(CustomContainer.self)!
         let child = container.getChildAt(Int32(index))!
         
-        let layoutParams = child.getLayoutParams().as(RelativeLayout.LayoutParams.self)!
-        layoutParams.leftMargin = Int32(position.x)
-        layoutParams.topMargin = Int32(position.y)
+        let layoutParams = child.getLayoutParams().as(CustomContainer.LayoutParams.self)!
+        layoutParams.setX(Int32(position.x))
+        layoutParams.setY(Int32(position.y))
         
         child.setLayoutParams(layoutParams.as(ViewGroup.LayoutParams.self))
     }
 
     public func remove(childAt index: Int, from container: Widget) {
-        let container = container.as(RelativeLayout.self)!
+        let container = container.as(CustomContainer.self)!
         container.removeViewAt(Int32(index))
     }
 
     public func swap(childAt firstIndex: Int, withChildAt secondIndex: Int, in container: Widget) {
-        let container = container.as(ViewGroup.self)!
+        let container = container.as(CustomContainer.self)!
         let largerIndex = Int32(max(firstIndex, secondIndex))
         let smallerIndex = Int32(min(firstIndex, secondIndex))
         let view1 = container.getChildAt(smallerIndex)

--- a/Sources/AndroidBackend/CustomContainer.swift
+++ b/Sources/AndroidBackend/CustomContainer.swift
@@ -1,0 +1,60 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomContainer",
+    extends: AndroidKit.ViewGroup.self
+)
+class CustomContainer: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: Activity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    // MARK: Methods from ViewGroup, for convenience to avoid '.as(...)' casting
+
+    @JavaMethod
+    func removeAllViews()
+
+    @JavaMethod
+    func addView(_ view: AndroidKit.View?, _ index: Int32)
+    
+    @JavaMethod
+    func getChildAt(_ index: Int32) -> AndroidKit.View?
+
+    @JavaMethod
+    func removeViewAt(_ index: Int32)
+}
+
+extension CustomContainer {
+    @JavaClass(
+        "dev.swiftcrossui.androidbackend.CustomContainer$LayoutParams",
+        extends: AndroidKit.ViewGroup.LayoutParams.self
+    )
+    class LayoutParams: JavaObject {
+        @JavaMethod
+        func getWidth() -> Int32
+
+        @JavaMethod
+        func setWidth(_ width: Int32)
+
+        @JavaMethod
+        func getHeight() -> Int32
+
+        @JavaMethod
+        func setHeight(_ height: Int32)
+
+        @JavaMethod
+        func getX() -> Int32
+
+        @JavaMethod
+        func setX(_ x: Int32)
+
+        @JavaMethod
+        func getY() -> Int32
+
+        @JavaMethod
+        func setY(_ y: Int32)
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/CustomContainer.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomContainer.kt
@@ -37,9 +37,6 @@ class CustomContainer(
     override protected fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         setMeasuredDimension(layoutParams.width, layoutParams.height)
 
-        val width = View.MeasureSpec.getSize(widthMeasureSpec)
-        val height = View.MeasureSpec.getSize(heightMeasureSpec)
-
         for (i in 0..<childCount) {
             val child = getChildAt(i)
             // If you're debugging this implementation and see a child with

--- a/Sources/AndroidBackend/Kotlin/CustomContainer.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomContainer.kt
@@ -1,0 +1,76 @@
+package dev.swiftcrossui.androidbackend
+
+import android.app.Activity
+import android.view.ViewGroup
+import android.util.Log
+import android.util.AttributeSet
+import android.view.View
+
+class CustomContainer(
+    val activity: Activity
+): ViewGroup(activity) {
+    class LayoutParams(
+        width: Int,
+        height: Int,
+        var x: Int,
+        var y: Int
+    ): ViewGroup.LayoutParams(width, height) {}
+
+    override fun checkLayoutParams(layoutParams: ViewGroup.LayoutParams?): Boolean {
+        return layoutParams is LayoutParams
+    }
+
+    override fun generateDefaultLayoutParams(): ViewGroup.LayoutParams? {
+        return LayoutParams(0, 0, 0, 0)
+    }
+
+    override fun generateLayoutParams(attrs: AttributeSet?): ViewGroup.LayoutParams? {
+        return LayoutParams(0, 0, 0, 0)
+    }
+
+    override fun generateLayoutParams(
+        layoutParams: ViewGroup.LayoutParams?
+    ): ViewGroup.LayoutParams {
+        return LayoutParams(layoutParams!!.width, layoutParams!!.height, 0, 0)
+    }
+
+    override protected fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        setMeasuredDimension(layoutParams.width, layoutParams.height)
+
+        val width = View.MeasureSpec.getSize(widthMeasureSpec)
+        val height = View.MeasureSpec.getSize(heightMeasureSpec)
+
+        for (i in 0..<childCount) {
+            val child = getChildAt(i)
+            // If you're debugging this implementation and see a child with
+            // strange layoutParams dimensions (such as 1073741822, or <= 0),
+            // then it's likely that there is a widget that SwiftCrossUI
+            // mistakenly hasn't assigned an explicit size via
+            // AndroidBackend.setSize(of:to:). This often leads to views
+            // within such a view not being visible at all.
+            val layoutParams = child.layoutParams
+            val widthSpec = View.MeasureSpec.makeMeasureSpec(
+                layoutParams.width,
+                View.MeasureSpec.EXACTLY
+            )
+            val heightSpec = View.MeasureSpec.makeMeasureSpec(
+                layoutParams.height,
+                View.MeasureSpec.EXACTLY
+            )
+            child.measure(widthSpec, heightSpec)
+        }
+    }
+
+    override protected fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        for (i in 0..<childCount) {
+            val child = getChildAt(i)
+            val layoutParams = child.layoutParams as LayoutParams
+            child.layout(
+                layoutParams.x,
+                layoutParams.y,
+                layoutParams.x + layoutParams.width,
+                layoutParams.y + layoutParams.height
+            )
+        }
+    }
+}

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Widgets.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Widgets.swift
@@ -56,6 +56,11 @@ extension BackendFeatures {
 
         /// Sets the size of a widget.
         ///
+        /// In general, View and Scene implementations must call ``setSize(of:to:)``
+        /// at least once for any given widget before it appears. Backends such as
+        /// AndroidBackend don't handle missing widget sizes very well (often because
+        /// of custom container implementations such as AndroidBackend's CustomContainer).
+        ///
         /// - Parameters:
         ///   - widget: The widget to set the size of.
         ///   - size: The new size.

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -263,6 +263,10 @@ final class WindowReference<SceneType: WindowingScene> {
             in: containerWidget.into(),
             to: (proposedWindowSize &- finalContentResult.size.vector) / 2
         )
+        backend.setSize(
+            of: containerWidget.into(),
+            to: proposedWindowSize
+        )
 
         if needsWindowSizeCommit {
             backend.setSize(ofWindow: window, to: proposedWindowSize)

--- a/Sources/SwiftCrossUI/Views/Checkbox.swift
+++ b/Sources/SwiftCrossUI/Views/Checkbox.swift
@@ -39,5 +39,6 @@ struct Checkbox: ElementaryView, View {
             }
         }
         backend.setState(ofCheckbox: widget, to: active.wrappedValue)
+        backend.setSize(of: widget, to: layout.size.vector)
     }
 }

--- a/Sources/SwiftCrossUI/Views/ToggleButton.swift
+++ b/Sources/SwiftCrossUI/Views/ToggleButton.swift
@@ -46,5 +46,6 @@ struct ToggleButton: ElementaryView, View {
         backend: Backend
     ) {
         backend.setState(ofToggle: widget, to: active.wrappedValue)
+        backend.setSize(of: widget, to: layout.size.vector)
     }
 }

--- a/Sources/SwiftCrossUI/Views/ToggleSwitch.swift
+++ b/Sources/SwiftCrossUI/Views/ToggleSwitch.swift
@@ -38,5 +38,6 @@ struct ToggleSwitch: ElementaryView, View {
             }
         }
         backend.setState(ofSwitch: widget, to: active.wrappedValue)
+        backend.setSize(of: widget, to: layout.size.vector)
     }
 }


### PR DESCRIPTION
RelativeLayout's onMeasure implementation has a branching factor of 2, leading to Android's measurement pass being exponential with regard to the depth of the SwiftCrossUI view hierarchy. That appears to be the cause of #545, which we found out thanks to @bbrk24's profiling earlier today.

This PR resolves the issue by switching over to a custom ViewGroup subclass for our container implementation. The new implementation is written in Kotlin because a) it's much more ergonomic interacting with Android APIs from Kotlin, and b) it reduces the number of JNI calls we have to make.

This is a draft because it seems to have broken a couple of views such as checkboxes. We may be assigning a size that is too small? I haven't looked into it yet.