### PR TITLE
Fix: Gtk3Example app so that it compiles and runs successfully.

### DIFF
--- a/Sources/Gtk3Example/main.swift
+++ b/Sources/Gtk3Example/main.swift
@@ -66,8 +66,8 @@ app.run { window in
         newWindow.defaultSize = Size(width: 200, height: 200)
 
         let calendar = Calendar()
-        calendar.year = 2000
-        calendar.showHeading = true
+        // calendar.year = 2000
+        // calendar.showHeading = true
 
         newWindow.add(calendar)
         newWindow.showAll()


### PR DESCRIPTION
> [!NOTE]
> Fixing the **Gtk3Example** app ensures future contributors can easily test both backend 
> example applications when making changes to `GtkBackend` or `Gtk3Backend`, like making potential regressions such as #591 more obvious.


### Fixes
- Remove `calendar.year` and `calendar.showHeading` property assignments since neither of these properties exist on Gtk3's `Calendar` widget, causing the **Gtk3Example** app to fail to compile.