### PR TITLE
Update sponsorship links to point to Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [stackotter]
+open_collective: moreSwift

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Discussion about SwiftCrossUI happens in the [moreSwift Discord server](https://
 
 ## Supporting SwiftCrossUI
 
-If you find SwiftCrossUI useful, please consider supporting its development by [becoming a sponsor](https://github.com/sponsors/stackotter). I spend most of my spare time working on open-source projects, and each sponsorship helps me focus more time on making high quality libraries and tools for the community.
+If you find SwiftCrossUI useful, please consider supporting its development by [becoming a sponsor](https://opencollective.com/moreswift). moreSwift's core contributors spend much of their spare time working on open-source projects, and each sponsorship helps us to focus more time on making high quality tools and libraries for the community.
 
 ## Documentation
 


### PR DESCRIPTION
moreSwift now has an [Open Collective](https://opencollective.com/moreswift)! This PR updates the README.md and FUNDING.yml files to point to this new sponsorship portal.