### PR TITLE
Fix ColorsExample grid layout

### DIFF
--- a/Examples/Sources/ColorsExample/ColorsApp.swift
+++ b/Examples/Sources/ColorsExample/ColorsApp.swift
@@ -34,7 +34,7 @@ struct ColorsApp: App {
         HStack(spacing: 5) {
             ForEach(colors, id: \.self) { color in
                 VStack {
-                    color.aspectRatio(1, contentMode: .fill)
+                    color.aspectRatio(1, contentMode: .fit)
 
                     #if os(tvOS)
                         // Add something focusable so we can scroll on tvOS.


### PR DESCRIPTION
Fixes a simple issue with the ColorsExample layout code. We should probably look into whether there's a better way for `.fill` to behave in that context, but `.fill` isn't what we wanted anyway.