### PR TITLE
fix: disfavor ToolbarItem.frame(width:) so View.frame wins on iOS

### DIFF
--- a/Sources/UIKitBackend/KeyboardToolbar.swift
+++ b/Sources/UIKitBackend/KeyboardToolbar.swift
@@ -190,6 +190,7 @@ extension ToolbarItem {
     ///
     /// If `width` is positive, the item will have that exact width. If `width` is zero or
     /// nil, the item will have its natural size.
+    @_disfavoredOverload
     public func frame(width: Double?) -> any ToolbarItem {
         if #available(iOS 14, macCatalyst 14, *),
            self is Spacer || self is FixedWidthSpacerItem


### PR DESCRIPTION
## Summary

Adds `@_disfavoredOverload` to the `ToolbarItem.frame(width:)` overload in `Sources/UIKitBackend/KeyboardToolbar.swift` so that `.frame(width:)` on a `Spacer` or `Button` resolves to the backend-independent layout modifier instead of the keyboard-toolbar overload.

## Why this matters

On iOS, `Spacer` and `Button` conform to both `View` and `ToolbarItem`. The `ToolbarItem.frame(width:)` overload at `Sources/UIKitBackend/KeyboardToolbar.swift:193` has no defaulted arguments, so Swift's overload resolver preferred it over `View.frame(width:height:alignment:)` (`Sources/SwiftCrossUI/Views/Modifiers/Layout/FrameModifier.swift:25`) for plain `.frame(width:)` calls. Because that overload returns `any ToolbarItem`, the call failed to compile with `type 'any ToolbarItem' cannot conform to 'View'` (#626).

`@_disfavoredOverload` is the established convention for this in the repo: it is already applied to overloads in `FrameModifier.swift`. With the attribute, view receivers resolve to the layout modifier (fixing the bug), while inside a `@ToolbarBuilder` closure the result type is a `ToolbarItem`, so the toolbar overload is still selected by return-type context. The documented `Spacer().frame(width: _)` fixed-width-spacer usage in keyboard toolbars keeps working unchanged.

This is preferred over adding a new top-level `frame(width:)` overload, which the maintainer noted produced an ambiguous-overload error.

## Testing

- `swift build --target SwiftCrossUI` succeeds.
- `swiftformat --lint` passes on the changed file.
- The change is isolated to the `UIKitBackend` (iOS / macCatalyst) target; desktop and other backends are unaffected. The full iOS build is exercised by CI.

Fixes #626
