### PR TITLE
Rudimentary icon support

### DIFF
--- a/Examples/Bundler.toml
+++ b/Examples/Bundler.toml
@@ -104,6 +104,11 @@ icon = 'Icons/MusicPlayerExample.png'
 identifier = 'dev.swiftcrossui.GradientsExample'
 product = 'GradientsExample'
 version = '0.1.0'
+
+[apps.IconsExample]
+identifier = 'dev.swiftcrossui.IconsExample'
+product = 'IconsExample'
+version = '0.1.0'
     
 [apps.TapGesturesExample]
 identifier = 'dev.swiftcrossui.TapGesturesExample'

--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c307864878e040a9f629f6c205b2cd1401625502dfa5bda8edbfb8b1d4d1617",
+  "originHash" : "2235a29b424bea0d76a8e8ab64057502d6b7d344da3a135aec70d6b9041a73d6",
   "pins" : [
     {
       "identity" : "aexml",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "db806756c989760b35108146381535aec231092b",
         "version" : "4.7.0"
-      }
-    },
-    {
-      "identity" : "androidkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/AndroidKit",
-      "state" : {
-        "revision" : "d5142b5a9b90fa940be54a2a41d7fd5842f21111",
-        "version" : "0.8.1"
       }
     },
     {
@@ -137,15 +128,6 @@
       }
     },
     {
-      "identity" : "swift-android-native",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
-      "state" : {
-        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
-        "version" : "2.0.1"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -253,24 +235,6 @@
       }
     },
     {
-      "identity" : "swift-java",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/swift-java",
-      "state" : {
-        "revision" : "e04c0ed6af98936ca6300e94be9a19869df418a2",
-        "version" : "0.5.1"
-      }
-    },
-    {
-      "identity" : "swift-java-jni-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-java-jni-core",
-      "state" : {
-        "revision" : "b440a0be98381550cf189c903782e817619ffa05",
-        "version" : "0.5.1"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
@@ -325,15 +289,6 @@
       }
     },
     {
-      "identity" : "swift-subprocess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-subprocess.git",
-      "state" : {
-        "revision" : "11633673a41f509f8945f23c96c7acd4adafd679",
-        "version" : "0.5.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
@@ -367,24 +322,6 @@
       "state" : {
         "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
         "version" : "6.0.3"
-      }
-    },
-    {
-      "identity" : "swiftjavalang",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/SwiftJavaLang.git",
-      "state" : {
-        "revision" : "000441db9284536a2af611745b82ec7653dca5bc",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "swiftkotlin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/SwiftKotlin.git",
-      "state" : {
-        "revision" : "ad30daacb7e4666e1a56bfdd48498f5ac4ff081d",
-        "version" : "0.3.0"
       }
     },
     {

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -108,6 +108,10 @@ let package = Package(
             dependencies: exampleDependencies
         ),
         .executableTarget(
+            name: "IconsExample",
+            dependencies: exampleDependencies
+        ),
+        .executableTarget(
             name: "MusicPlayerExample",
             dependencies: [
                 .product(name: "MiniAudio", package: "swift-miniaudio")

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -62,12 +62,21 @@ struct ControlsApp: App {
                         }
 
                         VStack {
+                            Text("Icons")
+                            HStack {
+                                Icon.share
+                                Icon.plus
+                                Icon.edit
+                                Icon.back
+                            }
+                        }
+
+                        VStack {
                             Text("Menu button")
                             Menu("Menu") {
                                 Button("Button item") {
                                     print("Button item clicked")
                                 }
-                                Divider()
                                 Toggle("Toggle item", isOn: $menuToggleState)
                                 Menu("Submenu") {
                                     Text("Text item 1")

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -62,16 +62,6 @@ struct ControlsApp: App {
                         }
 
                         VStack {
-                            Text("Icons")
-                            HStack {
-                                Icon.share
-                                Icon.plus
-                                Icon.edit
-                                Icon.back
-                            }
-                        }
-
-                        VStack {
                             Text("Menu button")
                             Menu("Menu") {
                                 Button("Button item") {

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -1,0 +1,35 @@
+import DefaultBackend
+import Foundation
+import SwiftCrossUI
+
+#if canImport(SwiftBundlerRuntime)
+    import SwiftBundlerRuntime
+#endif
+
+@main
+@HotReloadable
+struct IconsApp: App {
+    var body: some Scene {
+        WindowGroup("IconsApp") {
+            #hotReloadable {
+                VStack(spacing: 30) {
+                    VStack {
+                        Text("Icons")
+                        HStack {
+                            Icon.share
+                            Icon.plus
+                            Icon.edit
+                            Icon.back
+                        }
+                    }
+
+//                    VStack {
+//                        Text("Bigger Icons")
+//                        Icon.share
+//                            .frame(width: 50, height: 50)
+//                    }
+                }.padding()
+            }
+        }.defaultSize(width: 300, height: 300)
+    }
+}

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -9,6 +9,8 @@ import SwiftCrossUI
 @main
 @HotReloadable
 struct IconsApp: App {
+    @State var iconSize = 20.0
+
     var body: some Scene {
         WindowGroup("IconsApp") {
             #hotReloadable {
@@ -18,16 +20,20 @@ struct IconsApp: App {
                         HStack {
                             Icon.share
                             Icon.plus
+                                .foregroundColor(.green)
                             Icon.edit
                             Icon.back
                         }
                     }
 
-//                    VStack {
-//                        Text("Bigger Icons")
-//                        Icon.share
-//                            .frame(width: 50, height: 50)
-//                    }
+                    VStack {
+                        Text("Icon Resizing")
+                        #if !canImport(AndroidBackend)
+                            Slider(value: $iconSize, in: 10...100)
+                        #endif
+                        Icon.share
+                            .font(.system(size: iconSize))
+                    }
                 }.padding()
             }
         }.defaultSize(width: 300, height: 300)

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -11,33 +11,56 @@ import SwiftCrossUI
 struct IconsApp: App {
     @State var iconSize = 20.0
 
+    let weights: [Font.Weight] = [
+        .ultraLight,
+        .thin,
+        .light,
+        .regular,
+        .medium,
+        .semibold,
+        .bold,
+        .heavy,
+        .black,
+    ]
+
     var body: some Scene {
         WindowGroup("IconsApp") {
             #hotReloadable {
-                VStack(spacing: 30) {
+                VStack {
                     VStack {
-                        Text("Icons")
-                        HStack {
-                            Icon.share
-                            Icon.plus
-                                .foregroundColor(.green)
-                            Icon.back
-                            Icon.cut
-                            Icon.copy
-                            Icon.paste
+                        Text("Icon Weights")
+                        ForEach(weights, id: \.self) { weight in
+                            HStack {
+                                Text("\(weight)")
+                                Spacer()
+
+                                Icon.share
+                                Icon.plus
+                                    .foregroundColor(.green)
+                                Icon.back
+                                Icon.cut
+                                Icon.copy
+                                Icon.paste
+                            }
+                            .fontWeight(weight)
                         }
                     }
 
-                    VStack {
-                        Text("Icon Resizing")
-                        #if !canImport(AndroidBackend)
+                    #if !canImport(AndroidBackend)
+                        Divider()
+
+                        VStack {
+                            Text("Icon Resizing")
                             Slider(value: $iconSize, in: 10...100)
-                        #endif
-                        Icon.share
-                            .font(.system(size: iconSize))
-                    }
-                }.padding()
+                            Icon.share
+                                .font(.system(size: iconSize))
+                        }
+                    #endif
+                }
+                .padding()
             }
-        }.defaultSize(width: 300, height: 300)
+        }
+        .defaultSize(width: 300, height: 300)
+        .windowResizability(.contentSize)
     }
 }

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -10,6 +10,7 @@ import SwiftCrossUI
 @HotReloadable
 struct IconsApp: App {
     @State var iconSize = 20.0
+    @State var showForegroundColors = false
 
     let weights: [Font.Weight] = [
         .ultraLight,
@@ -52,8 +53,11 @@ struct IconsApp: App {
                         VStack {
                             Text("Icon Resizing")
                             Slider(value: $iconSize, in: 10...100)
-                            Icon.share
-                                .font(.system(size: iconSize))
+                            HStack {
+                                Icon.copy
+                                Text("Some text for scale")
+                            }
+                            .font(.system(size: iconSize))
                         }
                     #endif
                 }
@@ -62,5 +66,10 @@ struct IconsApp: App {
         }
         .defaultSize(width: 300, height: 300)
         .windowResizability(.contentSize)
+        .commands {
+            CommandMenu("Icons") {
+                Toggle("Show foreground colors", isOn: $showForegroundColors)
+            }
+        }
     }
 }

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -21,8 +21,10 @@ struct IconsApp: App {
                             Icon.share
                             Icon.plus
                                 .foregroundColor(.green)
-                            Icon.edit
                             Icon.back
+                            Icon.cut
+                            Icon.copy
+                            Icon.paste
                         }
                     }
 

--- a/Examples/Sources/IconsExample/IconsApp.swift
+++ b/Examples/Sources/IconsExample/IconsApp.swift
@@ -12,6 +12,40 @@ struct IconsApp: App {
     @State var iconSize = 20.0
     @State var showForegroundColors = false
 
+    var body: some Scene {
+        WindowGroup("IconsApp") {
+            #hotReloadable {
+                VStack {
+                    IconWeightsView(showForegroundColors: $showForegroundColors)
+
+                    Divider()
+
+                    VStack {
+                        Text("Icon Resizing")
+                        Slider(value: $iconSize, in: 10...100)
+                        HStack {
+                            Icon.system(.copy)
+                            Text("Some text for scale")
+                        }
+                        .font(.system(size: iconSize))
+                    }
+                }
+                .padding()
+            }
+        }
+        .defaultSize(width: 300, height: 300)
+        .windowResizability(.contentSize)
+        .commands {
+            CommandMenu("Icons") {
+                Toggle("Show Foreground Colors", isOn: $showForegroundColors)
+            }
+        }
+    }
+}
+
+struct IconWeightsView: View {
+    @Binding var showForegroundColors: Bool
+
     let weights: [Font.Weight] = [
         .ultraLight,
         .thin,
@@ -23,52 +57,32 @@ struct IconsApp: App {
         .heavy,
         .black,
     ]
+    let icons: [Icon.SystemIcon] = [
+        .share,
+        .plus,
+        .back,
+        .cut,
+        .copy,
+        .paste,
+        .search,
+    ]
 
-    var body: some Scene {
-        WindowGroup("IconsApp") {
-            #hotReloadable {
-                VStack {
-                    VStack {
-                        Text("Icon Weights")
-                        ForEach(weights, id: \.self) { weight in
-                            HStack {
-                                Text("\(weight)")
-                                Spacer()
+    var body: some View {
+        VStack {
+            Text("Icon Weights")
+            ForEach(weights, id: \.self) { weight in
+                HStack {
+                    Text("\(weight)")
+                    Spacer()
 
-                                Icon.share
-                                Icon.plus
-                                    .foregroundColor(.green)
-                                Icon.back
-                                Icon.cut
-                                Icon.copy
-                                Icon.paste
-                            }
-                            .fontWeight(weight)
-                        }
+                    ForEach(icons, id: \.self) { icon in
+                        Icon.system(icon)
                     }
-
-                    #if !canImport(AndroidBackend)
-                        Divider()
-
-                        VStack {
-                            Text("Icon Resizing")
-                            Slider(value: $iconSize, in: 10...100)
-                            HStack {
-                                Icon.copy
-                                Text("Some text for scale")
-                            }
-                            .font(.system(size: iconSize))
-                        }
-                    #endif
+                    .if(showForegroundColors) {
+                        $0.foregroundColor(.green)
+                    }
                 }
-                .padding()
-            }
-        }
-        .defaultSize(width: 300, height: 300)
-        .windowResizability(.contentSize)
-        .commands {
-            CommandMenu("Icons") {
-                Toggle("Show foreground colors", isOn: $showForegroundColors)
+                .fontWeight(weight)
             }
         }
     }

--- a/Sources/AppKitBackend/AppKitBackend+Gestures.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Gestures.swift
@@ -1,7 +1,7 @@
 import AppKit
 @_spi(Backends) import SwiftCrossUI
 
-extension AppKitBackend {
+extension AppKitBackend: BackendFeatures.Gestures {
     public func createTapGestureTarget(wrapping child: Widget, gesture _: TapGesture) -> Widget {
         let container = NSView()
 

--- a/Sources/AppKitBackend/AppKitBackend+Gradient.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Gradient.swift
@@ -1,7 +1,7 @@
 import AppKit
 @_spi(Backends) import SwiftCrossUI
 
-extension AppKitBackend {
+extension AppKitBackend: BackendFeatures.Gradients {
     public func createLinearGradientWidget() -> Widget {
         LinearGradientView()
     }

--- a/Sources/AppKitBackend/AppKitBackend+Icons.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Icons.swift
@@ -25,6 +25,13 @@ extension AppKitBackend: BackendFeatures.Icons {
         environment: EnvironmentValues
     ) {
         let iconView = iconView as! NSImageView
-        iconView.image = Self.sfSymbol(for: icon)
+        let image = Self.sfSymbol(for: icon)?.withSymbolConfiguration(
+            .init(
+                pointSize: environment.resolvedFont.pointSize,
+                weight: Self.weight(for: environment.resolvedFont.weight)
+            )
+        )
+        iconView.image = image
+        iconView.contentTintColor = environment.foregroundColor?.resolve(in: environment).nsColor
     }
 }

--- a/Sources/AppKitBackend/AppKitBackend+Icons.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Icons.swift
@@ -8,8 +8,11 @@ extension AppKitBackend: BackendFeatures.Icons {
             switch icon {
                 case .share: "square.and.arrow.up"
                 case .plus: "plus"
-                case .edit: "pencil"
                 case .back: "chevron.backward"
+                case .cut: "scissors"
+                case .copy: "document.on.document"
+                case .paste: "document.on.clipboard"
+                case .search: "magnifyingglass"
             }
 
         return NSImage(systemSymbolName: name, accessibilityDescription: nil)

--- a/Sources/AppKitBackend/AppKitBackend+Icons.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Icons.swift
@@ -1,0 +1,30 @@
+import AppKit
+import SwiftCrossUI
+
+@available(macOS 11, *)
+extension AppKitBackend: BackendFeatures.Icons {
+    static func sfSymbol(for icon: Icon) -> NSImage? {
+        let name =
+            switch icon {
+                case .share: "square.and.arrow.up"
+                case .plus: "plus"
+                case .edit: "pencil"
+                case .back: "chevron.backward"
+            }
+
+        return NSImage(systemSymbolName: name, accessibilityDescription: nil)
+    }
+
+    public func createIconView() -> Widget {
+        NSImageView()
+    }
+
+    public func updateIconView(
+        _ iconView: Widget,
+        icon: Icon,
+        environment: EnvironmentValues
+    ) {
+        let iconView = iconView as! NSImageView
+        iconView.image = Self.sfSymbol(for: icon)
+    }
+}

--- a/Sources/AppKitBackend/AppKitBackend+Icons.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Icons.swift
@@ -1,11 +1,17 @@
 import AppKit
 import SwiftCrossUI
 
+extension SwiftCrossUI.Icon {
+    public init(sfSymbol: String) {
+        self = .custom(sfSymbol)
+    }
+}
+
 @available(macOS 11, *)
 extension AppKitBackend: BackendFeatures.Icons {
     static func sfSymbol(for icon: Icon) -> NSImage? {
         let name =
-            switch icon {
+            switch icon.kind {
                 case .share: "square.and.arrow.up"
                 case .plus: "plus"
                 case .back: "chevron.backward"
@@ -13,6 +19,7 @@ extension AppKitBackend: BackendFeatures.Icons {
                 case .copy: "document.on.document"
                 case .paste: "document.on.clipboard"
                 case .search: "magnifyingglass"
+                case .custom(let name): name
             }
 
         return NSImage(systemSymbolName: name, accessibilityDescription: nil)

--- a/Sources/AppKitBackend/AppKitBackend+Icons.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Icons.swift
@@ -1,24 +1,27 @@
 import AppKit
-import SwiftCrossUI
+@_spi(Backends) import SwiftCrossUI
 
 extension SwiftCrossUI.Icon {
     public init(sfSymbol: String) {
-        self = .custom(sfSymbol)
+        self = .system(.custom(sfSymbol))
     }
 }
 
 @available(macOS 11, *)
 extension AppKitBackend: BackendFeatures.Icons {
-    static func sfSymbol(for icon: Icon) -> NSImage? {
+    static func sfSymbol(for icon: Icon.SystemIcon) -> NSImage? {
         let name =
-            switch icon.kind {
-                case .share: "square.and.arrow.up"
-                case .plus: "plus"
-                case .back: "chevron.backward"
-                case .cut: "scissors"
-                case .copy: "document.on.document"
-                case .paste: "document.on.clipboard"
-                case .search: "magnifyingglass"
+            switch icon.storage {
+                case .builtin(let kind):
+                    switch kind {
+                        case .share: "square.and.arrow.up"
+                        case .plus: "plus"
+                        case .back: "chevron.backward"
+                        case .cut: "scissors"
+                        case .copy: "document.on.document"
+                        case .paste: "document.on.clipboard"
+                        case .search: "magnifyingglass"
+                    }
                 case .custom(let name): name
             }
 
@@ -34,14 +37,17 @@ extension AppKitBackend: BackendFeatures.Icons {
         icon: Icon,
         environment: EnvironmentValues
     ) {
-        let iconView = iconView as! NSImageView
-        let image = Self.sfSymbol(for: icon)?.withSymbolConfiguration(
-            .init(
-                pointSize: environment.resolvedFont.pointSize,
-                weight: Self.weight(for: environment.resolvedFont.weight)
-            )
-        )
-        iconView.image = image
-        iconView.contentTintColor = environment.foregroundColor?.resolve(in: environment).nsColor
+        switch icon.kind {
+            case .system(let icon):
+                let iconView = iconView as! NSImageView
+                let image = Self.sfSymbol(for: icon)?.withSymbolConfiguration(
+                    .init(
+                        pointSize: environment.resolvedFont.pointSize,
+                        weight: Self.weight(for: environment.resolvedFont.weight)
+                    )
+                )
+                iconView.image = image
+                iconView.contentTintColor = environment.foregroundColor?.resolve(in: environment).nsColor
+        }
     }
 }

--- a/Sources/AppKitBackend/AppKitBackend+Menus.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Menus.swift
@@ -1,7 +1,7 @@
 import AppKit
 @_spi(Backends) import SwiftCrossUI
 
-extension AppKitBackend: BackendFeatures.PopoverMenus {
+extension AppKitBackend: BackendFeatures.MenuButtons, BackendFeatures.PopoverMenus {
     public typealias Menu = NSMenu
 
     public func createPopoverMenu() -> Menu {

--- a/Sources/AppKitBackend/AppKitBackend+Path.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Path.swift
@@ -1,7 +1,7 @@
 import AppKit
 @_spi(Backends) import SwiftCrossUI
 
-extension AppKitBackend {
+extension AppKitBackend: BackendFeatures.Paths {
     public typealias Path = NSBezierPath
 
     final class NSBezierPathView: NSView {

--- a/Sources/AppKitBackend/AppKitBackend+Sheet.swift
+++ b/Sources/AppKitBackend/AppKitBackend+Sheet.swift
@@ -1,7 +1,7 @@
 import AppKit
 @_spi(Backends) import SwiftCrossUI
 
-extension AppKitBackend {
+extension AppKitBackend: BackendFeatures.Sheets {
     public typealias Sheet = NSCustomSheet
 
     public func createSheet(content: NSView) -> NSCustomSheet {

--- a/Sources/AppKitBackend/AppKitBackend+WebView.swift
+++ b/Sources/AppKitBackend/AppKitBackend+WebView.swift
@@ -2,7 +2,7 @@ import AppKit
 @_spi(Backends) import SwiftCrossUI
 import WebKit
 
-extension AppKitBackend {
+extension AppKitBackend: BackendFeatures.WebViews {
     public func createWebView() -> Widget {
         let webView = CustomWKWebView()
         webView.navigationDelegate = webView.strongNavigationDelegate

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -9,7 +9,21 @@ extension App {
     }
 }
 
-public final class AppKitBackend: FullAppBackend {
+public final class AppKitBackend:
+    BaseAppBackend,
+    BackendFeatures.Alerts,
+    BackendFeatures.IncomingURLs,
+    BackendFeatures.ExternalURLs,
+    BackendFeatures.RevealFiles,
+    BackendFeatures.ApplicationMenus,
+    BackendFeatures.FileDialogs,
+    BackendFeatures.CornerRadius,
+    BackendFeatures.Tables,
+    BackendFeatures.Tooltips,
+    BackendFeatures.Colors,
+    BackendFeatures.DatePickers,
+    BackendFeatures.Windowing
+{
     public typealias Window = NSCustomWindow
     public typealias Widget = NSView
     public typealias Alert = NSAlert

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -1263,7 +1263,7 @@ public final class AppKitBackend:
         }
     }
 
-    private static func weight(for weight: Font.Weight) -> NSFont.Weight {
+    static func weight(for weight: Font.Weight) -> NSFont.Weight {
         switch weight {
             case .thin:
                 .thin

--- a/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
@@ -4,8 +4,6 @@ import SwiftCrossUI
 
 extension Gtk3Backend: BackendFeatures.Icons {
     static func iconName(for icon: Icon) -> String {
-        // TODO(kaascevich): Use icons from libadwaita once we can link that
-        // (These icons are all built in to GTK3, and there aren't very many of them.)
         switch icon {
             case .share: "folder-publicshare-symbolic" // FIXME(kaascevich): Nonexistent on GTK3
             case .plus: "list-add-symbolic"
@@ -29,6 +27,9 @@ extension Gtk3Backend: BackendFeatures.Icons {
         let iconView = iconView as! Gtk3.Image
         iconView.iconName = Self.iconName(for: icon)
         iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+        if let tintColor = environment.foregroundColor?.resolve(in: environment) {
+            iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+        }
     }
 }
 

--- a/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
@@ -1,0 +1,34 @@
+import CGtk3
+import Gtk3
+import SwiftCrossUI
+
+extension Gtk3Backend: BackendFeatures.Icons {
+    static func iconName(for icon: Icon) -> String {
+        // TODO(kaascevich): Use icons from libadwaita once we can link that
+        // (These icons are all built in to GTK3, and there aren't very many of them.)
+        switch icon {
+            case .share: "folder-publicshare-symbolic" // FIXME(kaascevich): Nonexistent on GTK3
+            case .plus: "list-add-symbolic"
+            case .back: "go-previous-symbolic"
+            case .cut: "edit-cut-symbolic"
+            case .copy: "edit-copy-symbolic"
+            case .paste: "edit-paste-symbolic"
+            case .search: "system-search-symbolic"
+        }
+    }
+
+    public func createIconView() -> Widget {
+        Gtk3.Image()
+    }
+
+    public func updateIconView(
+        _ iconView: Widget,
+        icon: Icon,
+        environment: EnvironmentValues
+    ) {
+        let iconView = iconView as! Gtk3.Image
+        iconView.iconName = Self.iconName(for: icon)
+        iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+    }
+}
+

--- a/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
@@ -2,9 +2,15 @@ import CGtk3
 import Gtk3
 import SwiftCrossUI
 
+extension SwiftCrossUI.Icon {
+    public init(gtkIcon: String) {
+        self = .custom(gtkIcon)
+    }
+}
+
 extension Gtk3Backend: BackendFeatures.Icons {
     static func iconName(for icon: Icon) -> String {
-        switch icon {
+        switch icon.kind {
             case .share: "folder-publicshare-symbolic" // FIXME(kaascevich): Nonexistent on GTK3
             case .plus: "list-add-symbolic"
             case .back: "go-previous-symbolic"
@@ -12,6 +18,7 @@ extension Gtk3Backend: BackendFeatures.Icons {
             case .copy: "edit-copy-symbolic"
             case .paste: "edit-paste-symbolic"
             case .search: "system-search-symbolic"
+            case .custom(let name): name
         }
     }
 

--- a/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend+Icons.swift
@@ -1,23 +1,26 @@
 import CGtk3
 import Gtk3
-import SwiftCrossUI
+@_spi(Backends) import SwiftCrossUI
 
 extension SwiftCrossUI.Icon {
     public init(gtkIcon: String) {
-        self = .custom(gtkIcon)
+        self = .system(.custom(gtkIcon))
     }
 }
 
 extension Gtk3Backend: BackendFeatures.Icons {
-    static func iconName(for icon: Icon) -> String {
-        switch icon.kind {
-            case .share: "folder-publicshare-symbolic" // FIXME(kaascevich): Nonexistent on GTK3
-            case .plus: "list-add-symbolic"
-            case .back: "go-previous-symbolic"
-            case .cut: "edit-cut-symbolic"
-            case .copy: "edit-copy-symbolic"
-            case .paste: "edit-paste-symbolic"
-            case .search: "system-search-symbolic"
+    static func iconName(for icon: Icon.SystemIcon) -> String {
+        switch icon.storage {
+            case .builtin(let kind):
+                switch kind {
+                    case .share: "folder-publicshare-symbolic" // FIXME(kaascevich): Nonexistent on GTK3
+                    case .plus: "list-add-symbolic"
+                    case .back: "go-previous-symbolic"
+                    case .cut: "edit-cut-symbolic"
+                    case .copy: "edit-copy-symbolic"
+                    case .paste: "edit-paste-symbolic"
+                    case .search: "system-search-symbolic"
+                }
             case .custom(let name): name
         }
     }
@@ -31,11 +34,14 @@ extension Gtk3Backend: BackendFeatures.Icons {
         icon: Icon,
         environment: EnvironmentValues
     ) {
-        let iconView = iconView as! Gtk3.Image
-        iconView.iconName = Self.iconName(for: icon)
-        iconView.pixelSize = Int(environment.resolvedFont.pointSize)
-        if let tintColor = environment.foregroundColor?.resolve(in: environment) {
-            iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+        switch icon.kind {
+            case .system(let icon):
+                let iconView = iconView as! Gtk3.Image
+                iconView.iconName = Self.iconName(for: icon)
+                iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+                if let tintColor = environment.foregroundColor?.resolve(in: environment) {
+                    iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+                }
         }
     }
 }

--- a/Sources/GtkBackend/GtkBackend+Icons.swift
+++ b/Sources/GtkBackend/GtkBackend+Icons.swift
@@ -1,0 +1,34 @@
+import CGtk
+import Gtk
+import SwiftCrossUI
+
+extension GtkBackend: BackendFeatures.Icons {
+    static func iconName(for icon: Icon) -> String {
+        // TODO(kaascevich): Use icons from libadwaita once we can link that
+        // (These icons are all built in to GTK, and there aren't very many of them.)
+        switch icon {
+            case .share: "folder-publicshare-symbolic"
+            case .plus: "list-add-symbolic"
+            case .back: "go-previous-symbolic"
+            case .cut: "edit-cut-symbolic"
+            case .copy: "edit-copy-symbolic"
+            case .paste: "edit-paste-symbolic"
+            case .search: "system-search-symbolic"
+        }
+    }
+
+    public func createIconView() -> Widget {
+        Gtk.Image()
+    }
+
+    public func updateIconView(
+        _ iconView: Widget,
+        icon: Icon,
+        environment: EnvironmentValues
+    ) {
+        let iconView = iconView as! Gtk.Image
+        iconView.iconName = Self.iconName(for: icon)
+        iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+    }
+}
+

--- a/Sources/GtkBackend/GtkBackend+Icons.swift
+++ b/Sources/GtkBackend/GtkBackend+Icons.swift
@@ -2,11 +2,17 @@ import CGtk
 import Gtk
 import SwiftCrossUI
 
+extension SwiftCrossUI.Icon {
+    public init(gtkIcon: String) {
+        self = .custom(gtkIcon)
+    }
+}
+
 extension GtkBackend: BackendFeatures.Icons {
     static func iconName(for icon: Icon) -> String {
         // TODO(kaascevich): Use icons from libadwaita once we can link that
         // (These icons are all built in to GTK, and there aren't very many of them.)
-        switch icon {
+        switch icon.kind {
             case .share: "folder-publicshare-symbolic"
             case .plus: "list-add-symbolic"
             case .back: "go-previous-symbolic"
@@ -14,6 +20,7 @@ extension GtkBackend: BackendFeatures.Icons {
             case .copy: "edit-copy-symbolic"
             case .paste: "edit-paste-symbolic"
             case .search: "system-search-symbolic"
+            case .custom(let name): name
         }
     }
 

--- a/Sources/GtkBackend/GtkBackend+Icons.swift
+++ b/Sources/GtkBackend/GtkBackend+Icons.swift
@@ -29,6 +29,9 @@ extension GtkBackend: BackendFeatures.Icons {
         let iconView = iconView as! Gtk.Image
         iconView.iconName = Self.iconName(for: icon)
         iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+        if let tintColor = environment.foregroundColor?.resolve(in: environment) {
+            iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+        }
     }
 }
 

--- a/Sources/GtkBackend/GtkBackend+Icons.swift
+++ b/Sources/GtkBackend/GtkBackend+Icons.swift
@@ -1,25 +1,28 @@
 import CGtk
 import Gtk
-import SwiftCrossUI
+@_spi(Backends) import SwiftCrossUI
 
 extension SwiftCrossUI.Icon {
     public init(gtkIcon: String) {
-        self = .custom(gtkIcon)
+        self = .system(.custom(gtkIcon))
     }
 }
 
 extension GtkBackend: BackendFeatures.Icons {
-    static func iconName(for icon: Icon) -> String {
+    static func iconName(for icon: Icon.SystemIcon) -> String {
         // TODO(kaascevich): Use icons from libadwaita once we can link that
         // (These icons are all built in to GTK, and there aren't very many of them.)
-        switch icon.kind {
-            case .share: "folder-publicshare-symbolic"
-            case .plus: "list-add-symbolic"
-            case .back: "go-previous-symbolic"
-            case .cut: "edit-cut-symbolic"
-            case .copy: "edit-copy-symbolic"
-            case .paste: "edit-paste-symbolic"
-            case .search: "system-search-symbolic"
+        switch icon.storage {
+            case .builtin(let kind):
+                switch kind {
+                    case .share: "folder-publicshare-symbolic"
+                    case .plus: "list-add-symbolic"
+                    case .back: "go-previous-symbolic"
+                    case .cut: "edit-cut-symbolic"
+                    case .copy: "edit-copy-symbolic"
+                    case .paste: "edit-paste-symbolic"
+                    case .search: "system-search-symbolic"
+                }
             case .custom(let name): name
         }
     }
@@ -33,11 +36,14 @@ extension GtkBackend: BackendFeatures.Icons {
         icon: Icon,
         environment: EnvironmentValues
     ) {
-        let iconView = iconView as! Gtk.Image
-        iconView.iconName = Self.iconName(for: icon)
-        iconView.pixelSize = Int(environment.resolvedFont.pointSize)
-        if let tintColor = environment.foregroundColor?.resolve(in: environment) {
-            iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+        switch icon.kind {
+            case .system(let icon):
+                let iconView = iconView as! Gtk.Image
+                iconView.iconName = Self.iconName(for: icon)
+                iconView.pixelSize = Int(environment.resolvedFont.pointSize)
+                if let tintColor = environment.foregroundColor?.resolve(in: environment) {
+                    iconView.css.set(property: .foregroundColor(tintColor.gtkColor))
+                }
         }
     }
 }

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Icons.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Icons.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension BackendFeatures {
+    /// Backend methods for showing system icons.
+    ///
+    /// These are used by ``Icon``.
+    @MainActor
+    public protocol Icons: Core {
+//        /// If `true`, all icons in a window will get updated when the window's
+//        /// scale factor changes (``EnvironmentValues/windowScaleFactor``).
+//        ///
+//        /// Backends based on modern UI frameworks can usually get away with setting
+//        /// this to `false`, but backends such as `Gtk3Backend` have to set this to
+//        /// `true` to properly support HiDPI (aka Retina) displays because they
+//        /// manually rescale the icon meaning that it must get rescaled when the
+//        /// scale factor changes.
+//        var requiresIconUpdateOnScaleFactorChange: Bool { get }
+
+        /// Creates an icon view.
+        ///
+        /// Predominantly used by ``Icon``.
+        ///
+        /// - Returns: An icon view.
+        func createIconView() -> Widget
+
+        /// Sets the icon to be displayed.
+        ///
+        /// - Parameters:
+        ///   - iconView: The icon view to update.
+        ///   - icon: The icon to use.
+        ///   - environment: The current environment.
+        func updateIconView(
+            _ iconView: Widget,
+            icon: Icon,
+            environment: EnvironmentValues
+        )
+    }
+}

--- a/Sources/SwiftCrossUI/Backend/FullAppBackend.swift
+++ b/Sources/SwiftCrossUI/Backend/FullAppBackend.swift
@@ -22,6 +22,8 @@
 /// - ``BackendFeatures/Colors``
 /// - ``BackendFeatures/DatePickers``
 /// - ``BackendFeatures/Windowing``
+/// - ``BackendFeatures/Gradients``
+/// - ``BackendFeatures/Icons``
 public typealias FullAppBackend =
     BaseAppBackend
         & BackendFeatures.MenuButtons
@@ -42,6 +44,7 @@ public typealias FullAppBackend =
         & BackendFeatures.DatePickers
         & BackendFeatures.Windowing
         & BackendFeatures.Gradients
+        & BackendFeatures.Icons
 
 /// A typealias for ``FullAppBackend``.
 ///

--- a/Sources/SwiftCrossUI/Values/Icon.swift
+++ b/Sources/SwiftCrossUI/Values/Icon.swift
@@ -1,0 +1,9 @@
+#if compiler(>=6.2.3)
+    @nonexhaustive(warn)
+#endif
+public enum Icon: Hashable, Sendable {
+    case share
+    case plus
+    case edit
+    case back
+}

--- a/Sources/SwiftCrossUI/Values/Icon.swift
+++ b/Sources/SwiftCrossUI/Values/Icon.swift
@@ -1,12 +1,37 @@
-#if compiler(>=6.2.3)
-    @nonexhaustive(warn)
-#endif
-public enum Icon: Hashable, Sendable {
-    case share
-    case plus
-    case back
-    case cut
-    case copy
-    case paste
-    case search
+/// A system icon.
+public struct Icon: Hashable, Sendable {
+    package enum Kind: Hashable, Sendable {
+        case share
+        case plus
+        case back
+        case cut
+        case copy
+        case paste
+        case search
+        case custom(_ name: String)
+    }
+
+    package let kind: Kind
+    package init(kind: Kind) {
+        self.kind = kind
+    }
+
+    /// A system icon representing a sharing operation.
+    public static let share = Icon(kind: .share)
+    /// A system icon representing adding an item.
+    public static let plus = Icon(kind: .plus)
+    /// A system icon representing a backwards navigation.
+    public static let back = Icon(kind: .back)
+    /// A system icon representing a cutting operation.
+    public static let cut = Icon(kind: .cut)
+    /// A system icon representing a copying operation.
+    public static let copy = Icon(kind: .copy)
+    /// A system icon representing a pasting operation.
+    public static let paste = Icon(kind: .paste)
+    /// A system icon representing a searching operation.
+    public static let search = Icon(kind: .search)
+
+    package static func custom(_ name: String) -> Icon {
+        Icon(kind: .custom(name))
+    }
 }

--- a/Sources/SwiftCrossUI/Values/Icon.swift
+++ b/Sources/SwiftCrossUI/Values/Icon.swift
@@ -4,6 +4,9 @@
 public enum Icon: Hashable, Sendable {
     case share
     case plus
-    case edit
     case back
+    case cut
+    case copy
+    case paste
+    case search
 }

--- a/Sources/SwiftCrossUI/Values/Icon.swift
+++ b/Sources/SwiftCrossUI/Values/Icon.swift
@@ -1,6 +1,16 @@
-/// A system icon.
+/// An icon.
 public struct Icon: Hashable, Sendable {
-    package enum Kind: Hashable, Sendable {
+    @_spi(Backends) public enum Kind: Hashable, Sendable {
+        /// Represents a system-adaptive icon.
+        case system(SystemIcon)
+
+        // TODO: Add a `crossPlatform` case here
+    }
+
+
+    /// A set of system-adaptive icons, a limited set of icons for developers
+    /// who want to create an absolutely native experience.
+    @_spi(Backends) public enum SystemIconKind: Hashable, Sendable {
         case share
         case plus
         case back
@@ -8,30 +18,52 @@ public struct Icon: Hashable, Sendable {
         case copy
         case paste
         case search
-        case custom(_ name: String)
     }
 
-    package let kind: Kind
-    package init(kind: Kind) {
+    @_spi(Backends) public let kind: Kind
+    init(kind: Kind) {
         self.kind = kind
     }
 
-    /// A system icon representing a sharing operation.
-    public static let share = Icon(kind: .share)
-    /// A system icon representing adding an item.
-    public static let plus = Icon(kind: .plus)
-    /// A system icon representing a backwards navigation.
-    public static let back = Icon(kind: .back)
-    /// A system icon representing a cutting operation.
-    public static let cut = Icon(kind: .cut)
-    /// A system icon representing a copying operation.
-    public static let copy = Icon(kind: .copy)
-    /// A system icon representing a pasting operation.
-    public static let paste = Icon(kind: .paste)
-    /// A system icon representing a searching operation.
-    public static let search = Icon(kind: .search)
+    /// A system icon.
+    public struct SystemIcon: Hashable, Sendable {
+        @_spi(Backends) public enum Storage: Hashable, Sendable {
+            case builtin(SystemIconKind)
+            case custom(String)
+        }
 
-    package static func custom(_ name: String) -> Icon {
-        Icon(kind: .custom(name))
+        @_spi(Backends) public var storage: Storage
+        init(storage: Storage) {
+            self.storage = storage
+        }
+
+        init(kind: SystemIconKind) {
+            self.storage = .builtin(kind)
+        }
+
+        /// A system icon representing a sharing operation.
+        public static let share = Self(kind: .share)
+        /// A system icon representing adding an item.
+        public static let plus = Self(kind: .plus)
+        /// A system icon representing a backwards navigation.
+        public static let back = Self(kind: .back)
+        /// A system icon representing a cutting operation.
+        public static let cut = Self(kind: .cut)
+        /// A system icon representing a copying operation.
+        public static let copy = Self(kind: .copy)
+        /// A system icon representing a pasting operation.
+        public static let paste = Self(kind: .paste)
+        /// A system icon representing a searching operation.
+        public static let search = Self(kind: .search)
+
+        /// Creates a custom system icon that uses a default identifier, or a platform-specific
+        /// identifier if provided.
+        public static func custom(_ identifier: String) -> Self {
+            return Self(storage: .custom(identifier))
+        }
+    }
+
+    public static func system(_ icon: SystemIcon) -> Icon {
+        Self(kind: .system(icon))
     }
 }

--- a/Sources/SwiftCrossUI/Views/IconView.swift
+++ b/Sources/SwiftCrossUI/Views/IconView.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension Icon: ElementaryView {
+    @CastBackend<BackendFeatures.Icons>(returnsWidget: true)
+    public func asWidget<Backend: BaseAppBackend>(backend: Backend) -> Backend.Widget {
+        return backend.createIconView()
+    }
+
+    @CastBackend<BackendFeatures.Icons>
+    func computeLayout<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) -> ViewLayoutResult {
+        return ViewLayoutResult.leafView(
+            size: ViewSize(backend.naturalSize(of: widget))
+        )
+    }
+
+    @CastBackend<BackendFeatures.Icons>
+    func commit<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        backend.updateIconView(widget, icon: self, environment: environment)
+    }
+}

--- a/Sources/SwiftCrossUI/Views/IconView.swift
+++ b/Sources/SwiftCrossUI/Views/IconView.swift
@@ -26,5 +26,6 @@ extension Icon: ElementaryView {
         backend: Backend
     ) {
         backend.updateIconView(widget, icon: self, environment: environment)
+        backend.setSize(of: widget, to: layout.size.vector)
     }
 }

--- a/Sources/SwiftCrossUI/Views/IconView.swift
+++ b/Sources/SwiftCrossUI/Views/IconView.swift
@@ -3,7 +3,10 @@ import Foundation
 extension Icon: ElementaryView {
     @CastBackend<BackendFeatures.Icons>(returnsWidget: true)
     public func asWidget<Backend: BaseAppBackend>(backend: Backend) -> Backend.Widget {
-        return backend.createIconView()
+        switch kind {
+            case .system(let systemIcon):
+                return backend.createIconView()
+        }
     }
 
     @CastBackend<BackendFeatures.Icons>

--- a/Sources/UIKitBackend/UIKitBackend+Icons.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Icons.swift
@@ -1,13 +1,19 @@
 import UIKit
 import SwiftCrossUI
 
+extension SwiftCrossUI.Icon {
+    public init(sfSymbol: String) {
+        self = .custom(sfSymbol)
+    }
+}
+
 final class ImageView: WrapperWidget<UIImageView> {}
 
 @available(iOS 15.0, *)
 extension UIKitBackend: BackendFeatures.Icons {
     static func sfSymbol(for icon: Icon) -> UIImage? {
         let name =
-            switch icon {
+            switch icon.kind {
                 case .share: "square.and.arrow.up"
                 case .plus: "plus"
                 case .back: "chevron.backward"
@@ -15,6 +21,7 @@ extension UIKitBackend: BackendFeatures.Icons {
                 case .copy: "document.on.document"
                 case .paste: "document.on.clipboard"
                 case .search: "magnifyingglass"
+                case .custom(let name): name
             }
 
         return UIImage(systemName: name)

--- a/Sources/UIKitBackend/UIKitBackend+Icons.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Icons.swift
@@ -1,0 +1,71 @@
+import UIKit
+import SwiftCrossUI
+
+final class ImageView: WrapperWidget<UIImageView> {}
+
+extension UIKitBackend: BackendFeatures.Icons {
+    static func sfSymbol(for icon: Icon) -> UIImage? {
+        let name =
+            switch icon {
+                case .share: "square.and.arrow.up"
+                case .plus: "plus"
+                case .back: "chevron.backward"
+                case .cut: "scissors"
+                case .copy: "document.on.document"
+                case .paste: "document.on.clipboard"
+                case .search: "magnifyingglass"
+            }
+
+        return UIImage(systemName: name)
+    }
+
+    public func createIconView() -> Widget {
+        ImageView()
+    }
+
+    public func updateIconView(
+        _ iconView: Widget,
+        icon: Icon,
+        environment: EnvironmentValues
+    ) {
+        let iconView = iconView as! ImageView
+        let image = Self.sfSymbol(for: icon)?.applyingSymbolConfiguration(
+            .init(
+                pointSize: environment.resolvedFont.pointSize,
+                weight: environment.resolvedFont.weight.uiSymbolWeight
+            )
+        )
+
+        iconView.child.image =
+            if let tintColor = environment.foregroundColor {
+                image?.withTintColor(tintColor.resolve(in: environment).uiColor)
+            } else {
+                image
+            }
+    }
+}
+
+extension Font.Weight {
+    var uiSymbolWeight: UIImage.SymbolWeight {
+        switch self {
+            case .ultraLight:
+                .ultraLight
+            case .thin:
+                .thin
+            case .light:
+                .light
+            case .regular:
+                .regular
+            case .medium:
+                .medium
+            case .semibold:
+                .semibold
+            case .bold:
+                .bold
+            case .heavy:
+                .heavy
+            case .black:
+                .black
+        }
+    }
+}

--- a/Sources/UIKitBackend/UIKitBackend+Icons.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Icons.swift
@@ -3,6 +3,7 @@ import SwiftCrossUI
 
 final class ImageView: WrapperWidget<UIImageView> {}
 
+@available(iOS 15.0, *)
 extension UIKitBackend: BackendFeatures.Icons {
     static func sfSymbol(for icon: Icon) -> UIImage? {
         let name =
@@ -38,7 +39,10 @@ extension UIKitBackend: BackendFeatures.Icons {
 
         iconView.child.image =
             if let tintColor = environment.foregroundColor {
-                image?.withTintColor(tintColor.resolve(in: environment).uiColor)
+                image?.withTintColor(
+                    tintColor.resolve(in: environment).uiColor,
+                    renderingMode: .alwaysOriginal
+                )
             } else {
                 image
             }

--- a/Sources/UIKitBackend/UIKitBackend+Icons.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Icons.swift
@@ -1,9 +1,9 @@
 import UIKit
-import SwiftCrossUI
+@_spi(Backends) import SwiftCrossUI
 
 extension SwiftCrossUI.Icon {
     public init(sfSymbol: String) {
-        self = .custom(sfSymbol)
+        self = .system(.custom(sfSymbol))
     }
 }
 
@@ -11,16 +11,19 @@ final class ImageView: WrapperWidget<UIImageView> {}
 
 @available(iOS 15.0, *)
 extension UIKitBackend: BackendFeatures.Icons {
-    static func sfSymbol(for icon: Icon) -> UIImage? {
+    static func sfSymbol(for icon: Icon.SystemIcon) -> UIImage? {
         let name =
-            switch icon.kind {
-                case .share: "square.and.arrow.up"
-                case .plus: "plus"
-                case .back: "chevron.backward"
-                case .cut: "scissors"
-                case .copy: "document.on.document"
-                case .paste: "document.on.clipboard"
-                case .search: "magnifyingglass"
+            switch icon.storage {
+                case .builtin(let kind):
+                    switch kind {
+                        case .share: "square.and.arrow.up"
+                        case .plus: "plus"
+                        case .back: "chevron.backward"
+                        case .cut: "scissors"
+                        case .copy: "document.on.document"
+                        case .paste: "document.on.clipboard"
+                        case .search: "magnifyingglass"
+                    }
                 case .custom(let name): name
             }
 
@@ -36,23 +39,26 @@ extension UIKitBackend: BackendFeatures.Icons {
         icon: Icon,
         environment: EnvironmentValues
     ) {
-        let iconView = iconView as! ImageView
-        let image = Self.sfSymbol(for: icon)?.applyingSymbolConfiguration(
-            .init(
-                pointSize: environment.resolvedFont.pointSize,
-                weight: environment.resolvedFont.weight.uiSymbolWeight
-            )
-        )
-
-        iconView.child.image =
-            if let tintColor = environment.foregroundColor {
-                image?.withTintColor(
-                    tintColor.resolve(in: environment).uiColor,
-                    renderingMode: .alwaysOriginal
+        switch icon.kind {
+            case .system(let icon):
+                let iconView = iconView as! ImageView
+                let image = Self.sfSymbol(for: icon)?.applyingSymbolConfiguration(
+                    .init(
+                        pointSize: environment.resolvedFont.pointSize,
+                        weight: environment.resolvedFont.weight.uiSymbolWeight
+                    )
                 )
-            } else {
-                image
-            }
+
+                iconView.child.image =
+                    if let tintColor = environment.foregroundColor {
+                        image?.withTintColor(
+                            tintColor.resolve(in: environment).uiColor,
+                            renderingMode: .alwaysOriginal
+                        )
+                    } else {
+                        image
+                    }
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds basic support for icons to SwiftCrossUI as well as some of the backends.

I have *not* settled on precisely how to design the SCUI-side icon API; right now `Icon` is just an enum that conforms to `View`, but we might remove that conformance and merge it in with `Image` instead to match SwiftUI. The precise naming of `Icon`'s cases -- as well as which cases are even present in the first place -- is also open to discussion.

### Implemented backends
- [x] AppKitBackend
- [x] GtkBackend
- [x] Gtk3Backend
- [x] UIKitBackend
- [ ] WinUIBackend
- [ ] AndroidBackend
- [ ] DummyBackend