### PR TITLE
Bump swift-winui version (to get static linking + monorepo)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -172,16 +172,8 @@ let package = Package(
             .upToNextMinor(from: "0.5.0")
         ),
         .package(
-            url: "https://github.com/moreSwift/swift-windowsappsdk",
-            .upToNextMinor(from: "0.1.1")
-        ),
-        .package(
-            url: "https://github.com/moreSwift/swift-windowsfoundation",
-            .upToNextMinor(from: "0.1.0")
-        ),
-        .package(
             url: "https://github.com/moreSwift/swift-winui",
-            .upToNextMinor(from: "0.1.1")
+            .upToNextMinor(from: "0.2.0")
         ),
         .package(
             url: "https://github.com/stackotter/swift-benchmark",
@@ -323,8 +315,8 @@ let package = Package(
                 "SwiftCrossUI",
                 "WinUIInterop",
                 .product(name: "WinUI", package: "swift-winui"),
-                .product(name: "WinAppSDK", package: "swift-windowsappsdk"),
-                .product(name: "WindowsFoundation", package: "swift-windowsfoundation"),
+                .product(name: "WinAppSDK", package: "swift-winui"),
+                .product(name: "WindowsFoundation", package: "swift-winui"),
                 .product(name: "Mutex", package: "swift-mutex"),
             ]
         ),


### PR DESCRIPTION
This PR updates SwiftCrossUI to use the latest version of moreSwift/swift-winui which brings static linking support. Apps that use WinUIBackend will see significant binary size improvements when compiled with this newer version of moreSwift/swift-winui.

In my preliminary testing, the installed size of a stripped release build of CounterExample.exe (along with the bundled Swift runtime etc) is 144mb. It used to be aroun 360mb, which makes that a **60% size reduction**!