### PR TITLE
Add point about PR complexity to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@
 4. Add unit tests to cover your changes if your changes would benefit from tests. If it’s not obvious whether a change would benefit from unit tests, omit them and ask for clarification in your pull request description.
 5. If you are adding a new feature, consider adding an example usage of it to the examples
 6. Run `Scripts/format.sh` (requires installing [`SwiftFormat`](https://github.com/nicklockwood/SwiftFormat?tab=readme-ov-file#command-line-tool))
+7. Large pull requests (generally ones with over 1000 additions+deletions) should focus on one specific piece of work unless there is a very compelling reason that the pull request should/must tackle multiple pieces of work at once.
+   - If you're ever unsure whether a piece of work belongs in a pull request, consult the reviewer or the [Discord server](https://moreswift.dev/discord).
+   - Generally, as PRs grow in size, each new change adds another dimension of complexity for the reviewer to keep track of in their head. They then also have exponentially more interactions between changes to think about each time that the PR comes back for another review.
 
 ## 3. Finding something to do
 


### PR DESCRIPTION
This is something that I've realised recently while reviewing #590, and I figured that I should make it explicit. In the context of #590, we should've left button styles for a future PR, because the complexity of the interactions between custom button labels and the introduction of button styles is making subsequent reviews of the PR rather tricky for me. I believe that I may have said that it was ok to mix button style PR into this PR, but I can't find back the conversation any more so who knows 😅 you live and you learn