### PR TITLE
CI: Limit push-triggering to main branch (to avoid duplicate jobs)

### DIFF
--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -2,8 +2,8 @@ name: Build, test, and docs
 
 on:
   push:
-    branches-ignore:
-      - 'gh-pages'
+    branches:
+      - 'main'
   pull_request:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -2,11 +2,12 @@ name: Lint
 
 on:
   push:
-    branches-ignore:
-      - 'gh-pages'
+    branches:
+      - 'main'
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 jobs:
   swift-lint:


### PR DESCRIPTION
This should reduce the number of runners required by pull requests opened from branches within the SwiftCrossUI repository (i.e. pull requests opened by me).