### PR TITLE
[AndroidBackend] Fix windowing behavior on older API levels

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -208,15 +208,6 @@
       }
     },
     {
-      "identity" : "swift-cwinrt",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-cwinrt",
-      "state" : {
-        "revision" : "601287a2a89e8e56e8aa53782b6054db8be0bce8",
-        "version" : "0.1.2"
-      }
-    },
-    {
       "identity" : "swift-filestreamer",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sersoft-gmbh/swift-filestreamer",
@@ -352,48 +343,12 @@
       }
     },
     {
-      "identity" : "swift-uwp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-uwp",
-      "state" : {
-        "revision" : "a0a86467514eaa63272eae848c70d49e6874ede4",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-webview2core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-webview2core",
-      "state" : {
-        "revision" : "a8ed52a57f6d81ee06c8db692f8ee0431174379a",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-windowsappsdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-windowsappsdk",
-      "state" : {
-        "revision" : "40d2db0c4cfadf557b9ce60a0ce1c5c96defc438",
-        "version" : "0.1.2"
-      }
-    },
-    {
-      "identity" : "swift-windowsfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-windowsfoundation",
-      "state" : {
-        "revision" : "94d56a5aea472672bc5d041c091f6cdf72e3cc44",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swift-winui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-winui",
       "state" : {
-        "revision" : "73d5d19c39c523c92355027dd13aee445fc627a7",
-        "version" : "0.1.1"
+        "revision" : "7cce3fcd0b55c48e6d8993fd2c7c392e8bc945c4",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "848af29777f0d85216ca529814aeef544ac2b82e4829189e9521f4f5ce3070b3",
+  "originHash" : "3f78b4201a2b283fa0247a8d63a937c8d8195da44b7445818adfa8c6d2bc6cba",
   "pins" : [
     {
       "identity" : "androidkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/AndroidKit",
       "state" : {
-        "revision" : "937a0643efb2f0820dc62a9249729f12987bf340",
-        "version" : "0.7.2"
+        "revision" : "ed371b3becaab639cada60f5c65f0ee8f0d6d149",
+        "version" : "0.8.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
       }
     },
     {
@@ -71,15 +71,6 @@
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-cwinrt",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-cwinrt",
-      "state" : {
-        "revision" : "601287a2a89e8e56e8aa53782b6054db8be0bce8",
-        "version" : "0.1.2"
       }
     },
     {
@@ -112,10 +103,10 @@
     {
       "identity" : "swift-java",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-java",
+      "location" : "https://github.com/stackotter/swift-java",
       "state" : {
-        "revision" : "3d52a15db42c4d5ef322fde074626106b9bf82d7",
-        "version" : "0.2.0"
+        "revision" : "e04c0ed6af98936ca6300e94be9a19869df418a2",
+        "version" : "0.5.1"
       }
     },
     {
@@ -182,48 +173,12 @@
       }
     },
     {
-      "identity" : "swift-uwp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-uwp",
-      "state" : {
-        "revision" : "a0a86467514eaa63272eae848c70d49e6874ede4",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-webview2core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-webview2core",
-      "state" : {
-        "revision" : "a8ed52a57f6d81ee06c8db692f8ee0431174379a",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-windowsappsdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-windowsappsdk",
-      "state" : {
-        "revision" : "40d2db0c4cfadf557b9ce60a0ce1c5c96defc438",
-        "version" : "0.1.2"
-      }
-    },
-    {
-      "identity" : "swift-windowsfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-windowsfoundation",
-      "state" : {
-        "revision" : "94d56a5aea472672bc5d041c091f6cdf72e3cc44",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swift-winui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/moreSwift/swift-winui",
       "state" : {
-        "revision" : "73d5d19c39c523c92355027dd13aee445fc627a7",
-        "version" : "0.1.1"
+        "revision" : "7cce3fcd0b55c48e6d8993fd2c7c392e8bc945c4",
+        "version" : "0.2.0"
       }
     },
     {
@@ -231,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/SwiftJavaLang.git",
       "state" : {
-        "revision" : "b60871fd650b81b142a1d6a62d7d440ea1e9bff7",
-        "version" : "0.2.1"
+        "revision" : "000441db9284536a2af611745b82ec7653dca5bc",
+        "version" : "0.3.0"
       }
     },
     {
@@ -240,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/SwiftKotlin.git",
       "state" : {
-        "revision" : "f408b73ebb86a33411f27a668e2d843a10f007c2",
-        "version" : "0.2.1"
+        "revision" : "ad30daacb7e4666e1a56bfdd48498f5ac4ff081d",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -168,12 +168,11 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
             return
         }
 
+        let matchParent = try! JavaClass<AndroidKit.ViewGroup.LayoutParams>().MATCH_PARENT
+
         let leftInset = Int(helpers.getSafeAreaLeftInset(Self.activity))
         let topInset = Int(helpers.getSafeAreaTopInset(Self.activity))
-        let fullWindowSize = SIMD2(
-            Int(helpers.getFullWindowWidth(Self.activity)),
-            Int(helpers.getFullWindowHeight(Self.activity))
-        )
+        let fullWindowSize = SIMD2(Int(matchParent), Int(matchParent))
         setSize(of: container, to: fullWindowSize)
         setPosition(ofChildAt: 0, in: container, to: SIMD2(leftInset, topInset))
 

--- a/Sources/AndroidBackend/AndroidBackendHelpers.swift
+++ b/Sources/AndroidBackend/AndroidBackendHelpers.swift
@@ -17,16 +17,6 @@ class AndroidBackendHelpers: JavaObject {
     @JavaMethod
     func getSafeWindowHeight(_ activity: Activity?) -> Int32
 
-    /// Get the window width, including the parts that extend outside of the
-    /// safe areas.
-    @JavaMethod
-    func getFullWindowWidth(_ activity: Activity?) -> Int32
-
-    /// Get the window height, including the parts that extend outside of the
-    /// safe areas.
-    @JavaMethod
-    func getFullWindowHeight(_ activity: Activity?) -> Int32
-
     @JavaMethod
     func getSafeAreaLeftInset(_ activity: Activity?) -> Int32
 

--- a/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
+++ b/Sources/AndroidBackend/Kotlin/AndroidBackendHelpers.kt
@@ -17,7 +17,13 @@ class AndroidBackendHelpers {
         private const val DEVICE_CLASS_WATCH: Short = 4
     }
 
+    // In API 34 and earlier, the insets are accounted for by the system, and it's impossible to
+    // render anything within them. resources.configuration has the correct size.
+    // Starting in API 35, it is possible to render things in the insets, and the system bars are
+    // transparent.
     fun getSafeWindowWidth(activity: Activity): Int {
+        if (Build.VERSION.SDK_INT <= 34) return activity.resources.configuration.screenWidthDp
+
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val displayMetrics = activity.resources.displayMetrics
         val insets =
@@ -32,6 +38,8 @@ class AndroidBackendHelpers {
     }
 
     fun getSafeWindowHeight(activity: Activity): Int {
+        if (Build.VERSION.SDK_INT <= 34) return activity.resources.configuration.screenHeightDp
+
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val displayMetrics = activity.resources.displayMetrics
         val insets =
@@ -43,21 +51,9 @@ class AndroidBackendHelpers {
             .toInt()
     }
 
-    fun getFullWindowWidth(activity: Activity): Int {
-        val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
-        val displayMetrics = activity.resources.displayMetrics
-        // density is very frequently a fractional value like 1.5, so cast to int after division
-        // instead of before
-        return (windowMetrics.getBounds().width().toFloat() / displayMetrics.density).toInt()
-    }
-
-    fun getFullWindowHeight(activity: Activity): Int {
-        val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
-        val displayMetrics = activity.resources.displayMetrics
-        return (windowMetrics.getBounds().height().toFloat() / displayMetrics.density).toInt()
-    }
-
     fun getSafeAreaLeftInset(activity: Activity): Int {
+        if (Build.VERSION.SDK_INT <= 34) return 0
+
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val displayMetrics = activity.resources.displayMetrics
         val insets =
@@ -68,6 +64,8 @@ class AndroidBackendHelpers {
     }
 
     fun getSafeAreaTopInset(activity: Activity): Int {
+        if (Build.VERSION.SDK_INT <= 34) return 0
+
         val windowMetrics = activity.getWindowManager().getCurrentWindowMetrics()
         val displayMetrics = activity.resources.displayMetrics
         val insets =


### PR DESCRIPTION
Fixes #579

This PR changes how the window is measured in older API levels. I also found that the system accounts for the insets for you on API 30-34, so I apply the legacy logic for those API levels, too (not just API 28-29, where the functions we've been using don't exist).