### PR TITLE
Fix: `Gtk3Backend` to match `GtkBackend` signal registering behavior.

### DIFF
--- a/Sources/Gtk3/GObject.swift
+++ b/Sources/Gtk3/GObject.swift
@@ -18,6 +18,12 @@ open class GObject: GObjectRepresentable {
     }
 
     deinit {
+        // disconnect all GTK signal handlers before releasing the object
+        // to prevent callbacks firing on deallocated Swift wrapper instances.
+        for (id, _) in signals {
+            g_signal_handler_disconnect(gobjectPointer, id)
+        }
+      
         g_object_unref(gobjectPointer)
     }
 

--- a/Sources/Gtk3/Widgets/Widget.swift
+++ b/Sources/Gtk3/Widgets/Widget.swift
@@ -25,7 +25,12 @@ open class Widget: GObject {
 
     open func didMoveToParent() {
         removeSignals()
-      
+        registerSignals()
+    }
+
+    open func didMoveFromParent() {}
+
+    open override func registerSignals() {
         // The Gtk3 docs claim that this handler should take GdkEventButton as a
         // value, but that leads to crashes on Rocky Linux. These crashes are
         // fixed by instead taking the event as a pointer. I've confirmed that
@@ -102,12 +107,8 @@ open class Widget: GObject {
             guard let self else { return }
             self.styleUpdated?()
         }
-      
-        registerSignals()
     }
-
-    open func didMoveFromParent() {}
-
+  
     public func queueDraw() {
         gtk_widget_queue_draw(widgetPointer)
     }

--- a/Sources/Gtk3/Widgets/Widget.swift
+++ b/Sources/Gtk3/Widgets/Widget.swift
@@ -24,6 +24,8 @@ open class Widget: GObject {
     }
 
     open func didMoveToParent() {
+        removeSignals()
+      
         // The Gtk3 docs claim that this handler should take GdkEventButton as a
         // value, but that leads to crashes on Rocky Linux. These crashes are
         // fixed by instead taking the event as a pointer. I've confirmed that
@@ -100,6 +102,8 @@ open class Widget: GObject {
             guard let self else { return }
             self.styleUpdated?()
         }
+      
+        registerSignals()
     }
 
     open func didMoveFromParent() {}


### PR DESCRIPTION
> [!IMPORTANT]
> `@State` and dynamic properties broke on `Gtk3` after #588 because the
> generated `registerSignals()` overrides were never being called — `Gtk3Backend`'s
> `didMoveToParent` didn't call `removeSignals()`/`registerSignals()` unlike `GtkBackend`.

> [!NOTE]
> This PR aligns `Gtk3Backend` behavior with `GtkBackend` to remove subtle differences
> and prevent unknown behavior.

### Fixes:
- Call `removeSignals()` and `registerSignals()` in `Gtk3`'s `didMoveToParent`, matching
  `GtkBackend`'s existing pattern and restoring dynamic property support on the Gtk3 backend.
- Disconnect all GTK signal handlers before releasing the `GObject` in `deinit` to prevent
  callbacks firing into deallocated Swift wrapper instances — now consistent across both backends.
- Moved `Gtk3` base `Widget` signal registrations out of `didMoveToParent()` and into a new dedicated `registerSignals()` override method.

### Potentially related issues:
- https://github.com/moreSwift/swift-cross-ui/issues/434
- https://github.com/moreSwift/swift-cross-ui/issues/433