### PR TITLE
Fix ZStack layout issue related to unspecified dimensions

### DIFF
--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -41,7 +41,7 @@ struct ControlsApp: App {
     @State var date = Date()
     @State var datePickerStyle: DatePickerStyle? = .automatic
     @State var menuToggleState = false
-    @State var progressViewSize: Int = 10
+    @State var progressViewSize: Double = 10
     @State var isProgressViewResizable = true
     @State var pickerStyle: BuiltInPickerStyle? = .automatic
 

--- a/Sources/SwiftCrossUI/Views/ZStack.swift
+++ b/Sources/SwiftCrossUI/Views/ZStack.swift
@@ -56,6 +56,25 @@ public struct ZStack<Content: View>: View {
             childResults.map(\.size.height).max() ?? 0
         )
 
+        if !(children is TupleViewChildren || children is EmptyViewChildren) {
+            logger.warning(
+                "ZStack will not function correctly with non-TupleView content",
+                metadata: [
+                    "childrenType": "\(type(of: children))",
+                    "contentType": "\(Content.self)",
+                ]
+            )
+        }
+
+        (children as? TupleViewChildren)?.stackLayoutCache = StackLayoutCache(
+            priorityGroups: [],
+            isHidden: [],
+            totalSpacing: 0,
+            totalReservedSpace: 0,
+            minimumLengths: [],
+            redistributeSpaceOnCommit: proposedSize.width == nil || proposedSize.height == nil
+        )
+
         return ViewLayoutResult(size: size, childResults: childResults)
     }
 
@@ -66,15 +85,26 @@ public struct ZStack<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) {
-        let size = layout.size
+        let cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache.initial
         let children = layoutableChildren(backend: backend, children: children)
-            .map { child in
-                child.commit()
-            }
 
-        for (i, child) in children.enumerated() {
+        if cache.redistributeSpaceOnCommit {
+            for child in children {
+                _ = child.computeLayout(
+                    proposedSize: ProposedViewSize(layout.size),
+                    environment: environment
+                )
+            }
+        }
+
+        let size = layout.size
+        let layoutResults = children.map { child in
+            child.commit()
+        }
+
+        for (i, layoutResult) in layoutResults.enumerated() {
             let position = alignment.position(
-                ofChild: child.size.vector,
+                ofChild: layoutResult.size.vector,
                 in: size.vector
             )
             backend.setPosition(ofChildAt: i, in: widget, to: position)


### PR DESCRIPTION
When a dimension is unspecified we have to re-layout the ZStack's children on commit so that they expand to fill the space occupied by the largest child (rather than remaining at their own 'ideal' sizes.