### PR TITLE
Android Representables

### DIFF
--- a/Examples/Sources/AdvancedCustomizationExample/AdvancedCustomizationApp.swift
+++ b/Examples/Sources/AdvancedCustomizationExample/AdvancedCustomizationApp.swift
@@ -11,6 +11,27 @@ import SwiftCrossUI
     import SwiftBundlerRuntime
 #endif
 
+#if canImport(AndroidBackend)
+    // Workaround so that things compile
+    extension View {
+        public func inspect(
+            _ inspectionPoints: InspectionPoints = .onCreate,
+            _ action: @escaping @MainActor @Sendable (Never) -> Void
+        ) -> some View {
+            self
+        }
+
+        public func inspectWindow(
+            _ action: @escaping @MainActor @Sendable (Never) -> Void
+        ) -> some View {
+            self
+        }
+    }
+
+    // TODO(bbrk24): Remove this when Android supports scroll views
+    typealias ScrollView = VStack
+#endif
+
 @main
 @HotReloadable
 struct CounterApp: App {
@@ -72,7 +93,7 @@ struct CounterApp: App {
                         }
                     }
 
-                    #if !os(tvOS)
+                    #if !os(tvOS) && !canImport(AndroidBackend)
                         Slider(value: $value, in: 0...10)
                             .inspect { slider in
                                 #if canImport(AppKitBackend)
@@ -166,49 +187,62 @@ struct CounterApp: App {
                         #endif
                     }.frame(height: 200)
 
-                    List(["Red", "Green", "Blue"], id: \.self, selection: $color) { color in
-                        Text(color)
-                    }.inspect(.afterUpdate) { table in
-                        #if canImport(AppKitBackend)
-                            table.usesAlternatingRowBackgroundColors = true
-                        #elseif canImport(UIKitBackend)
-                            table.isEditing = true
-                        #elseif canImport(WinUIBackend)
-                            let brush = WinUI.SolidColorBrush()
-                            brush.color = .init(a: 255, r: 255, g: 0, b: 255)
-                            table.borderBrush = brush
-                            table.borderThickness = .init(
-                                left: 1,
-                                top: 1,
-                                right: 1,
-                                bottom: 1
-                            )
-                        #elseif canImport(GtkBackend)
-                            table.showSeparators = true
-                        #elseif canImport(Gtk3Backend)
-                            table.selectionMode = .multiple
-                        #endif
-                    }
-
-                    Image(Bundle.module.bundleURL.appendingPathComponent("Banner.png"))
-                        .resizable()
-                        .inspect(.afterUpdate) { image in
+                    #if !canImport(AndroidBackend)
+                        List(["Red", "Green", "Blue"], id: \.self, selection: $color) { color in
+                            Text(color)
+                        }.inspect(.afterUpdate) { table in
                             #if canImport(AppKitBackend)
-                                image.isEditable = true
+                                table.usesAlternatingRowBackgroundColors = true
                             #elseif canImport(UIKitBackend)
-                                image.layer.borderWidth = 1
-                                image.layer.borderColor = .init(red: 0, green: 1, blue: 0, alpha: 1)
+                                table.isEditing = true
                             #elseif canImport(WinUIBackend)
-                            // Couldn't find anything visually interesting
-                            // to do to the WinUI.Image, but the point is
-                            // that you could do something if you wanted to.
+                                let brush = WinUI.SolidColorBrush()
+                                brush.color = .init(a: 255, r: 255, g: 0, b: 255)
+                                table.borderBrush = brush
+                                table.borderThickness = .init(
+                                    left: 1,
+                                    top: 1,
+                                    right: 1,
+                                    bottom: 1
+                                )
                             #elseif canImport(GtkBackend)
-                                image.css.set(property: .border(color: .init(0, 1, 0), width: 2))
+                                table.showSeparators = true
                             #elseif canImport(Gtk3Backend)
-                                image.css.set(property: .border(color: .init(0, 1, 0), width: 2))
+                                table.selectionMode = .multiple
                             #endif
                         }
-                        .aspectRatio(contentMode: .fit)
+
+                        Image(Bundle.module.bundleURL.appendingPathComponent("Banner.png"))
+                            .resizable()
+                            .inspect(.afterUpdate) { image in
+                                #if canImport(AppKitBackend)
+                                    image.isEditable = true
+                                #elseif canImport(UIKitBackend)
+                                    image.layer.borderWidth = 1
+                                    image.layer.borderColor = .init(
+                                        red: 0,
+                                        green: 1,
+                                        blue: 0,
+                                        alpha: 1
+                                    )
+                                #elseif canImport(WinUIBackend)
+                                // Couldn't find anything visually interesting
+                                // to do to the WinUI.Image, but the point is
+                                // that you could do something if you wanted to.
+                                #elseif canImport(GtkBackend)
+                                    image.css.set(property: .border(
+                                        color: .init(0, 1, 0),
+                                        width: 2
+                                    ))
+                                #elseif canImport(Gtk3Backend)
+                                    image.css.set(property: .border(
+                                        color: .init(0, 1, 0),
+                                        width: 2
+                                    ))
+                                #endif
+                            }
+                            .aspectRatio(contentMode: .fit)
+                    #endif
                 }
                 .padding()
                 .inspectWindow { window in

--- a/Examples/Sources/AdvancedCustomizationExample/CustomNativeButton.swift
+++ b/Examples/Sources/AdvancedCustomizationExample/CustomNativeButton.swift
@@ -139,3 +139,26 @@ struct CustomNativeButton {
         }
     }
 #endif
+
+#if canImport(AndroidBackend)
+    import AndroidBackend
+    import AndroidKit
+    import SwiftJava
+
+    extension CustomNativeButton: AndroidViewRepresentable {
+        func makeAndroidView(context: Self.Context) -> AndroidKit.Button {
+            AndroidKit.Button(
+                context.environment.androidActivity,
+                environment: context.environment.jniEnv
+            )
+        }
+
+        func updateAndroidView(_ view: AndroidKit.Button, context: Self.Context) {
+            view.setText(
+                JavaString(label, environment: context.environment.jniEnv)
+                    .as(CharSequence.self)
+            )
+            view.setBackgroundColor(Int32(bitPattern: 0xffff00ff))
+        }
+    }
+#endif

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -73,6 +73,11 @@ extension App {
     }
 }
 
+extension EnvironmentValues {
+    @Entry public var androidActivity: AndroidKit.Activity! = nil
+    @Entry public var jniEnv: UnsafeMutablePointer<JNIEnv?>? = nil
+}
+
 // TODO: Implement the rest of `BaseAppBackend` so we can move off of `BaseStubs`
 
 public final class AndroidBackend: BackendFeatures.BaseStubs {
@@ -239,6 +244,9 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
     public func computeRootEnvironment(defaultEnvironment: EnvironmentValues) -> EnvironmentValues {
         var environment = defaultEnvironment
+
+        environment.androidActivity = Self.activity
+        environment.jniEnv = Self.env
 
         if helpers.isNightMode(Self.activity) {
             environment.colorScheme = .dark

--- a/Sources/AndroidBackend/AndroidViewRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidViewRepresentable.swift
@@ -1,0 +1,197 @@
+import AndroidKit
+import SwiftCrossUI
+import SwiftJava
+
+public struct AndroidViewRepresentableContext<Representable: AndroidViewRepresentable> {
+    public let coordinator: Representable.Coordinator
+    public internal(set) var environment: EnvironmentValues
+}
+
+public protocol AndroidViewRepresentable: SwiftCrossUI.View where Content == Never {
+    associatedtype ViewType: AndroidKit.View
+    associatedtype Coordinator = Void
+
+    @MainActor
+    func makeCoordinator() -> Coordinator
+
+    @MainActor
+    func makeAndroidView(context: Self.Context) -> ViewType
+
+    @MainActor
+    func updateAndroidView(
+        _ view: ViewType,
+        context: Self.Context
+    )
+
+    @MainActor
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        view: ViewType,
+        context: Self.Context
+    ) -> ViewSize
+}
+
+extension AndroidViewRepresentable {
+    public typealias Context = AndroidViewRepresentableContext<Self>
+
+    @MainActor
+    public func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        view: ViewType,
+        context: Self.Context
+    ) -> ViewSize {
+        let density = context.environment.windowScaleFactor
+
+        // 0x80000000 = View.MeasureSpec.AT_MOST
+        // 0x3FFFFFFF = View.MeasureSpec.makeMeasureSpec(Int32.max, View.MeasureSpec.UNSPECIFIED)
+        let widthMeasureSpec =
+            if
+                let proposedWidth = proposal.width,
+                proposedWidth > 0
+            {
+                Int32(bitPattern: 0x80000000 | UInt32(min(proposedWidth * density, 0x3FFFFFFF)))
+            } else {
+                0x3FFFFFFF as Int32
+            }
+
+        let heightMeasureSpec =
+            if
+                let proposedHeight = proposal.height,
+                proposedHeight > 0
+            {
+                Int32(bitPattern: 0x80000000 | UInt32(min(proposedHeight * density, 0x3FFFFFFF)))
+            } else {
+                0x3FFFFFFF as Int32
+            }
+
+        view.measure(widthMeasureSpec, heightMeasureSpec)
+
+        let width = Double(view.getMeasuredWidth()) / density
+        let height = Double(view.getMeasuredHeight()) / density
+
+        return ViewSize(width, height)
+    }
+}
+
+extension AndroidViewRepresentable where Coordinator == Void {
+    public func makeCoordinator() {}
+}
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.RepresentingView",
+    extends: AndroidKit.FrameLayout.self
+)
+class RepresentingView: AndroidKit.FrameLayout {
+    @JavaMethod
+    convenience init(
+        _ activity: AndroidKit.Activity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func getSwiftContext() -> SwiftObject?
+
+    @JavaMethod
+    func setSwiftContext(_ swiftContext: SwiftObject?)
+
+    @JavaMethod
+    func getChild() -> AndroidKit.View?
+
+    @JavaMethod
+    func setChild(_ value: AndroidKit.View?)
+}
+
+extension RepresentingView {
+    @MainActor
+    func updateAndGetSize<T: AndroidViewRepresentable>(
+        environment: EnvironmentValues,
+        proposedSize: ProposedViewSize,
+        representable: T
+    ) -> ViewSize {
+        var context: T.Context
+        if let untypedContext = getSwiftContext()?.value() {
+            context = untypedContext as! T.Context
+            context.environment = environment
+        } else {
+            context = AndroidViewRepresentableContext(
+                coordinator: representable.makeCoordinator(),
+                environment: environment
+            )
+        }
+
+        setSwiftContext(SwiftObject(context, environment: environment.jniEnv))
+
+        let child: T.ViewType
+        if let untypedChild = getChild() {
+            child = untypedChild.as(T.ViewType.self)!
+        } else {
+            child = representable.makeAndroidView(context: context)
+            setChild(child)
+        }
+
+        representable.updateAndroidView(child, context: context)
+
+        return representable.sizeThatFits(proposedSize, view: child, context: context)
+    }
+}
+
+extension SwiftCrossUI.View where Self: AndroidViewRepresentable {
+    public var body: Never {
+        preconditionFailure("This should never be called")
+    }
+
+    public func children<Backend: BaseAppBackend>(
+        backend _: Backend,
+        snapshots _: [ViewGraphSnapshotter.NodeSnapshot]?,
+        environment _: EnvironmentValues
+    ) -> any ViewGraphNodeChildren {
+        EmptyViewChildren()
+    }
+
+    public func layoutableChildren<Backend: BaseAppBackend>(
+        backend _: Backend,
+        children _: any ViewGraphNodeChildren
+    ) -> [LayoutSystem.LayoutableChild] {
+        []
+    }
+
+    public func asWidget<Backend: BaseAppBackend>(
+        _: any ViewGraphNodeChildren,
+        backend _: Backend
+    ) -> Backend.Widget {
+        if let widget = RepresentingView(
+            AndroidBackend.activity,
+            environment: AndroidBackend.env
+        ) as? Backend.Widget {
+            return widget
+        } else {
+            fatalError("AndroidViewRepresentable requested by \(Backend.self)")
+        }
+    }
+
+    public func computeLayout<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: any ViewGraphNodeChildren,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) -> ViewLayoutResult {
+        let widget = (widget as! AndroidBackend.Widget).as(RepresentingView.self)!
+        let size = widget.updateAndGetSize(
+            environment: environment,
+            proposedSize: proposedSize,
+            representable: self
+        )
+        return ViewLayoutResult.leafView(size: size)
+    }
+
+    public func commit<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: any ViewGraphNodeChildren,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        backend.setSize(of: widget, to: layout.size.vector)
+    }
+}

--- a/Sources/AndroidBackend/AndroidViewRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidViewRepresentable.swift
@@ -11,24 +11,46 @@ public protocol AndroidViewRepresentable: SwiftCrossUI.View where Content == Nev
     associatedtype ViewType: AndroidKit.View
     associatedtype Coordinator = Void
 
+    /// Make the coordinator for this view.
+    ///
+    /// The coordinator is used when the view needs to communicate changes to the rest of
+    /// the view hierarchy (i.e. through bindings).
     @MainActor
     func makeCoordinator() -> Coordinator
 
+    /// Create the initial `android.view.View` instance.
     @MainActor
     func makeAndroidView(context: Self.Context) -> ViewType
 
+    /// Update the view with new values.
+    /// - Parameters:
+    ///   - view: The view to update.
+    ///   - context: The context, including the coordinator and potentially new environment
+    ///   values.
+    /// - Note: This may be called even when `context` has not changed.
     @MainActor
     func updateAndroidView(
         _ view: ViewType,
         context: Self.Context
     )
 
+    /// Compute the view's preferred size.
+    ///
+    /// The default implementation uses `view.measure(_:_:)` to determine the view's preferred size.
+    /// - Parameters:
+    ///   - proposal: The proposed size for the view.
+    ///   - view: The view being queried for its preferred size.
+    ///   - context: The context, including the coordinator and environment values.
+    /// - Returns: The view's preferred size.
     @MainActor
     func sizeThatFits(
         _ proposal: ProposedViewSize,
         view: ViewType,
         context: Self.Context
     ) -> ViewSize
+
+    // TODO(bbrk24): Support dismantleAndroidView
+    // View doesn't have the same kind of lifecycle as Fragment, so it's not straightforward
 }
 
 extension AndroidViewRepresentable {

--- a/Sources/AndroidBackend/AndroidViewRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidViewRepresentable.swift
@@ -2,6 +2,7 @@ import AndroidKit
 import SwiftCrossUI
 import SwiftJava
 
+@MainActor
 public struct AndroidViewRepresentableContext<Representable: AndroidViewRepresentable> {
     public let coordinator: Representable.Coordinator
     public internal(set) var environment: EnvironmentValues
@@ -26,7 +27,7 @@ public protocol AndroidViewRepresentable: SwiftCrossUI.View where Content == Nev
     /// - Parameters:
     ///   - view: The view to update.
     ///   - context: The context, including the coordinator and potentially new environment
-    ///   values.
+    ///     values.
     /// - Note: This may be called even when `context` has not changed.
     @MainActor
     func updateAndroidView(

--- a/Sources/AndroidBackend/Androidx.swift
+++ b/Sources/AndroidBackend/Androidx.swift
@@ -1,3 +1,4 @@
+import AndroidKit
 import SwiftJava
 
 @JavaClass("androidx.fragment.app.FragmentManager")
@@ -7,4 +8,14 @@ class AndroidxFragmentManager: JavaObject {}
 class FragmentActivity: JavaObject {
     @JavaMethod
     func getSupportFragmentManager() -> AndroidxFragmentManager?
+}
+
+@JavaClass(
+    "androidx.fragment.app.Fragment",
+    implements: AndroidKit.ComponentCallbacks.self,
+    AndroidKit.View.OnCreateContextMenuListener.self
+)
+open class AndroidxFragment: JavaObject {
+    @JavaMethod
+    open func getView() -> AndroidKit.View?
 }

--- a/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
@@ -2,6 +2,7 @@ import AndroidKit
 import SwiftCrossUI
 import SwiftJava
 
+@MainActor
 public struct AndroidxFragmentRepresentableContext<Representable: AndroidxFragmentRepresentable> {
     public let coordinator: Representable.Coordinator
     public internal(set) var environment: EnvironmentValues
@@ -26,7 +27,7 @@ public protocol AndroidxFragmentRepresentable: SwiftCrossUI.View where Content =
     /// - Parameters:
     ///   - fragment: The fragment to update.
     ///   - context: The context, including the coordinator and potentially new environment
-    ///   values.
+    ///     values.
     /// - Note: This may be called even when `context` has not changed.
     @MainActor
     func updateFragment(

--- a/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
@@ -11,18 +11,38 @@ public protocol AndroidxFragmentRepresentable: SwiftCrossUI.View where Content =
     associatedtype FragmentType: AndroidxFragment
     associatedtype Coordinator = Void
 
+    /// Make the coordinator for this fragment.
+    ///
+    /// The coordinator is used when the fragment needs to communicate changes to the rest of
+    /// the view hierarchy (i.e. through bindings).
     @MainActor
     func makeCoordinator() -> Coordinator
 
+    /// Create the initial `androidx.fragment.app.Fragment` instance.
     @MainActor
     func makeFragment(context: Self.Context) -> FragmentType
 
+    /// Update the fragment with new values.
+    /// - Parameters:
+    ///   - fragment: The fragment to update.
+    ///   - context: The context, including the coordinator and potentially new environment
+    ///   values.
+    /// - Note: This may be called even when `context` has not changed.
     @MainActor
     func updateFragment(
         _ fragment: FragmentType,
         context: Self.Context
     )
 
+    /// Compute the fragment's preferred size.
+    ///
+    /// The default implementation uses `fragment.getView().measure(_:_:)` to determine the
+    /// fragment's preferred size.
+    /// - Parameters:
+    ///   - proposal: The proposed size for the fragment.
+    ///   - fragment: The fragment being queried for its preferred size.
+    ///   - context: The context, including the coordinator and environment values.
+    /// - Returns: The fragment's preferred size.
     @MainActor
     func sizeThatFits(
         _ proposal: ProposedViewSize,
@@ -30,6 +50,12 @@ public protocol AndroidxFragmentRepresentable: SwiftCrossUI.View where Content =
         context: Self.Context
     ) -> ViewSize
 
+    /// Called to clean up the fragment when it's removed.
+    ///
+    /// The default implementation does nothing.
+    /// - Parameters:
+    ///   - fragment: The fragment being dismantled.
+    ///   - coordinator: The coordinator.
     static func dismantleFragment(
         _ fragment: FragmentType,
         coordinator: Coordinator

--- a/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
@@ -62,6 +62,7 @@ public protocol AndroidxFragmentRepresentable: SwiftCrossUI.View where Content =
     )
 }
 
+// swiftlint:disable force_try
 extension AndroidxFragmentRepresentable {
     public typealias Context = AndroidxFragmentRepresentableContext<Self>
 

--- a/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
@@ -1,0 +1,228 @@
+import AndroidKit
+import SwiftCrossUI
+import SwiftJava
+
+public struct AndroidxFragmentRepresentableContext<Representable: AndroidxFragmentRepresentable> {
+    public let coordinator: Representable.Coordinator
+    public internal(set) var environment: EnvironmentValues
+}
+
+public protocol AndroidxFragmentRepresentable: SwiftCrossUI.View where Content == Never {
+    associatedtype FragmentType: AndroidxFragment
+    associatedtype Coordinator = Void
+
+    @MainActor
+    func makeCoordinator() -> Coordinator
+
+    @MainActor
+    func makeFragment(context: Self.Context) -> FragmentType
+
+    @MainActor
+    func updateFragment(
+        _ fragment: FragmentType,
+        context: Self.Context
+    )
+
+    @MainActor
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        fragment: FragmentType,
+        context: Self.Context
+    ) -> ViewSize
+
+    static func dismantleFragment(
+        _ fragment: FragmentType,
+        coordinator: Coordinator
+    )
+}
+
+extension AndroidxFragmentRepresentable {
+    public typealias Context = AndroidxFragmentRepresentableContext<Self>
+
+    @MainActor
+    public func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        fragment: FragmentType,
+        context: Self.Context
+    ) -> ViewSize {
+        guard let view = fragment.getView() else {
+            // TODO(bbrk24): Request relayout after view is created
+            return proposal.replacingUnspecifiedDimensions(by: .init(10, 10))
+        }
+
+        let density = context.environment.windowScaleFactor
+
+        // 0x80000000 = View.MeasureSpec.AT_MOST
+        // 0x3FFFFFFF = View.MeasureSpec.makeMeasureSpec(Int32.max, View.MeasureSpec.UNSPECIFIED)
+        let widthMeasureSpec =
+            if
+                let proposedWidth = proposal.width,
+                proposedWidth > 0
+            {
+                Int32(bitPattern: 0x80000000 | UInt32(min(proposedWidth * density, 0x3FFFFFFF)))
+            } else {
+                0x3FFFFFFF as Int32
+            }
+
+        let heightMeasureSpec =
+            if
+                let proposedHeight = proposal.height,
+                proposedHeight > 0
+            {
+                Int32(bitPattern: 0x80000000 | UInt32(min(proposedHeight * density, 0x3FFFFFFF)))
+            } else {
+                0x3FFFFFFF as Int32
+            }
+
+        view.measure(widthMeasureSpec, heightMeasureSpec)
+
+        let width = Double(view.getMeasuredWidth()) / density
+        let height = Double(view.getMeasuredHeight()) / density
+
+        return ViewSize(width, height)
+    }
+
+    public static func dismantleFragment(
+        _ fragment: FragmentType,
+        coordinator: Coordinator
+    ) {
+        // no-op
+    }
+}
+
+extension AndroidxFragmentRepresentable where Coordinator == Void {
+    public func makeCoordinator() {}
+}
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.FragmentRepresentingView",
+    extends: AndroidKit.FrameLayout.self
+)
+class FragmentRepresentingView: AndroidKit.FrameLayout {
+    @JavaMethod
+    convenience init(
+        _ activity: FragmentActivity?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func getSwiftContext() -> SwiftObject?
+
+    @JavaMethod
+    func setSwiftContext(_ swiftContext: SwiftObject?)
+
+    @JavaMethod
+    func setOnDestroyListener(_ onDestroyListener: SwiftAction?)
+
+    @JavaMethod
+    func setFragment(
+        _ fragment: AndroidxFragment!,
+        _ manager: AndroidxFragmentManager!
+    )
+
+    @JavaMethod
+    func getFragment() -> AndroidxFragment?
+}
+
+extension FragmentRepresentingView {
+    @MainActor
+    func updateAndGetSize<T: AndroidxFragmentRepresentable>(
+        environment: EnvironmentValues,
+        proposedSize: ProposedViewSize,
+        representable: T
+    ) -> ViewSize {
+        var context: T.Context
+        if let untypedContext = getSwiftContext()?.value() {
+            context = untypedContext as! T.Context
+            context.environment = environment
+        } else {
+            context = AndroidxFragmentRepresentableContext(
+                coordinator: representable.makeCoordinator(),
+                environment: environment
+            )
+        }
+
+        setSwiftContext(SwiftObject(context, environment: environment.jniEnv))
+
+        let fragment: T.FragmentType
+        if let untypedFragment = getFragment() {
+            fragment = untypedFragment.as(T.FragmentType.self)!
+        } else {
+            fragment = representable.makeFragment(context: context)
+            let fragmentActivity = environment.androidActivity.as(FragmentActivity.self)!
+            setFragment(fragment, fragmentActivity.getSupportFragmentManager())
+
+            let coordinator = context.coordinator
+            widget.setOnDestroyListener(
+                SwiftAction(environment: environment.jniEnv) {
+                    T.dismantleFragment(fragment, coordinator: coordinator)
+                }
+            )
+        }
+
+        representable.updateFragment(fragment, context: context)
+
+        return representable.sizeThatFits(proposedSize, fragment: fragment, context: context)
+    }
+}
+
+extension SwiftCrossUI.View where Self: AndroidxFragmentRepresentable {
+    public var body: Never {
+        preconditionFailure("This should never be called")
+    }
+
+    public func children<Backend: BaseAppBackend>(
+        backend _: Backend,
+        snapshots _: [ViewGraphSnapshotter.NodeSnapshot]?,
+        environment _: EnvironmentValues
+    ) -> any ViewGraphNodeChildren {
+        EmptyViewChildren()
+    }
+
+    public func layoutableChildren<Backend: BaseAppBackend>(
+        backend _: Backend,
+        children _: any ViewGraphNodeChildren
+    ) -> [LayoutSystem.LayoutableChild] {
+        []
+    }
+
+    public func asWidget<Backend: BaseAppBackend>(
+        _: any ViewGraphNodeChildren,
+        backend _: Backend
+    ) -> Backend.Widget {
+        if let widget = FragmentRepresentingView(
+            AndroidBackend.activity.as(FragmentActivity.self)!,
+            environment: AndroidBackend.env
+        ) as? Backend.Widget {
+            return widget
+        } else {
+            fatalError("AndroidxFragmentRepresentable requested by \(Backend.self)")
+        }
+    }
+
+    public func computeLayout<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: any ViewGraphNodeChildren,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) -> ViewLayoutResult {
+        let widget = (widget as! AndroidBackend.Widget).as(FragmentRepresentingView.self)!
+        let size = widget.updateAndGetSize(
+            environment: environment,
+            proposedSize: proposedSize,
+            representable: self
+        )
+        return ViewLayoutResult.leafView(size: size)
+    }
+
+    public func commit<Backend: BaseAppBackend>(
+        _ widget: Backend.Widget,
+        children: any ViewGraphNodeChildren,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        backend.setSize(of: widget, to: layout.size.vector)
+    }
+}

--- a/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
+++ b/Sources/AndroidBackend/AndroidxFragmentRepresentable.swift
@@ -46,8 +46,9 @@ extension AndroidxFragmentRepresentable {
         context: Self.Context
     ) -> ViewSize {
         guard let view = fragment.getView() else {
-            // TODO(bbrk24): Request relayout after view is created
-            return proposal.replacingUnspecifiedDimensions(by: .init(10, 10))
+            // onCreateView has not been called yet. onStart will trigger a relayout, but for now,
+            // return a placeholder value.
+            return .zero
         }
 
         let density = context.environment.windowScaleFactor
@@ -73,6 +74,14 @@ extension AndroidxFragmentRepresentable {
             } else {
                 0x3FFFFFFF as Int32
             }
+
+        // For some reason, the measured size often prefers to return the current size over the
+        // ideal size when given AT_MOST. Set the size to WRAP_CONTENT to suppress this effect.
+        let layoutParamsClass = try! JavaClass<AndroidKit.ViewGroup.LayoutParams>()
+        let layoutParams = view.getLayoutParams()!
+        layoutParams.width = layoutParamsClass.WRAP_CONTENT
+        layoutParams.height = layoutParamsClass.WRAP_CONTENT
+        view.setLayoutParams(layoutParams)
 
         view.measure(widthMeasureSpec, heightMeasureSpec)
 
@@ -112,12 +121,11 @@ class FragmentRepresentingView: AndroidKit.FrameLayout {
     func setSwiftContext(_ swiftContext: SwiftObject?)
 
     @JavaMethod
-    func setOnDestroyListener(_ onDestroyListener: SwiftAction?)
-
-    @JavaMethod
-    func setFragment(
-        _ fragment: AndroidxFragment!,
-        _ manager: AndroidxFragmentManager!
+    func set(
+        fragment: AndroidxFragment!,
+        manager: AndroidxFragmentManager!,
+        onStartListener: SwiftAction!,
+        onDestroyListener: SwiftAction!
     )
 
     @JavaMethod
@@ -150,13 +158,22 @@ extension FragmentRepresentingView {
         } else {
             fragment = representable.makeFragment(context: context)
             let fragmentActivity = environment.androidActivity.as(FragmentActivity.self)!
-            setFragment(fragment, fragmentActivity.getSupportFragmentManager())
+
+            let onStartListener = SwiftAction(environment: environment.jniEnv) {
+                let context = self.getSwiftContext()!.value() as! T.Context
+                context.environment.onResize(.zero)
+            }
 
             let coordinator = context.coordinator
-            widget.setOnDestroyListener(
-                SwiftAction(environment: environment.jniEnv) {
-                    T.dismantleFragment(fragment, coordinator: coordinator)
-                }
+            let onDestroyListener = SwiftAction(environment: environment.jniEnv) {
+                T.dismantleFragment(fragment, coordinator: coordinator)
+            }
+
+            set(
+                fragment: fragment,
+                manager: fragmentActivity.getSupportFragmentManager(),
+                onStartListener: onStartListener,
+                onDestroyListener: onDestroyListener
             )
         }
 

--- a/Sources/AndroidBackend/Kotlin/FragmentRepresentingView.kt
+++ b/Sources/AndroidBackend/Kotlin/FragmentRepresentingView.kt
@@ -15,6 +15,13 @@ import androidx.lifecycle.LifecycleEventObserver
 class FragmentRepresentingView(activity: FragmentActivity) : FrameLayout(activity) {
     private val containerView = FragmentContainerView(activity)
 
+    var swiftContext: SwiftObject? = null
+
+    // TODO(bbrk24): Once we upgrade to androidx.fragment 1.4 or later, this could just be
+    //   computed as containerView.getFragment() instead of being a stored property
+    var fragment: Fragment? = null
+        private set
+
     init {
         containerView.id = View.generateViewId()
         containerView.layoutParams =
@@ -27,10 +34,14 @@ class FragmentRepresentingView(activity: FragmentActivity) : FrameLayout(activit
         addView(containerView)
     }
 
-    var swiftContext: SwiftObject? = null
-    var onDestroyListener: SwiftAction? = null
+    fun set(
+        fragment: Fragment,
+        manager: FragmentManager,
+        onStartListener: SwiftAction,
+        onDestroyListener: SwiftAction,
+    ) {
+        this.fragment = fragment
 
-    fun setFragment(fragment: Fragment, manager: FragmentManager) {
         val transaction = manager.beginTransaction()
         transaction.setReorderingAllowed(true)
         transaction.replace(containerView.id, fragment)
@@ -38,14 +49,12 @@ class FragmentRepresentingView(activity: FragmentActivity) : FrameLayout(activit
 
         fragment.lifecycle.addObserver(
             LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_DESTROY) {
-                    onDestroyListener?.call()
+                when (event) {
+                    Lifecycle.Event.ON_START -> onStartListener.call()
+                    Lifecycle.Event.ON_DESTROY -> onDestroyListener.call()
+                    else -> {}
                 }
             }
         )
     }
-
-    // FIXME: Upgrade to androidx.fragment 1.4 or later (ideally 1.8) so that this method actually
-    // exists
-    fun getFragment(): Fragment? = containerView.getFragment()
 }

--- a/Sources/AndroidBackend/Kotlin/FragmentRepresentingView.kt
+++ b/Sources/AndroidBackend/Kotlin/FragmentRepresentingView.kt
@@ -1,0 +1,51 @@
+package dev.swiftcrossui.androidbackend
+
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+
+// FragmentContainerView is final, which makes this needlessly complex.
+class FragmentRepresentingView(activity: FragmentActivity) : FrameLayout(activity) {
+    private val containerView = FragmentContainerView(activity)
+
+    init {
+        containerView.id = View.generateViewId()
+        containerView.layoutParams =
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Gravity.FILL,
+            )
+
+        addView(containerView)
+    }
+
+    var swiftContext: SwiftObject? = null
+    var onDestroyListener: SwiftAction? = null
+
+    fun setFragment(fragment: Fragment, manager: FragmentManager) {
+        val transaction = manager.beginTransaction()
+        transaction.setReorderingAllowed(true)
+        transaction.replace(containerView.id, fragment)
+        transaction.commitNow()
+
+        fragment.lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_DESTROY) {
+                    onDestroyListener?.call()
+                }
+            }
+        )
+    }
+
+    // FIXME: Upgrade to androidx.fragment 1.4 or later (ideally 1.8) so that this method actually
+    // exists
+    fun getFragment(): Fragment? = containerView.getFragment()
+}

--- a/Sources/AndroidBackend/Kotlin/RepresentingView.kt
+++ b/Sources/AndroidBackend/Kotlin/RepresentingView.kt
@@ -1,0 +1,29 @@
+package dev.swiftcrossui.androidbackend
+
+import android.app.Activity
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+
+class RepresentingView(activity: Activity) : FrameLayout(activity) {
+    var swiftContext: SwiftObject? = null
+
+    private var _child: View? = null
+
+    var child: View?
+        get() = _child
+        set(value) {
+            _child = value
+            value?.let {
+                addView(it)
+
+                it.layoutParams =
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        Gravity.FILL,
+                    )
+            }
+        }
+}

--- a/Sources/AndroidBackend/Kotlin/RepresentingView.kt
+++ b/Sources/AndroidBackend/Kotlin/RepresentingView.kt
@@ -14,6 +14,7 @@ class RepresentingView(activity: Activity) : FrameLayout(activity) {
     var child: View?
         get() = _child
         set(value) {
+            removeAllViews()
             _child = value
             value?.let {
                 addView(it)

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -40,7 +40,7 @@ public struct EnvironmentValues {
     /// Each view graph node sets its own handler when passing the environment
     /// on to its children, setting up a bottom-up update chain up which resize
     /// events can propagate.
-    var onResize: @MainActor (_ newSize: ViewSize) -> Void
+    package var onResize: @MainActor (_ newSize: ViewSize) -> Void
 
     /// Backing storage for extensible subscript
     private var values: [ObjectIdentifier: Any]

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -12,7 +12,7 @@ public enum LayoutSystem {
             logger.warning("LayoutSystem.roundSize(_:) called with infinite size")
         }
 
-        let size = size.rounded(.towardZero)
+        let size = size.rounded(.up)
         return if size >= Double(Int.max) {
             Int.max
         } else if size <= Double(Int.min) {


### PR DESCRIPTION
Implements `AndroidViewRepresentable` and `AndroidxFragmentRepresentable`. As an aside, we currently depend on a very old version of androidx.fragment, and could afford to upgrade.