### PR TITLE
AndroidBackendShim: Fix reserved 'namespace' keyword conflict.

### DIFF
--- a/Sources/AndroidBackendShim/impl.c
+++ b/Sources/AndroidBackendShim/impl.c
@@ -1,5 +1,5 @@
 #include "header.h"
 
-void android_log(int priority, const char *namespace, const char *message) {
-    __android_log_write(priority, namespace, message);
+void android_log(int priority, const char *tag, const char *message) {
+    __android_log_write(priority, tag, message);
 }

--- a/Sources/AndroidBackendShim/include/header.h
+++ b/Sources/AndroidBackendShim/include/header.h
@@ -4,4 +4,4 @@
 // being given a handle to it.
 int main(int argc, char **argv);
 
-void android_log(int priority, const char *namespace, const char *message);
+void android_log(int priority, const char *tag, const char *message);


### PR DESCRIPTION
* When building swift projects with `.interoperabilityMode(.Cxx)` enabled, Android backends fail to compile due to Swift changing how things are imported, this should resolve that conflict.

Without this fix, we get build failures in Swift projects that enable Swift/C++ interoperability:
```sh
/Users/furby/wabi/SwiftUSD/.build/checkouts/swift-cross-ui/Sources/AndroidBackendShim/include/header.h:7:44: error: invalid parameter name: 'namespace' is a keyword
<unknown>:0: error: could not build C module 'AndroidBackendShim'
```