### PR TITLE
Feature Parity: Gradients on AndroidBackend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vcpkg_installed/
 notes.json
 /Tools
 .docc-build/
+.idea

--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8607048d24cdce44ffea552971060f8edde724f032d4b75e4e840ad0d2e3b8f9",
+  "originHash" : "e72ed50d35229773858c00ead5ee48b27378291dbff55cb87ae9f310150c1de2",
   "pins" : [
     {
       "identity" : "aexml",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "db806756c989760b35108146381535aec231092b",
         "version" : "4.7.0"
-      }
-    },
-    {
-      "identity" : "androidkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/AndroidKit",
-      "state" : {
-        "revision" : "937a0643efb2f0820dc62a9249729f12987bf340",
-        "version" : "0.7.2"
       }
     },
     {
@@ -125,15 +116,6 @@
       "state" : {
         "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
         "version" : "0.10.1"
-      }
-    },
-    {
-      "identity" : "swift-android-native",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
-      "state" : {
-        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
-        "version" : "2.0.1"
       }
     },
     {
@@ -253,24 +235,6 @@
       }
     },
     {
-      "identity" : "swift-java",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-java",
-      "state" : {
-        "revision" : "3d52a15db42c4d5ef322fde074626106b9bf82d7",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "swift-java-jni-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-java-jni-core",
-      "state" : {
-        "revision" : "b440a0be98381550cf189c903782e817619ffa05",
-        "version" : "0.5.1"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
@@ -322,15 +286,6 @@
       "state" : {
         "revision" : "f51d409e7a9571b67112fde55a5250d5d49ed8bc",
         "version" : "0.15.0"
-      }
-    },
-    {
-      "identity" : "swift-subprocess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-subprocess.git",
-      "state" : {
-        "revision" : "13d087685b95d64d6aac9b94500d347bbe84c39b",
-        "version" : "0.4.0"
       }
     },
     {
@@ -403,24 +358,6 @@
       "state" : {
         "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
         "version" : "6.0.3"
-      }
-    },
-    {
-      "identity" : "swiftjavalang",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/SwiftJavaLang.git",
-      "state" : {
-        "revision" : "b60871fd650b81b142a1d6a62d7d440ea1e9bff7",
-        "version" : "0.2.1"
-      }
-    },
-    {
-      "identity" : "swiftkotlin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/SwiftKotlin.git",
-      "state" : {
-        "revision" : "f408b73ebb86a33411f27a668e2d843a10f007c2",
-        "version" : "0.2.1"
       }
     },
     {

--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -11,6 +11,15 @@
       }
     },
     {
+      "identity" : "androidkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/moreSwift/AndroidKit",
+      "state" : {
+        "revision" : "937a0643efb2f0820dc62a9249729f12987bf340",
+        "version" : "0.7.2"
+      }
+    },
+    {
       "identity" : "async-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adam-fowler/async-collections.git",
@@ -119,9 +128,18 @@
       }
     },
     {
+      "identity" : "swift-android-native",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
+      "state" : {
+        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
+        "version" : "2.0.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
@@ -235,6 +253,24 @@
       }
     },
     {
+      "identity" : "swift-java",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-java",
+      "state" : {
+        "revision" : "3d52a15db42c4d5ef322fde074626106b9bf82d7",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-java-jni-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-java-jni-core",
+      "state" : {
+        "revision" : "b440a0be98381550cf189c903782e817619ffa05",
+        "version" : "0.5.1"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
@@ -286,6 +322,15 @@
       "state" : {
         "revision" : "f51d409e7a9571b67112fde55a5250d5d49ed8bc",
         "version" : "0.15.0"
+      }
+    },
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "13d087685b95d64d6aac9b94500d347bbe84c39b",
+        "version" : "0.4.0"
       }
     },
     {
@@ -358,6 +403,24 @@
       "state" : {
         "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
         "version" : "6.0.3"
+      }
+    },
+    {
+      "identity" : "swiftjavalang",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftJavaLang.git",
+      "state" : {
+        "revision" : "b60871fd650b81b142a1d6a62d7d440ea1e9bff7",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "swiftkotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftKotlin.git",
+      "state" : {
+        "revision" : "f408b73ebb86a33411f27a668e2d843a10f007c2",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Examples/Sources/GradientsExample/GradientsApp.swift
+++ b/Examples/Sources/GradientsExample/GradientsApp.swift
@@ -65,16 +65,16 @@ struct GradientsApp: App {
         case .linear:
             LinearGradientView()
         case .radial:
-            #if !canImport(AndroidBackend)
             RadialGradientView()
-            #endif
         case .angular:
             #if !canImport(WinUIBackend) && !canImport(GtkBackend) && !canImport(AndroidBackend)
-            ScrollView(.horizontal) {
+                ScrollView(.horizontal) {
+                    AngularGradientView()
+                }
+            #elseif canImport(AndroidBackend)
                 AngularGradientView()
-            }
             #else
-            Text("Angular Gradients are not supported on \(App.Backend)")
+                Text("Angular Gradients are not supported on \(App.Backend)")
             #endif
         case .none:
             Text("Please select a gradient type.")

--- a/Examples/Sources/GradientsExample/GradientsApp.swift
+++ b/Examples/Sources/GradientsExample/GradientsApp.swift
@@ -20,7 +20,7 @@ struct GradientsApp: App {
 
     var body: some Scene {
         WindowGroup("Gradients Example") {
-            #if !canImport(UIKitBackend)
+            #if !canImport(UIKitBackend) && !canImport(AndroidBackend)
                 NavigationSplitView {
                     // TODO: replace with List once bug described in #556 is fixed
                     ForEach(GradientType.allCases, id: \.rawValue) { type in
@@ -50,23 +50,34 @@ struct GradientsApp: App {
 
     @ViewBuilder
     func scrollViewWithGradient() -> some View {
+        #if !canImport(AndroidBackend)
         ScrollView {
-            switch gradientType {
-                case .linear:
-                    LinearGradientView()
-                case .radial:
-                    RadialGradientView()
-                case .angular:
-                    #if !canImport(WinUIBackend) && !canImport(GtkBackend)
-                        ScrollView(.horizontal) {
-                            AngularGradientView()
-                        }
-                    #else
-                        Text("Angular Gradients are not supported on \(App.Backend)")
-                    #endif
-                case .none:
-                    Text("Please select a gradient type.")
+            gradients()
+        }
+        #else
+            gradients()
+        #endif
+    }
+
+    @ViewBuilder
+    func gradients() -> some View {
+        switch gradientType {
+        case .linear:
+            LinearGradientView()
+        case .radial:
+            #if !canImport(AndroidBackend)
+            RadialGradientView()
+            #endif
+        case .angular:
+            #if !canImport(WinUIBackend) && !canImport(GtkBackend) && !canImport(AndroidBackend)
+            ScrollView(.horizontal) {
+                AngularGradientView()
             }
+            #else
+            Text("Angular Gradients are not supported on \(App.Backend)")
+            #endif
+        case .none:
+            Text("Please select a gradient type.")
         }
     }
 }

--- a/Examples/Sources/GradientsExample/GradientsApp.swift
+++ b/Examples/Sources/GradientsExample/GradientsApp.swift
@@ -51,9 +51,9 @@ struct GradientsApp: App {
     @ViewBuilder
     func scrollViewWithGradient() -> some View {
         #if !canImport(AndroidBackend)
-        ScrollView {
-            gradients()
-        }
+            ScrollView {
+                gradients()
+            }
         #else
             gradients()
         #endif
@@ -62,22 +62,22 @@ struct GradientsApp: App {
     @ViewBuilder
     func gradients() -> some View {
         switch gradientType {
-        case .linear:
-            LinearGradientView()
-        case .radial:
-            RadialGradientView()
-        case .angular:
-            #if !canImport(WinUIBackend) && !canImport(GtkBackend) && !canImport(AndroidBackend)
-                ScrollView(.horizontal) {
+            case .linear:
+                LinearGradientView()
+            case .radial:
+                RadialGradientView()
+            case .angular:
+                #if !canImport(WinUIBackend) && !canImport(GtkBackend) && !canImport(AndroidBackend)
+                    ScrollView(.horizontal) {
+                        AngularGradientView()
+                    }
+                #elseif canImport(AndroidBackend)
                     AngularGradientView()
-                }
-            #elseif canImport(AndroidBackend)
-                AngularGradientView()
-            #else
-                Text("Angular Gradients are not supported on \(App.Backend)")
-            #endif
-        case .none:
-            Text("Please select a gradient type.")
+                #else
+                    Text("Angular Gradients are not supported on \(App.Backend)")
+                #endif
+            case .none:
+                Text("Please select a gradient type.")
         }
     }
 }

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -5,7 +5,8 @@ import AndroidGraphics
 // swiftlint:disable force_try
 extension AndroidBackend: BackendFeatures.Gradients {
     public func createLinearGradientWidget() -> Widget {
-        return createPathWidget()
+        GradientWidget(Self.activity, environment: Self.env)
+            .as(AndroidKit.View.self)!
     }
 
     public func updateLinearGradientWidget(
@@ -14,13 +15,8 @@ extension AndroidBackend: BackendFeatures.Gradients {
         withSize size: SIMD2<Int>,
         in environment: EnvironmentValues
     ) {
-        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
-        let path = createPath()
-
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
-
-        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -32,9 +28,13 @@ extension AndroidBackend: BackendFeatures.Gradients {
             stops.append(Float(stop.location))
             colors.append(stop.color.resolve(in: environment).asColorInt())
         }
+        
+        let density = Float(environment.windowScaleFactor)
 
-        let pxWidth = Float(size.x) * density
-        let pxHeight = Float(size.y) * density
+        let width = Float(size.x)
+        let height = Float(size.y)
+        let pxWidth = width * density
+        let pxHeight = height * density
 
         let gradient = AndroidGraphics.LinearGradient(
             Float(gradient.startPoint.x) * pxWidth,
@@ -46,26 +46,20 @@ extension AndroidBackend: BackendFeatures.Gradients {
             tileClass.CLAMP,
             environment: Self.env
         )
+        
+        let gradientWidget = widget.as(GradientWidget.self)!
+        
+        gradientWidget.setLinearGradient(gradient: gradient)
 
-        _ = path.fillPaint.setShader(gradient)
-
-        updatePath(
-            path,
-            scuiPath,
-            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
-            pointsChanged: true,
-            environment: environment
-        )
-
-        widget.as(PathView.self)!.set(
-            path: path.path,
-            fillPaint: path.fillPaint,
-            strokePaint: path.strokePaint
+        gradientWidget.set(
+            width: pxWidth,
+            height: pxHeight
         )
     }
 
     public func createRadialGradientWidget() -> Widget {
-        return createPathWidget()
+        GradientWidget(Self.activity, environment: Self.env)
+            .as(AndroidKit.View.self)!
     }
 
     public func updateRadialGradientWidget(
@@ -74,13 +68,8 @@ extension AndroidBackend: BackendFeatures.Gradients {
         withSize size: SIMD2<Int>,
         in environment: EnvironmentValues
     ) {
-        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
-        let path = createPath()
-
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
-
-        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -92,9 +81,13 @@ extension AndroidBackend: BackendFeatures.Gradients {
             stops.append(Float(stop.location))
             colors.append(stop.color.resolve(in: environment).asColorInt())
         }
+        
+        let density = Float(environment.windowScaleFactor)
 
-        let pxWidth = Float(size.x) * density
-        let pxHeight = Float(size.y) * density
+        let width = Float(size.x)
+        let height = Float(size.y)
+        let pxWidth = width * density
+        let pxHeight = height * density
 
         let centerX = Float(gradient.center.x) * pxWidth
         let centerY = Float(gradient.center.y) * pxHeight
@@ -109,25 +102,19 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: Self.env
         )
 
-        path.fillPaint.setShader(gradient)
-
-        updatePath(
-            path,
-            scuiPath,
-            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
-            pointsChanged: true,
-            environment: environment
-        )
-
-        widget.as(PathView.self)!.set(
-            path: path.path,
-            fillPaint: path.fillPaint,
-            strokePaint: path.strokePaint
+        let gradientWidget = widget.as(GradientWidget.self)!
+        
+        gradientWidget.setRadialGradient(gradient: gradient)
+        
+        gradientWidget.set(
+            width: pxWidth,
+            height: pxHeight
         )
     }
 
     public func createAngularGradientWidget() -> Widget {
-        return createPathWidget()
+        GradientWidget(Self.activity, environment: Self.env)
+            .as(AndroidKit.View.self)!
     }
 
     public func updateAngularGradientWidget(
@@ -136,13 +123,8 @@ extension AndroidBackend: BackendFeatures.Gradients {
         withSize size: SIMD2<Int>,
         in environment: EnvironmentValues
     ) {
-        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
-        let path = createPath()
-
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
-
-        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -154,9 +136,13 @@ extension AndroidBackend: BackendFeatures.Gradients {
             stops.append(Float(stop.location))
             colors.append(stop.color.resolve(in: environment).asColorInt())
         }
+        
+        let density = Float(environment.windowScaleFactor)
 
-        let pxWidth = Float(size.x) * density
-        let pxHeight = Float(size.y) * density
+        let width = Float(size.x)
+        let height = Float(size.y)
+        let pxWidth = width * density
+        let pxHeight = height * density
 
         let centerX = Float(gradient.center.x) * pxWidth
         let centerY = Float(gradient.center.y) * pxHeight
@@ -191,20 +177,13 @@ extension AndroidBackend: BackendFeatures.Gradients {
 
         gradient.setLocalMatrix(gradientMatrix)
 
-        _ = path.fillPaint.setShader(gradient)
-
-        updatePath(
-            path,
-            scuiPath,
-            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
-            pointsChanged: true,
-            environment: environment
-        )
-
-        widget.as(PathView.self)!.set(
-            path: path.path,
-            fillPaint: path.fillPaint,
-            strokePaint: path.strokePaint
+        let gradientWidget = widget.as(GradientWidget.self)!
+        
+        gradientWidget.setSweepGradient(gradient: gradient)
+        
+        gradientWidget.set(
+            width: pxWidth,
+            height: pxHeight
         )
     }
 }

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -101,10 +101,10 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let centerX = Float(gradient.center.x) * pxWidth
         let centerY = Float(gradient.center.y) * pxHeight
 
-        let gradient = AndroidGraphics.RadialGradient(
+        let gradient = CustomRadialGradient(
             centerX,
             centerY,
-            Float(gradient.endRadius) * density,
+            Float(max(gradient.endRadius, gradient.startRadius, 1)) * density,
             colors,
             stops,
             tileClass.CLAMP,

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -1,0 +1,68 @@
+import SwiftCrossUI
+import AndroidKit
+import AndroidGraphics
+
+// swiftlint:disable force_try
+extension AndroidBackend: BackendFeatures.LinearGradients {
+    public func createLinearGradientWidget() -> Widget {
+        return createPathWidget()
+    }
+
+    public func updateLinearGradientWidget(
+        _ widget: Widget,
+        gradient: SwiftCrossUI.LinearGradient,
+        withSize size: SIMD2<Int>,
+        in environment: EnvironmentValues
+    ) {
+        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
+        let path = createPath()
+
+        let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
+        let colorClass = try! JavaClass<AndroidGraphics.Color>()
+
+        let density = widget.getResources().getDisplayMetrics().density
+
+        let count = gradient.gradient.stops.count
+        var stops = [Float]()
+        var colors = [Int32]()
+        stops.reserveCapacity(count)
+        colors.reserveCapacity(count)
+
+        for stop in gradient.gradient.stops {
+            stops.append(Float(stop.location))
+            colors.append(stop.color.resolve(in: environment).asColorInt())
+        }
+
+        let pxWidth = Float(size.x) * density
+        let pxHeight = Float(size.y) * density
+
+        let gradient = AndroidGraphics.LinearGradient(
+            Float(gradient.startPoint.x) * pxWidth,
+            Float(gradient.startPoint.y) * pxHeight,
+            Float(gradient.endPoint.x) * pxWidth,
+            Float(gradient.endPoint.y) * pxHeight,
+            colors,
+            stops,
+            tileClass.CLAMP,
+            environment: Self.env
+        )
+
+        path.fillPaint.setShader(gradient)
+
+        updatePath(
+            path,
+            scuiPath,
+            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
+            pointsChanged: true,
+            environment: environment
+        )
+
+        setSize(of: widget, to: size)
+
+        widget.as(PathView.self)!.set(
+            path: path.path,
+            fillPaint: path.fillPaint,
+            strokePaint: path.strokePaint
+        )
+    }
+}

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -47,11 +47,8 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: Self.env
         )
         
-        let gradientWidget = widget.as(GradientWidget.self)!
-        
-        gradientWidget.setLinearGradient(gradient: gradient)
-
-        gradientWidget.set(
+        widget.as(GradientWidget.self)!.set(
+            shader: gradient,
             width: pxWidth,
             height: pxHeight
         )
@@ -102,11 +99,8 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: Self.env
         )
 
-        let gradientWidget = widget.as(GradientWidget.self)!
-        
-        gradientWidget.setRadialGradient(gradient: gradient)
-        
-        gradientWidget.set(
+        widget.as(GradientWidget.self)!.set(
+            shader: gradient,
             width: pxWidth,
             height: pxHeight
         )
@@ -157,33 +151,23 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: Self.env
         )
 
-        let gradientMatrix = AndroidGraphics.Matrix()
-
         let scaleX: Float = 1.0
         let scaleY: Float = Float(size.y) / Float(size.x)
 
-        gradientMatrix.postRotate(
-            startAngleDegrees,
-            centerX,
-            centerY
-        )
-
-        gradientMatrix.postScale(
-            scaleX,
-            scaleY,
-            centerX,
-            centerY
-        )
-
-        gradient.setLocalMatrix(gradientMatrix)
-
         let gradientWidget = widget.as(GradientWidget.self)!
         
-        gradientWidget.setSweepGradient(gradient: gradient)
-        
         gradientWidget.set(
+            shader: gradient,
             width: pxWidth,
             height: pxHeight
+        )
+        
+        gradientWidget.setMatrix(
+            centerX: centerX,
+            centerY: centerY,
+            rotationAngle: startAngleDegrees,
+            scaleX: scaleX,
+            scaleY: scaleY
         )
     }
 }

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -3,7 +3,7 @@ import AndroidKit
 import AndroidGraphics
 
 // swiftlint:disable force_try
-extension AndroidBackend: BackendFeatures.LinearGradients {
+extension AndroidBackend: BackendFeatures.Gradients {
     public func createLinearGradientWidget() -> Widget {
         return createPathWidget()
     }
@@ -47,7 +47,157 @@ extension AndroidBackend: BackendFeatures.LinearGradients {
             environment: Self.env
         )
 
+        _ = path.fillPaint.setShader(gradient)
+
+        updatePath(
+            path,
+            scuiPath,
+            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
+            pointsChanged: true,
+            environment: environment
+        )
+
+        setSize(of: widget, to: size)
+
+        widget.as(PathView.self)!.set(
+            path: path.path,
+            fillPaint: path.fillPaint,
+            strokePaint: path.strokePaint
+        )
+    }
+
+    public func createRadialGradientWidget() -> Widget {
+        return createPathWidget()
+    }
+
+    public func updateRadialGradientWidget(
+        _ widget: Widget,
+        gradient: SwiftCrossUI.RadialGradient,
+        withSize size: SIMD2<Int>,
+        in environment: EnvironmentValues
+    ) {
+        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
+        let path = createPath()
+
+        let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
+        let colorClass = try! JavaClass<AndroidGraphics.Color>()
+
+        let density = widget.getResources().getDisplayMetrics().density
+
+        let count = gradient.gradient.stops.count
+        var stops = [Float]()
+        var colors = [Int32]()
+        stops.reserveCapacity(count)
+        colors.reserveCapacity(count)
+
+        for stop in gradient.adjustedStops {
+            stops.append(Float(stop.location))
+            colors.append(stop.color.resolve(in: environment).asColorInt())
+        }
+
+        let pxWidth = Float(size.x) * density
+        let pxHeight = Float(size.y) * density
+
+        let centerX = Float(gradient.center.x) * pxWidth
+        let centerY = Float(gradient.center.y) * pxHeight
+
+        let gradient = AndroidGraphics.RadialGradient(
+            centerX,
+            centerY,
+            Float(gradient.endRadius) * density,
+            colors,
+            stops,
+            tileClass.CLAMP,
+            environment: Self.env
+        )
+
         path.fillPaint.setShader(gradient)
+
+        updatePath(
+            path,
+            scuiPath,
+            bounds: .init(origin: .zero, size: .init(x: Double(size.x), y: Double(size.y))),
+            pointsChanged: true,
+            environment: environment
+        )
+
+        setSize(of: widget, to: size)
+
+        widget.as(PathView.self)!.set(
+            path: path.path,
+            fillPaint: path.fillPaint,
+            strokePaint: path.strokePaint
+        )
+    }
+
+    public func createAngularGradientWidget() -> Widget {
+        return createPathWidget()
+    }
+
+    public func updateAngularGradientWidget(
+        _ widget: Widget,
+        gradient: SwiftCrossUI.AngularGradient,
+        withSize size: SIMD2<Int>,
+        in environment: EnvironmentValues
+    ) {
+        let scuiPath = SwiftCrossUI.Rectangle().path(in: .init(origin: .zero, size: .init(Double(size.x), Double(size.y))))
+        let path = createPath()
+
+        let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
+        let colorClass = try! JavaClass<AndroidGraphics.Color>()
+
+        let density = widget.getResources().getDisplayMetrics().density
+
+        let count = gradient.gradient.stops.count
+        var stops = [Float]()
+        var colors = [Int32]()
+        stops.reserveCapacity(count)
+        colors.reserveCapacity(count)
+
+        for stop in gradient.adjustedStops {
+            stops.append(Float(stop.location))
+            colors.append(stop.color.resolve(in: environment).asColorInt())
+        }
+
+        let pxWidth = Float(size.x) * density
+        let pxHeight = Float(size.y) * density
+
+        let centerX = Float(gradient.center.x) * pxWidth
+        let centerY = Float(gradient.center.y) * pxHeight
+
+        let startAngleDegrees = Float(gradient.startAngle.degrees)
+
+        let gradient = AndroidGraphics.SweepGradient(
+            centerX,
+            centerY,
+            colors,
+            stops,
+            environment: Self.env
+        )
+
+        let gradientMatrix = AndroidGraphics.Matrix()
+
+        let scaleX: Float = 1.0
+        let scaleY: Float = Float(size.y) / Float(size.x)
+
+        gradientMatrix.reset()
+
+        gradientMatrix.postRotate(
+            startAngleDegrees,
+            centerX,
+            centerY
+        )
+
+        gradientMatrix.postScale(
+            scaleX,
+            scaleY,
+            centerX,
+            centerY
+        )
+
+        gradient.setLocalMatrix(gradientMatrix)
+
+        _ = path.fillPaint.setShader(gradient)
 
         updatePath(
             path,

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -20,7 +20,7 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
-        let density = widget.getResources().getDisplayMetrics().density
+        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -57,8 +57,6 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: environment
         )
 
-        setSize(of: widget, to: size)
-
         widget.as(PathView.self)!.set(
             path: path.path,
             fillPaint: path.fillPaint,
@@ -82,7 +80,7 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
-        let density = widget.getResources().getDisplayMetrics().density
+        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -121,8 +119,6 @@ extension AndroidBackend: BackendFeatures.Gradients {
             environment: environment
         )
 
-        setSize(of: widget, to: size)
-
         widget.as(PathView.self)!.set(
             path: path.path,
             fillPaint: path.fillPaint,
@@ -146,7 +142,7 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
-        let density = widget.getResources().getDisplayMetrics().density
+        let density = Float(environment.windowScaleFactor)
 
         let count = gradient.gradient.stops.count
         var stops = [Float]()
@@ -180,8 +176,6 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let scaleX: Float = 1.0
         let scaleY: Float = Float(size.y) / Float(size.x)
 
-        gradientMatrix.reset()
-
         gradientMatrix.postRotate(
             startAngleDegrees,
             centerX,
@@ -206,8 +200,6 @@ extension AndroidBackend: BackendFeatures.Gradients {
             pointsChanged: true,
             environment: environment
         )
-
-        setSize(of: widget, to: size)
 
         widget.as(PathView.self)!.set(
             path: path.path,

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -19,14 +19,9 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
         let count = gradient.gradient.stops.count
-        var stops = [Float]()
-        var colors = [Int32]()
-        stops.reserveCapacity(count)
-        colors.reserveCapacity(count)
-
-        for stop in gradient.gradient.stops {
-            stops.append(Float(stop.location))
-            colors.append(stop.color.resolve(in: environment).asColorInt())
+        let stops = gradient.gradient.stops.map { Float($0.location) }
+        let colors = gradient.gradient.stops.map { stop in
+            stop.color.resolve(in: environment).asColorInt()
         }
         
         let density = Float(environment.windowScaleFactor)
@@ -69,14 +64,9 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
         let count = gradient.gradient.stops.count
-        var stops = [Float]()
-        var colors = [Int32]()
-        stops.reserveCapacity(count)
-        colors.reserveCapacity(count)
-
-        for stop in gradient.adjustedStops {
-            stops.append(Float(stop.location))
-            colors.append(stop.color.resolve(in: environment).asColorInt())
+        let stops = gradient.gradient.stops.map { Float($0.location) }
+        let colors = gradient.gradient.stops.map { stop in
+            stop.color.resolve(in: environment).asColorInt()
         }
         
         let density = Float(environment.windowScaleFactor)
@@ -121,14 +111,9 @@ extension AndroidBackend: BackendFeatures.Gradients {
         let colorClass = try! JavaClass<AndroidGraphics.Color>()
 
         let count = gradient.gradient.stops.count
-        var stops = [Float]()
-        var colors = [Int32]()
-        stops.reserveCapacity(count)
-        colors.reserveCapacity(count)
-
-        for stop in gradient.adjustedStops {
-            stops.append(Float(stop.location))
-            colors.append(stop.color.resolve(in: environment).asColorInt())
+        let stops = gradient.gradient.stops.map { Float($0.location) }
+        let colors = gradient.gradient.stops.map { stop in
+            stop.color.resolve(in: environment).asColorInt()
         }
         
         let density = Float(environment.windowScaleFactor)
@@ -152,7 +137,7 @@ extension AndroidBackend: BackendFeatures.Gradients {
         )
 
         let scaleX: Float = 1.0
-        let scaleY: Float = Float(size.y) / Float(size.x)
+        let scaleY = Float(size.y) / Float(size.x)
 
         let gradientWidget = widget.as(GradientWidget.self)!
         

--- a/Sources/AndroidBackend/CustomRadialGradient.swift
+++ b/Sources/AndroidBackend/CustomRadialGradient.swift
@@ -1,0 +1,19 @@
+import SwiftJava
+import AndroidKit
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.CustomRadialGradient",
+    extends: AndroidKit.RadialGradient.self
+)
+class CustomRadialGradient: AndroidKit.RadialGradient {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ centerX: Float,
+        _ centerY: Float,
+        _ radius: Float,
+        _ colors: [Int32],
+        _ stops: [Float],
+        _ tileMode: Shader.TileMode?,
+        environment: JNIEnvironment? = nil
+    )
+}

--- a/Sources/AndroidBackend/CustomRadialGradient.swift
+++ b/Sources/AndroidBackend/CustomRadialGradient.swift
@@ -1,6 +1,10 @@
 import SwiftJava
 import AndroidKit
 
+// This class exists to circumvent the weird issue of the AndroidGraphics bindings
+// we use not finding the class android.graphics.RadialGradient.
+// On the Kotlin side of things CustomRadialGradient is just a subclass of
+// RadialGradient, without any additional logic.
 @JavaClass(
     "dev.swiftcrossui.androidbackend.CustomRadialGradient",
     extends: AndroidKit.RadialGradient.self

--- a/Sources/AndroidBackend/GradientWidget.swift
+++ b/Sources/AndroidBackend/GradientWidget.swift
@@ -15,22 +15,19 @@ class GradientWidget: JavaObject {
     
     @JavaMethod
     func set(
+        shader: AndroidGraphics.Shader?,
         width: Float,
         height: Float
     )
     
+    /// Applies a transformation matrix to the currently used Shader.
+    /// Only call this method AFTER set, to ensure the shader is set.
     @JavaMethod
-    func setLinearGradient(
-        gradient: AndroidGraphics.LinearGradient?
-    )
-    
-    @JavaMethod
-    func setRadialGradient(
-        gradient: AndroidGraphics.RadialGradient?
-    )
-    
-    @JavaMethod
-    func setSweepGradient(
-        gradient: AndroidGraphics.SweepGradient?
+    func setMatrix(
+        centerX: Float,
+        centerY: Float,
+        rotationAngle: Float,
+        scaleX: Float,
+        scaleY: Float
     )
 }

--- a/Sources/AndroidBackend/GradientWidget.swift
+++ b/Sources/AndroidBackend/GradientWidget.swift
@@ -1,0 +1,36 @@
+import SwiftJava
+import AndroidKit
+import AndroidGraphics
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.GradientWidget",
+    extends: AndroidKit.View.self
+)
+class GradientWidget: JavaObject {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: Activity?,
+        environment: JNIEnvironment? = nil
+    )
+    
+    @JavaMethod
+    func set(
+        width: Float,
+        height: Float
+    )
+    
+    @JavaMethod
+    func setLinearGradient(
+        gradient: AndroidGraphics.LinearGradient?
+    )
+    
+    @JavaMethod
+    func setRadialGradient(
+        gradient: AndroidGraphics.RadialGradient?
+    )
+    
+    @JavaMethod
+    func setSweepGradient(
+        gradient: AndroidGraphics.SweepGradient?
+    )
+}

--- a/Sources/AndroidBackend/Kotlin/CustomRadialGradient.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomRadialGradient.kt
@@ -1,0 +1,13 @@
+package dev.swiftcrossui.androidbackend
+
+import android.graphics.RadialGradient
+import android.graphics.Shader
+
+class CustomRadialGradient(
+    centerX: Float,
+    centerY: Float,
+    radius: Float,
+    colors: IntArray,
+    stops: FloatArray?,
+    tileMode: Shader.TileMode
+) : RadialGradient(centerX, centerY, radius, colors, stops, tileMode)

--- a/Sources/AndroidBackend/Kotlin/GradientWidget.kt
+++ b/Sources/AndroidBackend/Kotlin/GradientWidget.kt
@@ -14,7 +14,7 @@ import android.view.View
 
 class GradientWidget(activity: Activity): View(activity) {
     private var path = Path()
-    private var matrix = Matrix()
+    private var matrix: Matrix? = null
     private var fillPaint = Paint().apply {
         style = Paint.Style.FILL
         color = Color.RED
@@ -25,8 +25,8 @@ class GradientWidget(activity: Activity): View(activity) {
         this.fillPaint.shader = shader
         
         // Reset path and draw rectangle for current bounds
-        this.path.reset()
         this.path.apply {
+            reset()
             addRect(0f, 0f, width, height, Path.Direction.CW)
         }
     }
@@ -39,10 +39,13 @@ class GradientWidget(activity: Activity): View(activity) {
         scaleX: Float,
         scaleY: Float
     ) {
-        this.matrix.reset()
-        this.matrix.postRotate(rotationAngle, centerX, centerY)
-        this.matrix.postScale(scaleX, scaleY, centerX, centerY)
-        this.fillPaint.shader?.setLocalMatrix(this.matrix)
+        // If matrix exists use it, else initialize, store and use new reference
+        val localMatrix = matrix ?: Matrix().also { matrix = it }
+        
+        localMatrix.reset()
+        localMatrix.postRotate(rotationAngle, centerX, centerY)
+        localMatrix.postScale(scaleX, scaleY, centerX, centerY)
+        this.fillPaint.shader?.setLocalMatrix(localMatrix)
     }
     
     override fun onDraw(canvas: Canvas) {

--- a/Sources/AndroidBackend/Kotlin/GradientWidget.kt
+++ b/Sources/AndroidBackend/Kotlin/GradientWidget.kt
@@ -1,0 +1,45 @@
+package dev.swiftcrossui.androidbackend
+
+import android.app.Activity
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Shader
+import android.graphics.LinearGradient
+import android.graphics.RadialGradient
+import android.graphics.SweepGradient
+import android.view.View
+
+class GradientWidget(activity: Activity): View(activity) {
+    private var path: Path = Path()
+    private var fillPaint: Paint = Paint().apply {
+        style = Paint.Style.FILL
+        color = Color.RED
+        isAntiAlias = true
+    }
+    
+    fun set(width: Float, height: Float) {
+        // Reset path and draw rectangle for current bounds
+        this.path.reset()
+        this.path.apply {
+            addRect(0f, 0f, width, height, Path.Direction.CW)
+        }
+    }
+    
+    fun setLinearGradient(gradient: LinearGradient) {
+        this.fillPaint.shader = gradient
+    }
+    
+    fun setRadialGradient(gradient: RadialGradient) {
+        this.fillPaint.shader = gradient
+    }
+    
+    fun setSweepGradient(gradient: SweepGradient) {
+        this.fillPaint.shader = gradient
+    }
+    
+    override fun onDraw(canvas: Canvas) {
+        canvas.drawPath(path, fillPaint)
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/GradientWidget.kt
+++ b/Sources/AndroidBackend/Kotlin/GradientWidget.kt
@@ -17,7 +17,6 @@ class GradientWidget(activity: Activity): View(activity) {
     private var matrix: Matrix? = null
     private var fillPaint = Paint().apply {
         style = Paint.Style.FILL
-        color = Color.RED
         isAntiAlias = true
     }
     
@@ -26,7 +25,7 @@ class GradientWidget(activity: Activity): View(activity) {
         
         // Reset path and draw rectangle for current bounds
         this.path.apply {
-            reset()
+            rewind()
             addRect(0f, 0f, width, height, Path.Direction.CW)
         }
     }

--- a/Sources/AndroidBackend/Kotlin/GradientWidget.kt
+++ b/Sources/AndroidBackend/Kotlin/GradientWidget.kt
@@ -9,17 +9,21 @@ import android.graphics.Shader
 import android.graphics.LinearGradient
 import android.graphics.RadialGradient
 import android.graphics.SweepGradient
+import android.graphics.Matrix
 import android.view.View
 
 class GradientWidget(activity: Activity): View(activity) {
-    private var path: Path = Path()
-    private var fillPaint: Paint = Paint().apply {
+    private var path = Path()
+    private var matrix = Matrix()
+    private var fillPaint = Paint().apply {
         style = Paint.Style.FILL
         color = Color.RED
         isAntiAlias = true
     }
     
-    fun set(width: Float, height: Float) {
+    fun set(shader: Shader, width: Float, height: Float) {
+        this.fillPaint.shader = shader
+        
         // Reset path and draw rectangle for current bounds
         this.path.reset()
         this.path.apply {
@@ -27,16 +31,18 @@ class GradientWidget(activity: Activity): View(activity) {
         }
     }
     
-    fun setLinearGradient(gradient: LinearGradient) {
-        this.fillPaint.shader = gradient
-    }
-    
-    fun setRadialGradient(gradient: RadialGradient) {
-        this.fillPaint.shader = gradient
-    }
-    
-    fun setSweepGradient(gradient: SweepGradient) {
-        this.fillPaint.shader = gradient
+    // Only call this method AFTER set, to ensure the shader is set.
+    fun setMatrix(
+        centerX: Float,
+        centerY: Float,
+        rotationAngle: Float,
+        scaleX: Float,
+        scaleY: Float
+    ) {
+        this.matrix.reset()
+        this.matrix.postRotate(rotationAngle, centerX, centerY)
+        this.matrix.postScale(scaleX, scaleY, centerX, centerY)
+        this.fillPaint.shader?.setLocalMatrix(this.matrix)
     }
     
     override fun onDraw(canvas: Canvas) {


### PR DESCRIPTION
Adds support for all currently supported types of gradients on AndroidBackend.

- [x] LinearGradient
- [x] RadialGradient
- [x] AngularGradient
- [x] Fix class not found for RadialGradient
- [x] Test RadialGradient

Current issue with RadialGradient:
```
SwiftRuntime: AndroidGraphics/RadialGradient.swift:7: Fatal error: 'try!' expression unexpectedly raised an error: java.lang.ClassNotFoundException: Didn't find class "android.graphics.RadialGradient" on path: DexPathList[[zip file "/data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/base.apk"],nativeLibraryDirectories=[/data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/lib/arm64, /data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
05-14 22:01:44.713  6923  7048 E Swift   : AndroidGraphics/RadialGradient.swift:7: Fatal error: 'try!' expression unexpectedly raised an error: java.lang.ClassNotFoundException: Didn't find class "android.graphics.RadialGradient" on path: DexPathList[[zip file "/data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/base.apk"],nativeLibraryDirectories=[/data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/lib/arm64, /data/app/~~59ImuJ13QCBQxXjCQGr2Yw==/dev.swiftcrossui.gradientsexample-Hku2_NZTVGz5A6mElLgVUQ==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
```

Edit: The above issue was resolved.

This PR implements Gradient support on Android.
To make the upcoming support for gradient filled shapes easier, it is already built on Path.
Android Paths can be filled by setting a shader on the respective paint. 
android.graphics.LinearGradient/RadialGradient/SweepGradient(conic/angular) implement Shader.

Shaders expect dimensions to be passed in pixels, size is dp. I convert it to pixels by multiplying by density.

Radial and AngularGradient use the existing adjusted stops computed property to polyfill support for startRadius on RadialGradient and endAngle on AngularGradient.

To match our existing AngularGradient behavior on all other supported platforms, the SweepGradient is transformed via a android.graphics.matrix.
The matrix both stretches/squeezes the SweepGradientShader so its elliptical, like CAGradientLayer/SwiftUI and rotates it by startAngle.degrees, to polyfill support for startAngle.

@bbrk24 knows Path and the AndroidBackend better than I do, so I welcome it’s suggestions regarding performance optimizations/simplifications. 

Though I would like to mention that all create/updateFooGradient functions will be removed in the future and handled inside the path methods.