### PR TITLE
Fix window resizing on desktop (and fix AndroidBackend clipping issue)

### DIFF
--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -171,14 +171,21 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
         let leftInset = Int(helpers.getSafeAreaLeftInset(Self.activity))
         let topInset = Int(helpers.getSafeAreaTopInset(Self.activity))
-        let windowSize = size(ofWindow: window)
+        let fullWindowSize = SIMD2(
+            Int(helpers.getFullWindowWidth(Self.activity)),
+            Int(helpers.getFullWindowHeight(Self.activity))
+        )
+        setSize(of: container, to: fullWindowSize)
         setPosition(ofChildAt: 0, in: container, to: SIMD2(leftInset, topInset))
-        setSize(of: container, to: windowSize)
+
+        let safeWindowSize = size(ofWindow: window)
+        let child = container.as(CustomContainer.self)!.getChildAt(0)!
+        setSize(of: child, to: safeWindowSize)
     }
 
     public func size(ofWindow window: Window) -> SIMD2<Int> {
-        let width = Int(helpers.getWindowWidth(Self.activity))
-        let height = Int(helpers.getWindowHeight(Self.activity))
+        let width = Int(helpers.getSafeWindowWidth(Self.activity))
+        let height = Int(helpers.getSafeWindowHeight(Self.activity))
         return SIMD2(Int(width), Int(height))
     }
 

--- a/Sources/AndroidBackend/AndroidBackendHelpers.swift
+++ b/Sources/AndroidBackend/AndroidBackendHelpers.swift
@@ -9,11 +9,23 @@ class AndroidBackendHelpers: JavaObject {
         environment: JNIEnvironment? = nil
     )
 
+    /// Get the width of the window's usable safe area.
     @JavaMethod
-    func getWindowWidth(_ activity: Activity?) -> Int32
+    func getSafeWindowWidth(_ activity: Activity?) -> Int32
 
+    /// Get the height of the window's usable safe area.
     @JavaMethod
-    func getWindowHeight(_ activity: Activity?) -> Int32
+    func getSafeWindowHeight(_ activity: Activity?) -> Int32
+
+    /// Get the window width, including the parts that extend outside of the
+    /// safe areas.
+    @JavaMethod
+    func getFullWindowWidth(_ activity: Activity?) -> Int32
+
+    /// Get the window height, including the parts that extend outside of the
+    /// safe areas.
+    @JavaMethod
+    func getFullWindowHeight(_ activity: Activity?) -> Int32
 
     @JavaMethod
     func getSafeAreaLeftInset(_ activity: Activity?) -> Int32

--- a/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
+++ b/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
@@ -17,7 +17,7 @@ class AndroidBackendHelpers {
         private const val DEVICE_CLASS_WATCH: Short = 4
     }
 
-    fun getWindowWidth(activity: Activity): Int {
+    fun getSafeWindowWidth(activity: Activity): Int {
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val insets = windowMetrics.getWindowInsets()
                 .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())
@@ -26,11 +26,23 @@ class AndroidBackendHelpers {
         return ((windowMetrics.getBounds().width() - insets.left - insets.right).toFloat() / windowMetrics.density).toInt()
     }
 
-    fun getWindowHeight(activity: Activity): Int {
+    fun getSafeWindowHeight(activity: Activity): Int {
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val insets = windowMetrics.getWindowInsets()
                 .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars())
         return ((windowMetrics.getBounds().height() - insets.top - insets.bottom).toFloat() / windowMetrics.density).toInt()
+    }
+
+    fun getFullWindowWidth(activity: Activity): Int {
+        val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
+        // density is very frequently a fractional value like 1.5, so cast to int after division
+        // instead of before
+        return (windowMetrics.getBounds().width().toFloat() / windowMetrics.density).toInt()
+    }
+
+    fun getFullWindowHeight(activity: Activity): Int {
+        val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
+        return (windowMetrics.getBounds().height().toFloat() / windowMetrics.density).toInt()
     }
 
     fun getSafeAreaLeftInset(activity: Activity): Int {

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Widgets.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Widgets.swift
@@ -60,6 +60,10 @@ extension BackendFeatures {
         /// at least once for any given widget before it appears. Backends such as
         /// AndroidBackend don't handle missing widget sizes very well (often because
         /// of custom container implementations such as AndroidBackend's CustomContainer).
+        /// The only exception is the root container widget of windows, as many backends
+        /// rely on such containers changing size as the user resizes the window. Backends
+        /// that need their root container to have a fixed size can do that in their own
+        /// window listeners.
         ///
         /// - Parameters:
         ///   - widget: The widget to set the size of.

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -264,10 +264,6 @@ final class WindowReference<SceneType: WindowingScene> {
             in: containerWidget.into(),
             to: (proposedWindowSize &- finalContentResult.size.vector) / 2
         )
-        backend.setSize(
-            of: containerWidget.into(),
-            to: proposedWindowSize
-        )
 
         if needsWindowSizeCommit {
             backend.setSize(ofWindow: window, to: proposedWindowSize)


### PR DESCRIPTION
This resolves #569, and also fixes an issue where AndroidBackend would clip the contents of window due to the outer window container not being big enough. The outer window container is meant to fit the whole screen, and it used to inset the actual window content to lie within the safe areas. Previously the outer container had the same size as the inner container, leading to clipping at the bottom of the screen (in portrait mode).