### PR TITLE
AppKitBackend: Implement window frame restoration (fixes #383)

### DIFF
--- a/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
@@ -29,7 +29,7 @@ struct Benchmarks {
         let backend = DummyBackend()
         let defaultEnvironment = EnvironmentValues(backend: backend)
         let environment = backend.computeRootEnvironment(defaultEnvironment: defaultEnvironment)
-            .with(\.window, backend.createWindow(withDefaultSize: nil))
+            .with(\.window, backend.createWindow(withDefaultSize: nil, id: "window"))
 
         @MainActor
         func makeNode<V: View>(_ view: V) -> ViewGraphNode<V, DummyBackend> {

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -103,6 +103,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
     public let defaultPaddingAmount = 10
     public let supportsMultipleWindows = false
     public let canOverrideWindowColorScheme = false
+    public let restoresWindowFrames = false
 
     static var fileDialogCallback: (([Foundation.URL]) -> Void)?
     static var folderDialogCallback: ((Foundation.URL?) -> Void)?
@@ -176,7 +177,7 @@ public final class AndroidBackend: BackendFeatures.BaseStubs {
         callback()
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
         // TODO(stackotter): Properly support multiple calls to createWindow
         return Window()
     }

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -28,6 +28,7 @@ public final class AppKitBackend: FullAppBackend {
         .radioGroup,
     ]
     public let canOverrideWindowColorScheme = true
+    public let restoresWindowFrames = true
 
     public var scrollBarWidth: Int {
         // We assume that all scrollers have their controlSize set to `.regular` by default.
@@ -61,7 +62,7 @@ public final class AppKitBackend: FullAppBackend {
         NSApplication.shared.run()
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
         // For bundled apps, the default activation policy is `regular`, but for unbundled
         // apps without an Info.plist the default is `prohibited` -- i.e. the app can't
         // create windows. We override that here.
@@ -79,11 +80,57 @@ public final class AppKitBackend: FullAppBackend {
             defer: true
         )
         window.delegate = window.customDelegate
+        window.windowController?.shouldCascadeWindows = false
 
         // NB: If this isn't set, AppKit will crash within -[NSApplication run]
         // the *second* time `openWindow` is called. I have absolutely no idea
         // why.
         window.isReleasedWhenClosed = false
+
+        // For some strange reason, AppKit is refusing to restore the window's
+        // persisted size, so for now we just fetch the persisted state ourselves
+        // to parse out the window size and manually apply it to the restored window.
+        let savedSize: SIMD2<Int>?
+        if let state = UserDefaults.standard.string(forKey: "NSWindow Frame \(id)") {
+            // Format: window.x window.y window.w window.h screen.x screen.y screen.w screen.h
+            //   E.g. "10 25 100 100 0 0 3440 1440"
+            let parts = state.split(separator: " ")
+            if parts.count == 8 {
+                let widthString = parts[2]
+                let heightString = parts[3]
+                if let width = Int(widthString), let height = Int(heightString) {
+                    savedSize = SIMD2(width, height)
+                } else {
+                    savedSize = nil
+                }
+            } else {
+                savedSize = nil
+            }
+        } else {
+            savedSize = nil
+
+            // Note that window.center doesn't actually center the window. It centers
+            // it horizontally, but its vertical location is chosen by AppKit to be
+            // "pleasing" (based off the golden ratio apparently?)
+            window.center()
+        }
+
+        _ = window.setFrameAutosaveName(id)
+
+        if let savedSize {
+            var frame = window.frame
+            frame.origin.y -= CGFloat(savedSize.y) - frame.size.height
+            frame.size = CGSize(width: savedSize.x, height: savedSize.y)
+
+            // If we set the window bigger than its target screen, then AppKit crashes,
+            // so we limit the restored window size to the size of the target screen.
+            if let screenFrame = window.screen?.visibleFrame {
+                frame.size.width = min(frame.size.width, screenFrame.size.width)
+                frame.size.height = min(frame.size.height, screenFrame.size.height)
+            }
+
+            window.setFrame(frame, display: true, animate: false)
+        }
 
         return window
     }

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -13,6 +13,7 @@ public final class DummyBackend:
         static let defaultSize = SIMD2<Int>(400, 200)
 
         public var size: SIMD2<Int>
+        public var id: String
         public var minimumSize: SIMD2<Int> = .zero
         public var maximumSize: SIMD2<Int>?
         public var title = "Window"
@@ -25,8 +26,9 @@ public final class DummyBackend:
         public var phase = ScenePhase.inactive
         public var colorScheme = ColorScheme.light
 
-        public init(defaultSize: SIMD2<Int>?) {
+        public init(defaultSize: SIMD2<Int>?, id: String) {
             size = defaultSize ?? Self.defaultSize
+            self.id = id
         }
     }
 
@@ -259,6 +261,7 @@ public final class DummyBackend:
     public var supportsMultipleWindows = true
     public var supportedPickerStyles: [BackendPickerStyle] = []
     public let canOverrideWindowColorScheme = true
+    public let restoresWindowFrames = false
 
     public var incomingURLHandler: ((URL) -> Void)?
     public var appPhase = AppPhase.active
@@ -269,8 +272,8 @@ public final class DummyBackend:
         callback()
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
-        Window(defaultSize: defaultSize)
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
+        Window(defaultSize: defaultSize, id: id)
     }
 
     public func updateWindow(_ window: Window, environment: EnvironmentValues) {

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -48,6 +48,7 @@ public final class Gtk3Backend:
     public let deviceClass = DeviceClass.desktop
     public let supportedPickerStyles: [BackendPickerStyle] = []
     public let canOverrideWindowColorScheme = false
+    public let restoresWindowFrames = false
 
     var gtkApp: Application
 
@@ -169,7 +170,7 @@ public final class Gtk3Backend:
         }
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
         let window: Gtk3.ApplicationWindow
         if let precreatedWindow {
             self.precreatedWindow = nil

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -59,6 +59,7 @@ public final class GtkBackend:
     public let supportedDatePickerStyles: [DatePickerStyle] = [.automatic, .graphical]
     public let supportedPickerStyles: [BackendPickerStyle] = [.menu]
     public let canOverrideWindowColorScheme = false
+    public let restoresWindowFrames = false
 
     var gtkApp: Application
 
@@ -167,7 +168,7 @@ public final class GtkBackend:
         }
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
         let window: Gtk.ApplicationWindow
         if let precreatedWindow {
             self.precreatedWindow = nil

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/BaseStubs.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/BaseStubs.swift
@@ -416,7 +416,11 @@ extension BackendFeatures.BaseStubs {
         todo()
     }
 
-    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window {
+    public var restoresWindowFrames: Bool {
+        todo()
+    }
+
+    public func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window {
         todo()
     }
 

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/CoreWindowing.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/CoreWindowing.swift
@@ -17,6 +17,17 @@ extension BackendFeatures {
         /// modifier as a nicer failure mode.
         var canOverrideWindowColorScheme: Bool { get }
 
+        /// Whether the backend handles restoring window frames from previous sessions.
+        ///
+        /// If `true`, the backend is expected to handle the default size by itself, and
+        /// calls to ``CoreWindowing/size(ofWindow)`` should return either the window's
+        /// default size, or its restored size.
+        ///
+        /// If `false`, then SwiftCrossUI will always use `defaultSize` as the window's
+        /// initial size, because it will presume that the backend's size restoration/defaulting
+        /// support is minimal.
+        var restoresWindowFrames: Bool { get }
+
         /// Creates a new window.
         ///
         /// For some backends it may make sense for this method to return the
@@ -26,11 +37,14 @@ extension BackendFeatures {
         /// A window's content size has precendence over the default size. The
         /// window should always be at least the size of its content.
         ///
-        /// - Parameter defaultSize: The default size of the window. This is only a
-        ///   suggestion; for example some backends may choose to restore the user's
-        ///   preferred window size from a previous session.
+        /// - Parameters:
+        ///   - defaultSize: The default size of the window. This is only a
+        ///     suggestion; for example some backends may choose to restore the user's
+        ///     preferred window size from a previous session.
+        ///   - id: A "unique" id for the window, to be used for restoring the window's
+        ///     position and size from disk if it has been opened before.
         /// - Returns: The created window.
-        func createWindow(withDefaultSize defaultSize: SIMD2<Int>?) -> Window
+        func createWindow(withDefaultSize defaultSize: SIMD2<Int>?, id: String) -> Window
 
         /// Updates a window, generally to react to the current color scheme from the
         /// environment.

--- a/Sources/SwiftCrossUI/Scenes/Window.swift
+++ b/Sources/SwiftCrossUI/Scenes/Window.swift
@@ -58,7 +58,8 @@ public final class WindowNode<Content: View>: SceneGraphNode {
                 scene: scene,
                 backend: backend,
                 environment: environment,
-                onClose: { self.windowReference = nil }
+                onClose: { self.windowReference = nil },
+                id: scene.id
             )
         }
     }
@@ -90,7 +91,8 @@ public final class WindowNode<Content: View>: SceneGraphNode {
                     scene: scene,
                     backend: backend,
                     environment: environment,
-                    onClose: { self.windowReference = nil }
+                    onClose: { self.windowReference = nil },
+                    id: scene.id
                 )
                 windowReference = reference
 

--- a/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowGroup.swift
@@ -64,10 +64,17 @@ public final class WindowGroupNode<Content: View>: SceneGraphNode {
                     scene: scene,
                     backend: backend,
                     environment: environment,
-                    onClose: { self.windowReferences[windowID] = nil }
+                    onClose: { self.windowReferences[windowID] = nil },
+                    id: nextId()
                 )
             ]
         }
+    }
+
+    private func nextId() -> String {
+        // Vaguely based off the research covered by https://github.com/pd95/SwiftUI-macos-HandleWindow
+        let baseId = scene.id ?? String(describing: Content.self)
+        return "\(baseId)-\(windowReferences.count)"
     }
 
     public func updateNode(
@@ -94,7 +101,8 @@ public final class WindowGroupNode<Content: View>: SceneGraphNode {
                     scene: scene,
                     backend: backend,
                     environment: environment,
-                    onClose: { self.windowReferences[windowID] = nil }
+                    onClose: { self.windowReferences[windowID] = nil },
+                    id: nextId()
                 )
                 windowReferences[windowID] = reference
 

--- a/Sources/SwiftCrossUI/Scenes/WindowReference.swift
+++ b/Sources/SwiftCrossUI/Scenes/WindowReference.swift
@@ -21,14 +21,19 @@ final class WindowReference<SceneType: WindowingScene> {
     /// - Parameters:
     ///   - closeHandler: The action to perform when the window is closed. Should
     ///     dispose of the scene's reference to this `WindowReference`.
+    ///   - id: A unique id to use when restoring the window's frame from disk (if present).
     init<Backend: BaseAppBackend>(
         scene: SceneType,
         backend: Backend,
         environment: EnvironmentValues,
-        onClose closeHandler: @escaping @Sendable @MainActor () -> Void
+        onClose closeHandler: @escaping @Sendable @MainActor () -> Void,
+        id: String
     ) {
         self.scene = scene
-        let window = backend.createWindow(withDefaultSize: environment.defaultWindowSize)
+        let window = backend.createWindow(
+            withDefaultSize: environment.defaultWindowSize,
+            id: id
+        )
 
         viewGraph = ViewGraph(
             for: scene.content(),
@@ -93,7 +98,7 @@ final class WindowReference<SceneType: WindowingScene> {
 
         let proposedWindowSize: SIMD2<Int>
         let usedDefaultSize: Bool
-        if isFirstUpdate && isProgramaticallyResizable {
+        if isFirstUpdate && isProgramaticallyResizable && !backend.restoresWindowFrames {
             proposedWindowSize = environment.defaultWindowSize
             usedDefaultSize = true
         } else {

--- a/Sources/UIKitBackend/UIKitBackend+Window.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Window.swift
@@ -67,7 +67,7 @@ final class RootViewController: UIViewController {
 extension UIKitBackend: BackendFeatures.WindowBehaviors {
     public typealias Window = UIWindow
 
-    public func createWindow(withDefaultSize _: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize _: SIMD2<Int>?, id: String) -> Window {
         let window: UIWindow
 
         if !Self.hasReturnedAWindow {

--- a/Sources/UIKitBackend/UIKitBackend.swift
+++ b/Sources/UIKitBackend/UIKitBackend.swift
@@ -37,6 +37,7 @@ public final class UIKitBackend:
 
     public let supportsMultipleWindows = false
     public let canOverrideWindowColorScheme = true
+    public let restoresWindowFrames = false
 
     public var deviceClass: DeviceClass {
         switch UIDevice.current.userInterfaceIdiom {

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -97,6 +97,7 @@ public final class WinUIBackend:
     ]
     public let supportedPickerStyles: [BackendPickerStyle] = [.menu, .radioGroup]
     public let canOverrideWindowColorScheme = true
+    public let restoresWindowFrames = false
 
     public var scrollBarWidth: Int {
         12
@@ -184,7 +185,7 @@ public final class WinUIBackend:
         WinUIApplication.main()
     }
 
-    public func createWindow(withDefaultSize size: SIMD2<Int>?) -> Window {
+    public func createWindow(withDefaultSize size: SIMD2<Int>?, id: String) -> Window {
         let window = CustomWindow()
         windows.append(window)
         window.closed.addHandler { _, _ in

--- a/Tests/Gtk3BackendTests/LayoutTests.swift
+++ b/Tests/Gtk3BackendTests/LayoutTests.swift
@@ -22,7 +22,7 @@ struct LayoutTests {
     func reproduce464() {
         let backend = Gtk3Backend()
         backend.runMainLoop {
-            let window = backend.createWindow(withDefaultSize: nil)
+            let window = backend.createWindow(withDefaultSize: nil, id: "window")
             let environment = EnvironmentValues(backend: backend).with(\.window, window)
 
             @MainActor

--- a/Tests/SwiftCrossUITests/ForEachTests.swift
+++ b/Tests/SwiftCrossUITests/ForEachTests.swift
@@ -9,7 +9,7 @@ struct ForEachTests {
     @Test("Duplicate ids", .bug("https://github.com/moreSwift/swift-cross-ui/issues/456"))
     func duplicateIds() {
         let backend = DummyBackend()
-        let window = backend.createWindow(withDefaultSize: nil)
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
 
         let view = ForEach([1, 1], id: \.self) { x in
@@ -38,7 +38,7 @@ struct ForEachTests {
     @Test("Reordered children")
     func reorderedChildren() {
         let backend = DummyBackend()
-        let window = backend.createWindow(withDefaultSize: nil)
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
 
         func makeView(_ ids: [Int]) -> ForEach<[Int], Int, TupleView1<Text>> {

--- a/Tests/SwiftCrossUITests/StackLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/StackLayoutTests.swift
@@ -12,7 +12,7 @@ struct StackLayoutTests {
     @MainActor
     init() {
         backend = DummyBackend()
-        window = backend.createWindow(withDefaultSize: nil)
+        window = backend.createWindow(withDefaultSize: nil, id: "window")
         environment = EnvironmentValues(backend: backend).with(\.window, window)
     }
 

--- a/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
+++ b/Tests/SwiftCrossUITests/SwiftCrossUITests.swift
@@ -83,7 +83,7 @@ struct SwiftCrossUITests {
     @MainActor
     func testBasicScrollView() async throws {
         let backend = DummyBackend()
-        let window = backend.createWindow(withDefaultSize: nil)
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend)
             .with(\.window, window)
 
@@ -170,7 +170,7 @@ struct SwiftCrossUITests {
         @MainActor
         func testBasicLayout() async throws {
             let backend = AppKitBackend()
-            let window = backend.createWindow(withDefaultSize: SIMD2(200, 200))
+            let window = backend.createWindow(withDefaultSize: SIMD2(200, 200), id: "window")
 
             // Idea taken from https://github.com/pointfreeco/swift-snapshot-testing/pull/533
             // and implemented in AppKitBackend.


### PR DESCRIPTION
This PR resolves #383 by implementing window frame restoration within AppKitBackend, and updating the CoreWindowing API as required to implement those changes.

Windows now appear 'centred' on first launch. We use `NSWindow.center()` to centre windows, so they get centred horizontally, but not vertically. AppKit places windows at a vertical position designed to look "pleasing". On the other hand, SwiftUI places windows at the exact centre of the screen. If people get annoyed by AppKit's behaviour then we may want to change our implementation in future, but for now I think it's reasonable, and a big improvement over the old behaviour which saw windows opening at the bottom left of the screen every time.

Additionally, windows get their position saved to and restored from user defaults (using AppKit's frame autosave system). The tricky part for saving/restoring window frames is assigning a consistent identity to windows. Windows created by `Window` scenes just use the scene's `id` (which gets supplied by the developer).

Windows created by `WindowGroup` scenes use the scene's `id` (if available) and append the window's index to the id to make it unique across windows corresponding to the same window group. This isn't ideal, but it appears to be similar to what SwiftUI does.

When a `WindowGroup` doesn't have an `id`, the string description of its content type is used instead. This isn't ideal either, but also appears to be similar to what SwiftUI does. Ideally, we would use the structure of the app's scenes to supplement the content type's description with an index representing what order the `WindowGroup` was defined in compared to all other `WindowGroup`s with the same content type, but I think our current approach is reasonable for now.

In cases where a window's saved size was from when the window was on a larger screen than its current one, we take care to clamp the window's saved size to the size of the current screen. Otherwise AppKit crashes.