### PR TITLE
Add ActivityDelegate

### DIFF
--- a/Sources/AndroidBackend/ActivityDelegate.swift
+++ b/Sources/AndroidBackend/ActivityDelegate.swift
@@ -1,0 +1,145 @@
+import AndroidKit
+import SwiftJava
+
+/// A delegate that is notified of the activity's lifecycle changes.
+///
+/// Since it's (currently) not possible to use a custom subclass of `FragmentActivity` in
+/// SwiftCrossUI apps, this allows you to act on lifecycle events instead. All methods have default
+/// implementations that do nothing.
+///
+/// - Important: Due to the different mechanisms Jetpack provides for installing listeners, some of
+/// these methods are called within the corresponding activity methods, while others are called
+/// shortly after the corresponding activity methods.
+///
+/// Methods called during the corresponding activity method are:
+/// - ``onCreate(of:env:)``
+/// - ``onConfigurationChanged(for:to:env:)``
+/// - ``onNewIntent(for:intent:env:)``
+///
+/// Methods called after the corresponding activity method are:
+/// - ``onStart(of:env:)``
+/// - ``onResume(of:env:)``
+/// - ``onPause(of:env:)``
+/// - ``onStop(of:env:)``
+/// - ``onDestroy(of:env:)``
+public protocol ActivityDelegate {
+    func onCreate(of activity: FragmentActivity, env: JNIEnvironment?)
+    func onStart(of activity: FragmentActivity, env: JNIEnvironment?)
+    func onResume(of activity: FragmentActivity, env: JNIEnvironment?)
+    func onPause(of activity: FragmentActivity, env: JNIEnvironment?)
+    func onStop(of activity: FragmentActivity, env: JNIEnvironment?)
+    func onDestroy(of activity: FragmentActivity, env: JNIEnvironment?)
+
+    func onConfigurationChanged(
+        for activity: FragmentActivity,
+        to configuration: AndroidKit.Configuration,
+        env: JNIEnvironment?
+    )
+    func onNewIntent(
+        for activity: FragmentActivity,
+        intent: AndroidKit.Intent,
+        env: JNIEnvironment?
+    )
+}
+
+extension ActivityDelegate {
+    public func onCreate(of _: FragmentActivity, env _: JNIEnvironment?) {}
+    public func onStart(of _: FragmentActivity, env _: JNIEnvironment?) {}
+    public func onResume(of _: FragmentActivity, env _: JNIEnvironment?) {}
+    public func onPause(of _: FragmentActivity, env _: JNIEnvironment?) {}
+    public func onStop(of _: FragmentActivity, env _: JNIEnvironment?) {}
+    public func onDestroy(of _: FragmentActivity, env _: JNIEnvironment?) {}
+
+    public func onConfigurationChanged(
+        for _: FragmentActivity,
+        to _: AndroidKit.Configuration,
+        env _: JNIEnvironment?
+    ) {}
+    public func onNewIntent(
+        for _: FragmentActivity,
+        intent _: AndroidKit.Intent,
+        env _: JNIEnvironment?
+    ) {}
+}
+
+@JavaClass("dev.swiftcrossui.androidbackend.ActivityListener")
+class ActivityListener: JavaObject {
+    @JavaMethod
+    convenience init(
+        _ activity: FragmentActivity?,
+        _ delegate: SwiftObject?,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func getActivity() -> FragmentActivity!
+
+    @JavaMethod
+    func getDelegate() -> SwiftObject!
+}
+
+extension ActivityListener {
+    func getCastedDelegate() -> any ActivityDelegate {
+        getDelegate().value() as! any ActivityDelegate
+    }
+}
+
+@JavaImplementation("dev.swiftcrossui.androidbackend.ActivityListener")
+extension ActivityListener {
+    @JavaMethod
+    func onStart() {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onStart(of: getActivity(), env: AndroidBackend.env)
+        }
+    }
+
+    @JavaMethod
+    func onResume() {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onResume(of: getActivity(), env: AndroidBackend.env)
+        }
+    }
+
+    @JavaMethod
+    func onPause() {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onPause(of: getActivity(), env: AndroidBackend.env)
+        }
+    }
+
+    @JavaMethod
+    func onStop() {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onStop(of: getActivity(), env: AndroidBackend.env)
+        }
+    }
+
+    @JavaMethod
+    func onDestroy() {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onDestroy(of: getActivity(), env: AndroidBackend.env)
+        }
+    }
+
+    @JavaMethod
+    func onNewIntent(_ intent: AndroidKit.Intent?) {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onNewIntent(
+                for: getActivity(),
+                intent: intent!,
+                env: AndroidBackend.env
+            )
+        }
+    }
+
+    @JavaMethod
+    func onConfigurationChanged(_ configuration: AndroidKit.Configuration?) {
+        MainActor.assumeIsolated {
+            getCastedDelegate().onConfigurationChanged(
+                for: getActivity(),
+                to: configuration!,
+                env: AndroidBackend.env
+            )
+        }
+    }
+}

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -151,6 +151,19 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         helpers.registerActivityResults(fragmentActivity, filesCallback, folderCallback)
     }
 
+    public convenience init(delegate: any ActivityDelegate) {
+        self.init()
+
+        let delegateObject = SwiftObject(delegate, environment: Self.env)
+        let castedActivity = Self.activity.as(FragmentActivity.self)!
+
+        // ActivityListener.init connects it to the Activity, which keeps it alive without Swift
+        // needing to keep any references to it.
+        _ = ActivityListener(castedActivity, delegateObject, environment: Self.env)
+
+        delegate.onCreate(of: castedActivity, env: Self.env)
+    }
+
     public func runMainLoop(
         _ callback: @escaping @MainActor () -> Void
     ) {

--- a/Sources/AndroidBackend/Androidx.swift
+++ b/Sources/AndroidBackend/Androidx.swift
@@ -4,8 +4,11 @@ import SwiftJava
 @JavaClass("androidx.fragment.app.FragmentManager")
 class AndroidxFragmentManager: JavaObject {}
 
-@JavaClass("androidx.fragment.app.FragmentActivity")
-class FragmentActivity: JavaObject {
+@JavaClass(
+    "androidx.fragment.app.FragmentActivity",
+    extends: AndroidKit.Activity.self
+)
+open class FragmentActivity: AndroidKit.Activity {
     @JavaMethod
     func getSupportFragmentManager() -> AndroidxFragmentManager?
 }

--- a/Sources/AndroidBackend/Kotlin/ActivityListener.kt
+++ b/Sources/AndroidBackend/Kotlin/ActivityListener.kt
@@ -1,0 +1,42 @@
+package dev.swiftcrossui.androidbackend
+
+import android.content.Intent
+import android.content.res.Configuration
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+class ActivityListener(val activity: FragmentActivity, val delegate: SwiftObject) {
+    init {
+        activity.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) = this@ActivityListener.onStart()
+
+                override fun onResume(owner: LifecycleOwner) = this@ActivityListener.onResume()
+
+                override fun onPause(owner: LifecycleOwner) = this@ActivityListener.onPause()
+
+                override fun onStop(owner: LifecycleOwner) = this@ActivityListener.onStop()
+
+                override fun onDestroy(owner: LifecycleOwner) = this@ActivityListener.onDestroy()
+            }
+        )
+
+        activity.addOnNewIntentListener(::onNewIntent)
+        activity.addOnConfigurationChangedListener(::onConfigurationChanged)
+    }
+
+    external fun onStart()
+
+    external fun onResume()
+
+    external fun onPause()
+
+    external fun onStop()
+
+    external fun onDestroy()
+
+    external fun onNewIntent(intent: Intent)
+
+    external fun onConfigurationChanged(configuration: Configuration)
+}


### PR DESCRIPTION
Discussed in Discord beforehand. Motivating use-case is to allow registering custom activity launchers in `onCreate`, but I included all the other methods for completeness.