### PR TITLE
AppKitBackend: Fix List item selection in macOS 26 (fixes #276)

### DIFF
--- a/Examples/Sources/NotesExample/ContentView.swift
+++ b/Examples/Sources/NotesExample/ContentView.swift
@@ -31,6 +31,10 @@ struct Note: Codable, Equatable, Identifiable {
     }
 }
 
+extension AppStorageValues {
+    @Entry var previewLines = 1
+}
+
 struct ContentView: View {
     let notesFile = URL(fileURLWithPath: "notes.json")
 
@@ -45,6 +49,8 @@ struct ContentView: View {
     @State var selectedNoteId: UUID?
 
     @State var error: String?
+
+    @AppStorage(\.previewLines) var previewLines
 
     var selectedNote: Binding<Note>? {
         guard let id = selectedNoteId else {
@@ -77,23 +83,33 @@ struct ContentView: View {
                     List(notes, selection: $selectedNoteId) { note in
                         VStack(alignment: .leading, spacing: 0) {
                             Text(note.title.isEmpty ? "Untitled" : note.title)
-                            Text(note.truncatedDescription)
+                            Text(note.content)
                                 .foregroundColor(.gray)
                                 .font(.system(size: 12))
+                                .lineLimit(previewLines)
                         }
                     }
-                    .padding(10)
+                    .padding()
                 }
                 if let error = error {
                     Text(error)
                         .foregroundColor(.red)
                 }
-                Button("New note") {
-                    let note = Note(title: "", content: "")
-                    notes.append(note)
-                    selectedNoteId = note.id
+
+                VStack {
+                    Button("New note") {
+                        let note = Note(title: "", content: "")
+                        notes.append(note)
+                        selectedNoteId = note.id
+                    }
+                    Divider()
+
+                    VStack(alignment: .leading) {
+                        Text("Max preview lines: \(previewLines)")
+                        Slider(value: $previewLines, in: 1...4)
+                    }.padding([.leading, .trailing])
                 }
-                .padding(10)
+                .padding([.top, .bottom])
             }
             .onChange(of: notes) {
                 do {
@@ -126,6 +142,21 @@ struct ContentView: View {
                             HStack(spacing: 4) {
                                 Text("Title")
                                 TextField("Title", text: selectedNote.title)
+
+                                Button("Delete note") {
+                                    guard
+                                        let index = notes.firstIndex(of: selectedNote.wrappedValue)
+                                    else {
+                                        return
+                                    }
+                                    notes.remove(at: index)
+                                    if notes.count == 0 {
+                                        selectedNoteId = nil
+                                    } else {
+                                        let newIndex = max(index - 1, 0)
+                                        selectedNoteId = notes[newIndex].id
+                                    }
+                                }
                             }
 
                             TextEditor(text: selectedNote.content)
@@ -141,7 +172,7 @@ struct ContentView: View {
                         }
                     }
                     .padding()
-                    .frame(minHeight: Int(proxy.size.height))
+                    .frame(minHeight: proxy.size.height)
                 }
             }
         }

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -967,11 +967,49 @@ public final class AppKitBackend: FullAppBackend {
         to items: [Widget],
         withRowHeights rowHeights: [Int]
     ) {
-        let listView = (listView as! NSScrollView).documentView! as! NSCustomTableView
-        listView.customDelegate.rowCount = items.count
-        listView.customDelegate.widgets = items
-        listView.customDelegate.rowHeights = rowHeights
-        listView.reloadData()
+        // NOTE: This implementation works under the assumption that items that
+        //   share an index in the new `items` and the previous `items` also
+        //   share a widget. This assumption lets us conclude that the only new
+        //   widgets are those added to the end of the list when the row count
+        //   increases, and the only widgets removed are those removed from the
+        //   end of the list when the row count decreases. These assumptions
+        //   allow us to avoid calling reloadData, which is too heavy handed for
+        //   what we want to do. reloadData also clobbers the selected row index,
+        //   and workarounds that I tried didn't appear to have any effect.
+        //
+        //   I believe that the assumption is technically possible to break if
+        //   a list view's data source changes state multiple times within a
+        //   single view layout cycle, but we can deal with that when we get to it.
+        //
+        //   Eventually once List supports identity, we'll want to update the
+        //   SelectableListViews API to provide a list of row operations instead
+        //   of an entirely new array of widgets every time, which should allow us
+        //   to resolve any worries that arise from the assumptions that we
+        //   currently have to make.
+
+        let table = (listView as! NSScrollView).documentView! as! NSCustomTableView
+
+        let previousRowCount = table.customDelegate.rowCount
+        let previousRowHeights = table.customDelegate.rowHeights
+        table.customDelegate.rowCount = items.count
+        table.customDelegate.widgets = items
+        table.customDelegate.rowHeights = rowHeights
+
+        if rowHeights != previousRowHeights {
+            // Use an animation group to disable the default animation for row
+            // height changes
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+
+                table.noteHeightOfRows(
+                    withIndexesChanged: IndexSet(0..<min(previousRowCount, items.count))
+                )
+            }
+        }
+
+        if items.count != previousRowCount {
+            table.noteNumberOfRowsChanged()
+        }
     }
 
     public func setSelectionHandler(
@@ -984,7 +1022,18 @@ public final class AppKitBackend: FullAppBackend {
 
     public func setSelectedItem(ofSelectableListView listView: Widget, toItemAt index: Int?) {
         let listView = (listView as! NSScrollView).documentView! as! NSCustomTableView
-        listView.selectRowIndexes(IndexSet([index].compactMap { $0 }), byExtendingSelection: false)
+
+        // We want to process row selections asynchronously, because previous calls to
+        // data reloading related NSTableView methods generally don't take effect
+        // immediately, and they often clear the selected row. Putting this in an async
+        // block appears to resolve some unselection issues we were facing that were
+        // caused by setItems(ofSelectableListView:to:withRowHeights:)
+        DispatchQueue.main.async {
+            listView.selectRowIndexes(
+                IndexSet([index].compactMap { $0 }),
+                byExtendingSelection: false
+            )
+        }
     }
 
     public func createSplitView(leadingChild: Widget, trailingChild: Widget) -> Widget {

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Containers/SelectableListViews.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Containers/SelectableListViews.swift
@@ -42,6 +42,13 @@ extension BackendFeatures {
         /// Row heights should include base item padding (i.e. they should be the
         /// external height of the row rather than the internal height).
         ///
+        /// Implementations may assume that if the row count hasn't changed, the
+        /// `items` array hasn't either. And furthermore, if the row count has
+        /// increased, then the only new widgets are the widgets appended to the
+        /// end of the previous items array to reach the new item count. Likewise,
+        /// if the row count has decreased, then the `items` array will simply have
+        /// been truncated to the new length.
+        ///
         /// - Parameters:
         ///   - listView: The list view.
         ///   - items: An array of widgets to add to `listView`.

--- a/Sources/SwiftCrossUI/Views/List.swift
+++ b/Sources/SwiftCrossUI/Views/List.swift
@@ -265,8 +265,8 @@ public struct List<SelectionValue: Hashable, RowView: View>: TypeSafeView, View 
             selectedIndex = nil
         }
 
-        backend.setSelectedItem(ofSelectableListView: widget, toItemAt: selectedIndex)
         backend.updateSelectableListView(widget, environment: environment)
+        backend.setSelectedItem(ofSelectableListView: widget, toItemAt: selectedIndex)
     }
 }
 


### PR DESCRIPTION
This PR resolves #276. It also updates NotesExample to exercise more of our List-view updating code to ensure that everything is working properly with our new, slightly more surgical, NSTableView updating code.

The essence of the issue was that `reloadData` clears the current selection, and it doesn't necessarily do so immediately. SwiftCrossUI always sets the selected index after updating a List's items, but due to AppKit's delayed processing of `NSTableView.reloadData`, our selection code runs too early and gets clobbered by `reloadData` once AppKit processes it.