### PR TITLE
CxxInterop: Add 'extern' to make global G*Flag declarations valid in C/C++.

### DIFF
--- a/Sources/Gtk3CHelpers/include/gtk_helpers.h
+++ b/Sources/Gtk3CHelpers/include/gtk_helpers.h
@@ -15,9 +15,9 @@ GtkWidget *wrapped_gtk_message_dialog_new(void);
 // failing in the next (with identical code). Then when I tried recreating the
 // issue on my Mac I could, even though I successfully built Gtk/Gtk3 a few days
 // earlier... I'm perplexed, but this does at least solve the issue
-const GConnectFlags SHIM_G_CONNECT_AFTER;
-const GConnectFlags SHIM_G_CONNECT_SWAPPED;
-const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
+extern const GConnectFlags SHIM_G_CONNECT_AFTER;
+extern const GConnectFlags SHIM_G_CONNECT_SWAPPED;
+extern const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
 
 #ifdef __cplusplus
 }

--- a/Sources/GtkCHelpers/include/gtk_helpers.h
+++ b/Sources/GtkCHelpers/include/gtk_helpers.h
@@ -14,9 +14,9 @@ GtkWidget *wrapped_gtk_message_dialog_new(void);
 // failing in the next (with identical code). Then when I tried recreating the
 // issue on my Mac I could, even though I successfully built Gtk/Gtk3 a few days
 // earlier... I'm perplexed, but this does at least solve the issue
-const GConnectFlags SHIM_G_CONNECT_AFTER;
-const GConnectFlags SHIM_G_CONNECT_SWAPPED;
-const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
+extern const GConnectFlags SHIM_G_CONNECT_AFTER;
+extern const GConnectFlags SHIM_G_CONNECT_SWAPPED;
+extern const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
`const X NAME;` is a proper definition in C but illegal (requires an initializer) in C++, in the following code:
```c
const GConnectFlags SHIM_G_CONNECT_AFTER;
const GConnectFlags SHIM_G_CONNECT_SWAPPED;
const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
```

Adding `extern` makes it a valid declaration in both languages, matching the actual definitions in the .c files:
```diff
+ extern const GConnectFlags SHIM_G_CONNECT_AFTER;
+ extern const GConnectFlags SHIM_G_CONNECT_SWAPPED;
+ extern const GApplicationFlags SHIM_G_APPLICATION_HANDLES_OPEN;
```

> [!IMPORTANT]
> This will not fully provide support for Swift/C++ interop enabled projects on **macOS** with the `GtkBackend` until [this Glib issue](https://gitlab.gnome.org/GNOME/glib/-/work_items?sort=created_date&state=opened&search=appears+within+extern+%22C%22+language+linkage+specification&first_page_size=20&show=eyJpaWQiOiIzOTgwIiwiZnVsbF9wYXRoIjoiR05PTUUvZ2xpYiIsImlkIjoyNDE2MTJ9) is resolved, however this _will_ provide support for Swift/C++ interop enabled projects with the `GtkBackend` on **Linux**.


### Background
* On **Darwin**, Swift's C++ stdlib overlay modularizes the SDK at a very fine grain: `<pthread.h>`, `<sys/types.h>`, `<math.h>` etc. each get their own individual submodule (e.g. `_DarwinFoundation3.pthread`). When `-fmodules` is on and code does `#include <pthread.h>`, Clang rewrites that into an `@import` of that specific submodule _every time the header is textually included, not just the first time_.

* On **Linux**, glibc's headers are exposed as one coarse umbrella **Glibc** module (per `glibc.modulemap.gyb`), not split per header. So re-including `<pthread.h>` **does not** generate a fresh, `@import` of that specific submodule, it's either swallowed by the umbrella import already in scope, or stays a plain textual include.