### PR TITLE
Fix: disconnect GTK signal handlers in `deinit` to prevent crashes

### DIFF
--- a/Sources/AndroidBackend/Kotlin/CustomRadialGradient.kt
+++ b/Sources/AndroidBackend/Kotlin/CustomRadialGradient.kt
@@ -9,5 +9,5 @@ class CustomRadialGradient(
     radius: Float,
     colors: IntArray,
     stops: FloatArray?,
-    tileMode: Shader.TileMode
+    tileMode: Shader.TileMode,
 ) : RadialGradient(centerX, centerY, radius, colors, stops, tileMode)

--- a/Sources/AndroidBackend/Kotlin/GradientWidget.kt
+++ b/Sources/AndroidBackend/Kotlin/GradientWidget.kt
@@ -2,51 +2,48 @@ package dev.swiftcrossui.androidbackend
 
 import android.app.Activity
 import android.graphics.Canvas
-import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.Shader
-import android.graphics.LinearGradient
-import android.graphics.RadialGradient
-import android.graphics.SweepGradient
-import android.graphics.Matrix
 import android.view.View
 
-class GradientWidget(activity: Activity): View(activity) {
+class GradientWidget(activity: Activity) : View(activity) {
     private var path = Path()
     private var matrix: Matrix? = null
-    private var fillPaint = Paint().apply {
-        style = Paint.Style.FILL
-        isAntiAlias = true
-    }
-    
+    private var fillPaint =
+        Paint().apply {
+            style = Paint.Style.FILL
+            isAntiAlias = true
+        }
+
     fun set(shader: Shader, width: Float, height: Float) {
         this.fillPaint.shader = shader
-        
+
         // Reset path and draw rectangle for current bounds
         this.path.apply {
             rewind()
             addRect(0f, 0f, width, height, Path.Direction.CW)
         }
     }
-    
+
     // Only call this method AFTER set, to ensure the shader is set.
     fun setMatrix(
         centerX: Float,
         centerY: Float,
         rotationAngle: Float,
         scaleX: Float,
-        scaleY: Float
+        scaleY: Float,
     ) {
         // If matrix exists use it, else initialize, store and use new reference
         val localMatrix = matrix ?: Matrix().also { matrix = it }
-        
+
         localMatrix.reset()
         localMatrix.postRotate(rotationAngle, centerX, centerY)
         localMatrix.postScale(scaleX, scaleY, centerX, centerY)
         this.fillPaint.shader?.setLocalMatrix(localMatrix)
     }
-    
+
     override fun onDraw(canvas: Canvas) {
         canvas.drawPath(path, fillPaint)
     }

--- a/Sources/Gtk/GObject.swift
+++ b/Sources/Gtk/GObject.swift
@@ -18,6 +18,12 @@ open class GObject: GObjectRepresentable {
     }
 
     deinit {
+        // disconnect all GTK signal handlers before releasing the object
+        // to prevent callbacks firing on deallocated Swift wrapper instances.
+        for (id, _) in signals {
+            g_signal_handler_disconnect(gobjectPointer, id)
+        }
+  
         g_object_unref(gobjectPointer)
     }
 

--- a/Sources/Gtk/Generated/Button.swift
+++ b/Sources/Gtk/Generated/Button.swift
@@ -81,8 +81,8 @@ open class Button: Widget, Actionable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/Calendar.swift
+++ b/Sources/Gtk/Generated/Calendar.swift
@@ -68,8 +68,8 @@ open class Calendar: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "day-selected") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/CheckButton.swift
+++ b/Sources/Gtk/Generated/CheckButton.swift
@@ -90,8 +90,8 @@ open class CheckButton: Widget, Actionable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/DrawingArea.swift
+++ b/Sources/Gtk/Generated/DrawingArea.swift
@@ -91,8 +91,8 @@ open class DrawingArea: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, Int, Int, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/DropDown.swift
+++ b/Sources/Gtk/Generated/DropDown.swift
@@ -62,8 +62,8 @@ open class DropDown: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/Entry.swift
+++ b/Sources/Gtk/Generated/Entry.swift
@@ -101,10 +101,17 @@ open class Entry: Widget, CellEditable, Editable {
             gtk_entry_new_with_buffer(buffer)
         )
     }
+    
+    /// Prevents duplicate GTK signal connections if the view is re-parented.
+    private var signalsConnected = false
 
     open override func didMoveToParent() {
         super.didMoveToParent()
 
+        // guard against reconnecting signals if already set up.
+        guard !signalsConnected else { return }
+        signalsConnected = true
+      
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }
             self.activate?(self)

--- a/Sources/Gtk/Generated/Entry.swift
+++ b/Sources/Gtk/Generated/Entry.swift
@@ -101,17 +101,10 @@ open class Entry: Widget, CellEditable, Editable {
             gtk_entry_new_with_buffer(buffer)
         )
     }
-    
-    /// Prevents duplicate GTK signal connections if the view is re-parented.
-    private var signalsConnected = false
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
-        // guard against reconnecting signals if already set up.
-        guard !signalsConnected else { return }
-        signalsConnected = true
-      
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }
             self.activate?(self)

--- a/Sources/Gtk/Generated/GLArea.swift
+++ b/Sources/Gtk/Generated/GLArea.swift
@@ -119,8 +119,8 @@ open class GLArea: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "create-context") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/Image.swift
+++ b/Sources/Gtk/Generated/Image.swift
@@ -126,8 +126,8 @@ open class Image: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/Label.swift
+++ b/Sources/Gtk/Generated/Label.swift
@@ -243,8 +243,8 @@ open class Label: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate-current-link") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/ListBox.swift
+++ b/Sources/Gtk/Generated/ListBox.swift
@@ -77,8 +77,8 @@ open class ListBox: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate-cursor-row") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/Picture.swift
+++ b/Sources/Gtk/Generated/Picture.swift
@@ -89,8 +89,8 @@ open class Picture: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/Popover.swift
+++ b/Sources/Gtk/Generated/Popover.swift
@@ -84,8 +84,8 @@ open class Popover: Widget, Native, ShortcutManager {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate-default") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/ProgressBar.swift
+++ b/Sources/Gtk/Generated/ProgressBar.swift
@@ -58,8 +58,8 @@ open class ProgressBar: Widget, Orientable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/Range.swift
+++ b/Sources/Gtk/Generated/Range.swift
@@ -21,8 +21,8 @@ import CGtk
 /// fine-tuning mode.
 open class Range: Widget, Orientable {
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, Double, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/Scale.swift
+++ b/Sources/Gtk/Generated/Scale.swift
@@ -127,8 +127,8 @@ open class Scale: Range {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/SpinButton.swift
+++ b/Sources/Gtk/Generated/SpinButton.swift
@@ -153,8 +153,8 @@ open class SpinButton: Widget, CellEditable, Editable, Orientable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk/Generated/Spinner.swift
+++ b/Sources/Gtk/Generated/Spinner.swift
@@ -28,8 +28,8 @@ open class Spinner: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk/Generated/Switch.swift
+++ b/Sources/Gtk/Generated/Switch.swift
@@ -50,8 +50,8 @@ open class Switch: Widget, Actionable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/Button.swift
+++ b/Sources/Gtk3/Generated/Button.swift
@@ -70,8 +70,8 @@ open class Button: Bin, Activatable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/Calendar.swift
+++ b/Sources/Gtk3/Generated/Calendar.swift
@@ -34,8 +34,8 @@ open class Calendar: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "day-selected") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/Entry.swift
+++ b/Sources/Gtk3/Generated/Entry.swift
@@ -92,8 +92,8 @@ open class Entry: Widget, CellEditable, Editable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/EventBox.swift
+++ b/Sources/Gtk3/Generated/EventBox.swift
@@ -16,8 +16,8 @@ open class EventBox: Bin {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/GLArea.swift
+++ b/Sources/Gtk3/Generated/GLArea.swift
@@ -112,8 +112,8 @@ open class GLArea: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "create-context") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/Image.swift
+++ b/Sources/Gtk3/Generated/Image.swift
@@ -161,8 +161,8 @@ open class Image: Misc {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/Label.swift
+++ b/Sources/Gtk3/Generated/Label.swift
@@ -205,8 +205,8 @@ open class Label: Misc {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate-current-link") { [weak self] () in
             guard let self else { return }

--- a/Sources/Gtk3/Generated/MenuShell.swift
+++ b/Sources/Gtk3/Generated/MenuShell.swift
@@ -34,8 +34,8 @@ import CGtk3
 /// grab and receive all key presses.
 open class MenuShell: Container {
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, Bool, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/ProgressBar.swift
+++ b/Sources/Gtk3/Generated/ProgressBar.swift
@@ -52,8 +52,8 @@ open class ProgressBar: Widget, Orientable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/Range.swift
+++ b/Sources/Gtk3/Generated/Range.swift
@@ -14,8 +14,8 @@ import CGtk3
 /// “fill level” on range widgets. See gtk_range_set_fill_level().
 open class Range: Widget, Orientable {
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, Double, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/Scale.swift
+++ b/Sources/Gtk3/Generated/Scale.swift
@@ -108,8 +108,8 @@ open class Scale: Range {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/SpinButton.swift
+++ b/Sources/Gtk3/Generated/SpinButton.swift
@@ -139,8 +139,8 @@ open class SpinButton: Entry, Orientable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, GtkScrollType, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/Spinner.swift
+++ b/Sources/Gtk3/Generated/Spinner.swift
@@ -24,8 +24,8 @@ open class Spinner: Widget {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         let handler0: @convention(c) (
             UnsafeMutableRawPointer, OpaquePointer, UnsafeMutableRawPointer

--- a/Sources/Gtk3/Generated/Switch.swift
+++ b/Sources/Gtk3/Generated/Switch.swift
@@ -29,8 +29,8 @@ open class Switch: Widget, Activatable {
         )
     }
 
-    open override func didMoveToParent() {
-        super.didMoveToParent()
+    open override func registerSignals() {
+        super.registerSignals()
 
         addSignal(name: "activate") { [weak self] () in
             guard let self else { return }

--- a/Sources/GtkCodeGen/GtkCodeGen.swift
+++ b/Sources/GtkCodeGen/GtkCodeGen.swift
@@ -642,7 +642,7 @@ struct GtkCodeGen {
             exprs.append(expr.description)
         }
 
-      let methodName = "registerSignals"
+        let methodName = "registerSignals"
 
         return DeclSyntax(
             """

--- a/Sources/GtkCodeGen/GtkCodeGen.swift
+++ b/Sources/GtkCodeGen/GtkCodeGen.swift
@@ -520,8 +520,7 @@ struct GtkCodeGen {
                     signals.map { signal in
                         signal.1
                     },
-                    namespace: namespace,
-                    isWidget: inheritanceChain.contains("Widget")
+                    namespace: namespace
                 )
             )
         }
@@ -558,8 +557,7 @@ struct GtkCodeGen {
 
     static func generateSignalRegistrationMethod(
         _ signals: [Signal],
-        namespace: Namespace,
-        isWidget: Bool
+        namespace: Namespace
     ) -> DeclSyntax {
         var exprs: [String] = []
 
@@ -644,7 +642,7 @@ struct GtkCodeGen {
             exprs.append(expr.description)
         }
 
-        let methodName = isWidget ? "didMoveToParent" : "registerSignals"
+      let methodName = "registerSignals"
 
         return DeclSyntax(
             """


### PR DESCRIPTION
GTK signals are bound to the widget's lifetime, not the Swift wrapper's. When the Swift wrapper deallocated, its signal boxes were freed - but GTK held live signal connections that kept firing into the now-freed memory, causing `EXC_BAD_ACCESS` and `EXC_BAD_INSTRUCTION` crashes.

> [!IMPORTANT]
> The crash was confirmed by inspecting the closure context in the debugger, which showed an `NSDateComponent`'s object occupying memory that previously held a `SignalBox1` - a clear sign of "use-after-free".

Fixes:
- Disconnect all GTK signal handlers in `deinit` before releasing the `GObject`, ensuring no callbacks fire after the Swift wrapper is gone.
- ~~`guard` against duplicate signal connections if a view is re-parented, which previously caused multiple handlers to fire per event.~~
- move all signal connections into a `registerSignals()` method and out of `didMoveToParent()` calls, which previously caused multiple handlers to fire per event every time a view was re-parented.

Potentially related issue(s) this fix would solve:
- https://github.com/moreSwift/swift-cross-ui/issues/434
- https://github.com/moreSwift/swift-cross-ui/issues/433