### PR TITLE
Fix AppStorage on Android

### DIFF
--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -298,6 +298,9 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
             environment.calendar = getCurrentCalendar(timeZone: nil)
         }
 
+        environment
+            .appStorageProvider = SharedPreferencesAppStorageProvider(activity: Self.activity)
+
         return environment
     }
 

--- a/Sources/AndroidBackend/SharedPreferencesAppStorageProvider.swift
+++ b/Sources/AndroidBackend/SharedPreferencesAppStorageProvider.swift
@@ -9,6 +9,7 @@ extension AndroidKit.SharedPreferences {
     func getString(key: String, defaultValue: JavaString?) throws -> JavaString?
 }
 
+// swiftlint:disable force_try
 public struct SharedPreferencesAppStorageProvider: AppStorageProvider {
     private let sharedPreferences: AndroidKit.SharedPreferences
     private let encoder = Foundation.JSONEncoder()
@@ -41,7 +42,8 @@ public struct SharedPreferencesAppStorageProvider: AppStorageProvider {
     ) -> Value? {
         var jsonString: String
         do {
-            guard let javaString = try sharedPreferences.getString(key: key, defaultValue: nil)
+            guard
+                let javaString = try sharedPreferences.getString(key: key, defaultValue: nil)
             else {
                 return nil
             }
@@ -51,7 +53,7 @@ public struct SharedPreferencesAppStorageProvider: AppStorageProvider {
             return nil
         }
 
-        guard let data = jsonString.data(using: .utf8) else { return nil }
+        let data = Data(jsonString.utf8)
 
         return try? decoder.decode(type, from: data)
     }

--- a/Sources/AndroidBackend/SharedPreferencesAppStorageProvider.swift
+++ b/Sources/AndroidBackend/SharedPreferencesAppStorageProvider.swift
@@ -1,0 +1,58 @@
+import SwiftCrossUI
+import AndroidKit
+import SwiftJava
+import Foundation
+
+extension AndroidKit.SharedPreferences {
+    // The generated binding isn't marked `throws` and doesn't have the correct optionality.
+    @JavaMethod
+    func getString(key: String, defaultValue: JavaString?) throws -> JavaString?
+}
+
+public struct SharedPreferencesAppStorageProvider: AppStorageProvider {
+    private let sharedPreferences: AndroidKit.SharedPreferences
+    private let encoder = Foundation.JSONEncoder()
+    private let decoder = Foundation.JSONDecoder()
+
+    init(activity: AndroidKit.Activity) {
+        let contextClass = try! JavaClass<AndroidKit.Context>()
+        sharedPreferences = activity.getSharedPreferences("AppStorage", contextClass.MODE_PRIVATE)!
+    }
+
+    public func persistValue<Value: Codable>(_ value: Value, forKey key: String) throws {
+        let data = try encoder.encode(value)
+        let jsonString = String(data: data, encoding: .utf8)
+
+        let editor = sharedPreferences.edit()!
+        // Some methods on Editor return the editor again, so that you can
+        // chain multiple put* or remove calls. We don't need that, and the
+        // Swift bindings aren't marked @discardableResult.
+        if let jsonString {
+            _ = editor.putString(key, jsonString)
+        } else {
+            _ = editor.remove(key)
+        }
+        editor.apply()
+    }
+
+    public func retrieveValue<Value: Codable>(
+        ofType type: Value.Type,
+        forKey key: String
+    ) -> Value? {
+        var jsonString: String
+        do {
+            guard let javaString = try sharedPreferences.getString(key: key, defaultValue: nil)
+            else {
+                return nil
+            }
+            jsonString = javaString.toString()
+        } catch {
+            log("Exception thrown by sharedPreferences.getString: \(error)")
+            return nil
+        }
+
+        guard let data = jsonString.data(using: .utf8) else { return nil }
+
+        return try? decoder.decode(type, from: data)
+    }
+}


### PR DESCRIPTION
Fixes #609

UserDefaults don't appear to work on Android, so this PR adds `SharedPreferencesAppStorageProvider` and makes it the default Android app storage provider.