### PR TITLE
Fix sheet content resize handling (fixes #384)

### DIFF
--- a/Sources/SwiftCrossUI/Views/Modifiers/SheetModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/SheetModifier.swift
@@ -90,18 +90,37 @@ struct SheetModifier<Content: View, SheetContent: View>: TypeSafeView {
     ) {
         _ = children.childNode.commit()
 
-        if isPresented.wrappedValue && children.sheet == nil {
-            let sheetViewGraphNode = ViewGraphNode(
-                for: sheetContent(),
-                backend: backend,
-                environment: environment
-            )
-            let sheetContentNode = AnyViewGraphNode(sheetViewGraphNode)
-            children.sheetContentNode = sheetContentNode
+        if isPresented.wrappedValue {
+            let needsPresenting = children.sheet == nil
 
-            let sheet = backend.createSheet(
-                content: children.sheetContentNode!.widget.into()
-            )
+            let sheet: NewBackend.Sheet
+            if children.sheetContentNode == nil {
+                let sheetViewGraphNode = ViewGraphNode(
+                    for: sheetContent(),
+                    backend: backend,
+                    environment: environment
+                )
+                let sheetContentNode = AnyViewGraphNode(sheetViewGraphNode)
+                children.sheetContentNode = sheetContentNode
+
+                sheet = backend.createSheet(
+                    content: children.sheetContentNode!.widget.into()
+                )
+            } else {
+                guard
+                    let existingSheet = children.sheet,
+                    let castedSheet = existingSheet as? NewBackend.Sheet
+                else {
+                    logger.warning(
+                        """
+                        SheetModifier has a nil sheet, even though the sheet \
+                        has already been presented
+                        """
+                    )
+                    return
+                }
+                sheet = castedSheet
+            }
 
             let dismissAction = DismissAction(action: { [isPresented] in
                 isPresented.wrappedValue = false
@@ -139,11 +158,15 @@ struct SheetModifier<Content: View, SheetContent: View>: TypeSafeView {
             )
 
             let parentSheet = environment.sheet.map { $0 as! NewBackend.Sheet }
-            backend.presentSheet(
-                sheet,
-                window: window as! NewBackend.Window,
-                parentSheet: parentSheet
-            )
+
+            if needsPresenting {
+                backend.presentSheet(
+                    sheet,
+                    window: window as! NewBackend.Window,
+                    parentSheet: parentSheet
+                )
+            }
+
             children.sheet = sheet
             children.window = window
             children.parentSheet = parentSheet


### PR DESCRIPTION
This PR fixes the layout of sheets with dynamically sized content.

Previously, when a bottom-up update reached a sheet (due to the sheet's content changing size), the sheet would simply relayout its wrapped view (i.e. the view that the sheet modifier has been attached to), but it wouldn't relayout the sheet itself, or its content. This led to two main issues; for one, the sheet wouldn't properly resize in sync with the size of its content, and two, the sheet's content would get left halfway through an update, leading to some weird state desyncing between different visual elements. The specific symptoms depended on how caching occured and which views committed to screen during their computeLayout implementations.

The fix was to correctly relayout the sheet's content and call `backend.updateSheet` when committing with an already-presented sheet.

This PR fixes #384.