### PR TITLE
Android file open dialog

### DIFF
--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -268,7 +268,7 @@ struct WindowingApp: App {
                         Divider()
                     #endif
 
-                    #if !os(tvOS) && !os(Android)
+                    #if !os(tvOS)
                         FileDialogDemo()
 
                         Divider()

--- a/Scripts/format.sh
+++ b/Scripts/format.sh
@@ -11,7 +11,7 @@ fi
 if which java &>/dev/null; then
   ./Scripts/ensure_ktfmt.sh
 
-  java -jar Tools/ktfmt.jar --kotlinlang-style --quiet Sources/AndroidBackend/Kotlin/*.kt
+  java -jar Tools/ktfmt.jar --kotlinlang-style --quiet Sources/AndroidBackend/Kotlin/
 else
   echo 'Skipping ktfmt, as Java was not found. To format Kotlin files, install Java 17.' >&2
 fi

--- a/Sources/AndroidBackend/ActivityResults.swift
+++ b/Sources/AndroidBackend/ActivityResults.swift
@@ -1,0 +1,33 @@
+import SwiftJava
+
+@JavaClass("dev.swiftcrossui.androidbackend.activityresults.FilesActivityCallback")
+class FilesActivityCallback: JavaObject {
+    @JavaMethod
+    func setAction(_ action: SwiftAction?)
+
+    @JavaMethod
+    func getUrlStrings() -> [String]
+}
+
+@JavaClass("dev.swiftcrossui.androidbackend.activityresults.FolderActivityCallback")
+class FolderActivityCallback: JavaObject {
+    @JavaMethod
+    func setAction(_ action: SwiftAction?)
+
+    @JavaMethod
+    func getUrlString() -> JavaString?
+}
+
+@JavaClass("dev.swiftcrossui.androidbackend.activityresults.FilesActivityContract")
+class FilesActivityContract: JavaObject {
+    @JavaClass("dev.swiftcrossui.androidbackend.activityresults.FilesActivityContract$Options")
+    class Options: JavaObject {
+        @JavaMethod
+        convenience init(
+            _ allowMultiple: Bool,
+            _ mimeTypes: [String],
+            _ rootDirectory: JavaString?,
+            environment: JNIEnvironment? = nil
+        )
+    }
+}

--- a/Sources/AndroidBackend/AndroidBackend+FileDialogs.swift
+++ b/Sources/AndroidBackend/AndroidBackend+FileDialogs.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftCrossUI
+import SwiftJava
+
+extension AndroidBackend: BackendFeatures.FileOpenDialogs {
+    public func showOpenDialog(
+        fileDialogOptions: FileDialogOptions,
+        openDialogOptions: OpenDialogOptions,
+        window: Window?,
+        resultHandler handleResult: @escaping (DialogResult<[Foundation.URL]>) -> Void
+    ) {
+        let startingFolder = fileDialogOptions.initialDirectory.map {
+            JavaString($0.absoluteString, environment: Self.env)
+        }
+
+        if openDialogOptions.allowSelectingFiles {
+            let options = FilesActivityContract.Options(
+                openDialogOptions.allowMultipleSelections,
+                fileDialogOptions.allowedContentTypes.flatMap(\.mimeTypes),
+                startingFolder,
+                environment: Self.env
+            )
+            Self.fileDialogCallback = {
+                handleResult($0.isEmpty ? .cancelled : .success($0))
+            }
+            helpers.launchFilesActivity(options)
+        } else if openDialogOptions.allowSelectingDirectories {
+            Self.folderDialogCallback = { url in
+                if let url {
+                    handleResult(.success([url]))
+                } else {
+                    handleResult(.cancelled)
+                }
+            }
+            helpers.launchFolderActivity(startingFolder)
+        } else {
+            preconditionFailure("Neither file nor directory selection allowed?!")
+        }
+    }
+}

--- a/Sources/AndroidBackend/AndroidBackend+WebViews.swift
+++ b/Sources/AndroidBackend/AndroidBackend+WebViews.swift
@@ -14,9 +14,11 @@ extension AndroidBackend: BackendFeatures.WebViews {
     ) {
         let webView = webView.as(CustomWebView.self)!
         webView.setOnNavigate(SwiftAction(environment: Self.env) {
-            if let javaString = webView.getLoadingUrl(),
-               let url = URL(string: javaString.toString())
-            {
+            if let javaString = webView.getLoadingUrl() {
+                guard let url = URL(string: javaString.toString()) else {
+                    log("Failed to convert Uri to Foundation.URL: \(javaString)")
+                    return
+                }
                 onNavigate(url)
             }
         })

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -208,8 +208,8 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
         let matchParent = try! JavaClass<AndroidKit.ViewGroup.LayoutParams>().MATCH_PARENT
 
-        let leftInset = Int(Self.helpers.getSafeAreaLeftInset(Self.activity))
-        let topInset = Int(Self.helpers.getSafeAreaTopInset(Self.activity))
+        let leftInset = Int(helpers.getSafeAreaLeftInset(Self.activity))
+        let topInset = Int(helpers.getSafeAreaTopInset(Self.activity))
         let fullWindowSize = SIMD2(Int(matchParent), Int(matchParent))
         setSize(of: container, to: fullWindowSize)
         setPosition(ofChildAt: 0, in: container, to: SIMD2(leftInset, topInset))

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -105,6 +105,9 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     public let supportsMultipleWindows = false
     public let canOverrideWindowColorScheme = false
 
+    static var fileDialogCallback: (([Foundation.URL]) -> Void)?
+    static var folderDialogCallback: ((Foundation.URL?) -> Void)?
+
     /// A reference used to keep the tickler alive.
     var tickler: MainRunLoopTickler?
 
@@ -117,6 +120,36 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
     public init() {
         helpers = AndroidBackendHelpers(environment: Self.env)
+
+        let fragmentActivity = Self.activity.as(FragmentActivity.self)!
+
+        let filesCallback = FilesActivityCallback(environment: Self.env)
+        let filesAction = SwiftAction(environment: Self.env) {
+            let urls = filesCallback.getUrlStrings()
+            AndroidBackend.fileDialogCallback?(urls.map {
+                guard let url = Foundation.URL(string: $0) else {
+                    fatalError("Failed to convert Uri to Foundation.URL: \($0)")
+                }
+                return url
+            })
+            AndroidBackend.fileDialogCallback = nil
+        }
+        filesCallback.setAction(filesAction)
+
+        let folderCallback = FolderActivityCallback(environment: Self.env)
+        let folderAction = SwiftAction(environment: Self.env) {
+            let url = folderCallback.getUrlString()?.toString()
+            AndroidBackend.folderDialogCallback?(url.map {
+                guard let url = Foundation.URL(string: $0) else {
+                    fatalError("Failed to convert Uri to Foundation.URL: \($0)")
+                }
+                return url
+            })
+            AndroidBackend.folderDialogCallback = nil
+        }
+        folderCallback.setAction(folderAction)
+
+        helpers.registerActivityResults(fragmentActivity, filesCallback, folderCallback)
     }
 
     public func runMainLoop(
@@ -175,8 +208,8 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
 
         let matchParent = try! JavaClass<AndroidKit.ViewGroup.LayoutParams>().MATCH_PARENT
 
-        let leftInset = Int(helpers.getSafeAreaLeftInset(Self.activity))
-        let topInset = Int(helpers.getSafeAreaTopInset(Self.activity))
+        let leftInset = Int(Self.helpers.getSafeAreaLeftInset(Self.activity))
+        let topInset = Int(Self.helpers.getSafeAreaTopInset(Self.activity))
         let fullWindowSize = SIMD2(Int(matchParent), Int(matchParent))
         setSize(of: container, to: fullWindowSize)
         setPosition(ofChildAt: 0, in: container, to: SIMD2(leftInset, topInset))

--- a/Sources/AndroidBackend/AndroidBackendHelpers.swift
+++ b/Sources/AndroidBackend/AndroidBackendHelpers.swift
@@ -46,4 +46,17 @@ class AndroidBackendHelpers: JavaObject {
 
     @JavaMethod
     func getTimeZoneIdentifier() -> JavaString?
+
+    @JavaMethod
+    func registerActivityResults(
+        _ activity: FragmentActivity!,
+        _ filesCallback: FilesActivityCallback!,
+        _ folderCallback: FolderActivityCallback!,
+    )
+
+    @JavaMethod
+    func launchFilesActivity(_ options: FilesActivityContract.Options!)
+
+    @JavaMethod
+    func launchFolderActivity(_ urlString: JavaString?)
 }

--- a/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
+++ b/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
@@ -4,10 +4,15 @@ import android.R
 import android.app.Activity
 import android.content.res.Configuration
 import android.icu.util.TimeZone
+import android.net.Uri
 import android.os.Build
 import android.util.TypedValue
 import android.view.WindowInsets
 import android.widget.TextView
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.FragmentActivity
+import dev.swiftcrossui.androidbackend.activityresults.*
 
 class AndroidBackendHelpers {
     companion object {
@@ -197,5 +202,30 @@ class AndroidBackendHelpers {
         } else {
             return TimeZone.getCanonicalID(tz.getID())
         }
+    }
+
+    private lateinit var filesLauncher: ActivityResultLauncher<FilesActivityContract.Options>
+    private lateinit var folderLauncher: ActivityResultLauncher<Uri?>
+
+    fun registerActivityResults(
+        activity: FragmentActivity,
+        filesCallback: FilesActivityCallback,
+        folderCallback: FolderActivityCallback,
+    ) {
+        filesLauncher = activity.registerForActivityResult(FilesActivityContract(), filesCallback)
+
+        folderLauncher =
+            activity.registerForActivityResult(
+                ActivityResultContracts.OpenDocumentTree(),
+                folderCallback,
+            )
+    }
+
+    fun launchFilesActivity(options: FilesActivityContract.Options) {
+        filesLauncher.launch(options)
+    }
+
+    fun launchFolderActivity(urlString: String?) {
+        folderLauncher.launch(urlString?.let { Uri.parse(it) })
     }
 }

--- a/Sources/AndroidBackend/Kotlin/activityresults/FilesActivityCallback.kt
+++ b/Sources/AndroidBackend/Kotlin/activityresults/FilesActivityCallback.kt
@@ -1,0 +1,17 @@
+package dev.swiftcrossui.androidbackend.activityresults
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultCallback
+import dev.swiftcrossui.androidbackend.SwiftAction
+
+class FilesActivityCallback() : ActivityResultCallback<Set<Uri>> {
+    var action: SwiftAction? = null
+
+    lateinit var urlStrings: Array<String>
+        private set
+
+    override fun onActivityResult(result: Set<Uri>) {
+        urlStrings = result.map { it.toString() }.toTypedArray()
+        action?.call()
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/activityresults/FilesActivityContract.kt
+++ b/Sources/AndroidBackend/Kotlin/activityresults/FilesActivityContract.kt
@@ -1,0 +1,59 @@
+package dev.swiftcrossui.androidbackend.activityresults
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.activity.result.contract.ActivityResultContract
+
+// ActivityResultContracts.OpenMultipleDocuments doesn't set the starting directory.
+class FilesActivityContract : ActivityResultContract<FilesActivityContract.Options, Set<Uri>>() {
+    data class Options(
+        val allowMultiple: Boolean,
+        val mimeTypes: Array<String>,
+        val rootDirectory: String?,
+    )
+
+    override fun createIntent(context: Context, input: Options) =
+        Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, input.allowMultiple)
+
+            when (input.mimeTypes.size) {
+                0 -> setType("*/*")
+                1 -> setType(input.mimeTypes[0])
+                else -> {
+                    setType("*/*")
+                    putExtra(Intent.EXTRA_MIME_TYPES, input.mimeTypes)
+                }
+            }
+
+            if (input.rootDirectory != null) {
+                putExtra(DocumentsContract.EXTRA_INITIAL_URI, Uri.parse(input.rootDirectory))
+            }
+        }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Set<Uri> {
+        if (intent == null || resultCode != Activity.RESULT_OK) return emptySet<Uri>()
+
+        val clipData = intent.clipData
+        if (clipData == null) return setOfNotNull(intent.data)
+
+        val result = hashSetOf<Uri>()
+
+        val intentData = intent.data
+        if (intentData != null) {
+            result.add(intentData)
+        }
+
+        for (i in 0..<clipData.itemCount) {
+            val uri = clipData.getItemAt(i).uri
+            if (uri != null) {
+                result.add(uri)
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/activityresults/FolderActivityCallback.kt
+++ b/Sources/AndroidBackend/Kotlin/activityresults/FolderActivityCallback.kt
@@ -1,0 +1,17 @@
+package dev.swiftcrossui.androidbackend.activityresults
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultCallback
+import dev.swiftcrossui.androidbackend.SwiftAction
+
+class FolderActivityCallback() : ActivityResultCallback<Uri?> {
+    var action: SwiftAction? = null
+
+    var urlString: String? = null
+        private set
+
+    override fun onActivityResult(result: Uri?) {
+        urlString = result?.toString()
+        action?.call()
+    }
+}


### PR DESCRIPTION
This PR adds support for file open dialogs in AndroidBackend. Save dialogs are left for future work, as they require the MIME type to be given.

Because of how Android does sandboxing, the URLs produced are not `file://` URLs, nor do they directly represent the folder structure on disk. They need to be passed into `ContentResolver` rather than being read directly.