### PR TITLE
"Fix" `App.backend` re-evaluation

### DIFF
--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -142,9 +142,10 @@ extension App {
     public static func main() {
         extractMetadataAndInitializeLogging()
         let app = Self()
-        let _app = _App(app)
+        let backend = app.backend
+        let _app = _App(app, backend: backend)
         _forceRefresh = {
-            app.backend.runInMainThread {
+            backend.runInMainThread {
                 _app.refreshSceneGraph()
             }
         }

--- a/Sources/SwiftCrossUI/_App.swift
+++ b/Sources/SwiftCrossUI/_App.swift
@@ -19,8 +19,8 @@ class _App<AppRoot: App> {
     var dynamicPropertyUpdater: DynamicPropertyUpdater<AppRoot>
 
     /// Wraps a user's app implementation.
-    init(_ app: AppRoot) {
-        backend = app.backend
+    init(_ app: AppRoot, backend: AppRoot.Backend) {
+        self.backend = backend
         self.app = app
         self.environment = EnvironmentValues(backend: backend)
         self.cancellables = []


### PR DESCRIPTION
Turns out this doesn't actually fix anything at all (#623 turned out to be user error), but it's a nice change to make anyway so we can actually guarantee that `App.backend` is only evaluated by SCUI once.