### PR TITLE
Add color support for Android

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -103,7 +103,7 @@
     {
       "identity" : "pathkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/PathKit",
+      "location" : "https://github.com/kylef/PathKit.git",
       "state" : {
         "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
         "version" : "1.0.1"
@@ -139,7 +139,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
@@ -185,14 +185,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates",
       "state" : {
-        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
-        "version" : "1.19.0"
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
@@ -219,7 +219,7 @@
     {
       "identity" : "swift-filestreamer",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sersoft-gmbh/swift-filestreamer.git",
+      "location" : "https://github.com/sersoft-gmbh/swift-filestreamer",
       "state" : {
         "revision" : "b01ff214cc629718a8729f33d2a8b88e47532dbd",
         "version" : "0.6.0"
@@ -275,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -374,8 +374,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-windowsappsdk",
       "state" : {
-        "revision" : "3c06cb36da9711e24a76c35861e0b97702448015",
-        "version" : "0.1.1"
+        "revision" : "40d2db0c4cfadf557b9ce60a0ce1c5c96defc438",
+        "version" : "0.1.2"
       }
     },
     {
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mxcl/Version",
       "state" : {
-        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
-        "version" : "2.2.0"
+        "revision" : "3043fcd2a50375db76d89ff206a612471833d1c2",
+        "version" : "2.2.1"
       }
     },
     {

--- a/Examples/Sources/ColorsExample/ColorsApp.swift
+++ b/Examples/Sources/ColorsExample/ColorsApp.swift
@@ -57,14 +57,25 @@ struct ColorsApp: App {
                         otherwise SCUI's built-in colors will be shown
                         """
                     )
-
-                    ScrollView(.horizontal) {
-                        VStack(spacing: 5) {
-                            colorStack.colorScheme(.dark)
-                            colorStack.colorScheme(.light)
-                            colorStack
+                    
+                    #if canImport(AndroidBackend)
+                        // TODO(bbrk24): Update this once AndroidBackend supports scrolling
+                        HStack {
+                            VStack(spacing: 5) {
+                                colorStack.colorScheme(.dark)
+                                colorStack.colorScheme(.light)
+                                colorStack
+                            }
                         }
-                    }
+                    #else
+                        ScrollView(.horizontal) {
+                            VStack(spacing: 5) {
+                                colorStack.colorScheme(.dark)
+                                colorStack.colorScheme(.light)
+                                colorStack
+                            }
+                        }
+                    #endif
                 }
                 .padding()
             }

--- a/Examples/Sources/ColorsExample/ColorsApp.swift
+++ b/Examples/Sources/ColorsExample/ColorsApp.swift
@@ -60,12 +60,10 @@ struct ColorsApp: App {
                     
                     #if canImport(AndroidBackend)
                         // TODO(bbrk24): Update this once AndroidBackend supports scrolling
-                        HStack {
-                            VStack(spacing: 5) {
-                                colorStack.colorScheme(.dark)
-                                colorStack.colorScheme(.light)
-                                colorStack
-                            }
+                        VStack(spacing: 5) {
+                            colorStack.colorScheme(.dark)
+                            colorStack.colorScheme(.light)
+                            colorStack
                         }
                     #else
                         ScrollView(.horizontal) {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
       "state" : {
-        "revision" : "86554f67e706892f202cf02a6ce7def19acb42a1",
-        "version" : "2.0.0"
+        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
+        "version" : "2.0.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
-        "version" : "1.6.2"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-windowsappsdk",
       "state" : {
-        "revision" : "3c06cb36da9711e24a76c35861e0b97702448015",
-        "version" : "0.1.1"
+        "revision" : "40d2db0c4cfadf557b9ce60a0ce1c5c96defc438",
+        "version" : "0.1.2"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CoreOffice/XMLCoder",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "b2b5d72345bab9e1938a483cf862b498aeed3796",
+        "version" : "0.18.1"
       }
     },
     {

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -647,45 +647,45 @@ extension AndroidBackend: BackendFeatures.ToggleButtons, BackendFeatures.Checkbo
     }
 }
 
-extension AndroidBackend: BackendFeatures.Colors {
-    public func createColorableRectangle() -> Widget {
-        AndroidKit.View(Self.activity, environment: Self.env)
-    }
-
-    private func toColorInt(_ color: SwiftCrossUI.Color.Resolved) -> Int32 {
-        // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/graphics/java/android/graphics/Color.java;drc=ba44b0b3545f60e2b82e864ea0e684ce7407349a;l=1338
-        let alpha = UInt32(color.opacity * 255.0 + 0.5)
-        let red = UInt32(color.red * 255.0 + 0.5)
-        let green = UInt32(color.green * 255.0 + 0.5)
-        let blue = UInt32(color.blue * 255.0 + 0.5)
+extension SwiftCrossUI.Color.Resolved {
+    func asColorInt() -> Int32 {
+        let alpha = UInt32(opacity * 255.0 + 0.5)
+        let red = UInt32(red * 255.0 + 0.5)
+        let green = UInt32(green * 255.0 + 0.5)
+        let blue = UInt32(blue * 255.0 + 0.5)
 
         let combined = (alpha << 24) | (red << 16) | (green << 8) | blue
 
         return Int32(bitPattern: combined)
     }
     
-    private func toResolvedColor(_ int: Int32) -> SwiftCrossUI.Color.Resolved {
-        // inverse of the above
+    init(fromColorInt int: Int32) {
         let uint = UInt32(bitPattern: int)
 
-        let alpha = (Float(uint >> 24) - 0.5) / 255.0
-        let red = (Float((uint & 0x00FF0000) >> 16) - 0.5) / 255.0
-        let green = (Float((uint & 0x0000FF00) >> 8) - 0.5) / 255.0
-        let blue = (Float(uint & 0x000000FF) - 0.5) / 255.0
+        let alpha = Float(uint >> 24) / 255.0
+        let red = Float((uint & 0x00FF0000) >> 16) / 255.0
+        let green = Float((uint & 0x0000FF00) >> 8) / 255.0
+        let blue = Float(uint & 0x000000FF) / 255.0
 
-        return .init(
+        self.init(
             red: red,
             green: green,
             blue: blue,
             opacity: alpha
         )
     }
+}
+
+extension AndroidBackend: BackendFeatures.Colors {
+    public func createColorableRectangle() -> Widget {
+        AndroidKit.View(Self.activity, environment: Self.env)
+    }
     
     public func setColor(
         ofColorableRectangle widget: Widget,
         to color: SwiftCrossUI.Color.Resolved
     ) {
-        widget.setBackgroundColor(toColorInt(color))
+        widget.setBackgroundColor(color.asColorInt())
     }
     
     public func resolveAdaptiveColor(
@@ -716,6 +716,6 @@ extension AndroidBackend: BackendFeatures.Colors {
         
         let colorInt = Self.activity.getColor(resId)
         
-        return toResolvedColor(colorInt)
+        return SwiftCrossUI.Color.Resolved(fromColorInt: colorInt)
     }
 }

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -646,3 +646,76 @@ extension AndroidBackend: BackendFeatures.ToggleButtons, BackendFeatures.Checkbo
         switchWidget.setChecked(state)
     }
 }
+
+extension AndroidBackend: BackendFeatures.Colors {
+    public func createColorableRectangle() -> Widget {
+        AndroidKit.View(Self.activity, environment: Self.env)
+    }
+
+    private func toColorInt(_ color: SwiftCrossUI.Color.Resolved) -> Int32 {
+        // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/graphics/java/android/graphics/Color.java;drc=ba44b0b3545f60e2b82e864ea0e684ce7407349a;l=1338
+        let alpha = UInt32(color.opacity * 255.0 + 0.5)
+        let red = UInt32(color.red * 255.0 + 0.5)
+        let green = UInt32(color.green * 255.0 + 0.5)
+        let blue = UInt32(color.blue * 255.0 + 0.5)
+
+        let combined = (alpha << 24) | (red << 16) | (green << 8) | blue
+
+        return Int32(bitPattern: combined)
+    }
+    
+    private func toResolvedColor(_ int: Int32) -> SwiftCrossUI.Color.Resolved {
+        // inverse of the above
+        let uint = UInt32(bitPattern: int)
+
+        let alpha = (Float(uint >> 24) - 0.5) / 255.0
+        let red = (Float((uint & 0x00FF0000) >> 16) - 0.5) / 255.0
+        let green = (Float((uint & 0x0000FF00) >> 8) - 0.5) / 255.0
+        let blue = (Float(uint & 0x000000FF) - 0.5) / 255.0
+
+        return .init(
+            red: red,
+            green: green,
+            blue: blue,
+            opacity: alpha
+        )
+    }
+    
+    public func setColor(
+        ofColorableRectangle widget: Widget,
+        to color: SwiftCrossUI.Color.Resolved
+    ) {
+        widget.setBackgroundColor(toColorInt(color))
+    }
+    
+    public func resolveAdaptiveColor(
+        _ adaptiveColor: SwiftCrossUI.Color.SystemAdaptive,
+        in environment: EnvironmentValues
+    ) -> SwiftCrossUI.Color.Resolved {
+        let Rcolor = try! JavaClass<AndroidKit.R.color>()
+
+        let resId: Int32? =
+            switch (adaptiveColor, environment.colorScheme) {
+                case (.blue, .light): Rcolor.holo_blue_dark
+                case (.blue, .dark): Rcolor.holo_blue_light
+                case (.gray, _): Rcolor.darker_gray
+                case (.green, .light): Rcolor.holo_green_dark
+                case (.green, .dark): Rcolor.holo_green_light
+                case (.orange, .light): Rcolor.holo_orange_dark
+                case (.orange, .dark): Rcolor.holo_orange_light
+                case (.red, .light): Rcolor.holo_red_dark
+                case (.red, .dark): Rcolor.holo_red_light
+                case (.purple, _): Rcolor.holo_purple
+                default: // brown, yellow
+                    nil
+            }
+        
+        guard let resId else {
+            return SwiftCrossUI.Color.defaultResolveAdaptiveColor(adaptiveColor, in: environment)
+        }
+        
+        let colorInt = Self.activity.getColor(resId)
+        
+        return toResolvedColor(colorInt)
+    }
+}

--- a/Sources/SwiftCrossUI/Values/Color/Color+Resolved.swift
+++ b/Sources/SwiftCrossUI/Values/Color/Color+Resolved.swift
@@ -68,7 +68,7 @@ extension Color {
     // NB: Also used in the default implementation for
     // `BackendFeatures.Colors.resolveAdaptiveColor(_:in:)`.
     @MainActor
-    internal static func defaultResolveAdaptiveColor(
+    package static func defaultResolveAdaptiveColor(
         _ adaptiveColor: Color.SystemAdaptive,
         in environment: EnvironmentValues
     ) -> Color.Resolved {


### PR DESCRIPTION
Uses the default shades of yellow and brown because Android doesn't have system resources for those.