### PR TITLE
GtkBackend: Fix List item selection flicker (fixes #391)

### DIFF
--- a/Sources/Gtk/Widgets/ListBox+ManualAdditions.swift
+++ b/Sources/Gtk/Widgets/ListBox+ManualAdditions.swift
@@ -8,7 +8,8 @@ extension ListBox {
 
     /// Removes all rows in the list box.
     public func removeAll() {
-        gtk_list_box_remove_all(opaquePointer)
+        // gtk_list_box_remove_all was introduced in 4.12 (too late for us)
+        while removeRow(at: 0) {}
     }
 
     /// Removes the row at the given index.

--- a/Sources/Gtk/Widgets/ListBox+ManualAdditions.swift
+++ b/Sources/Gtk/Widgets/ListBox+ManualAdditions.swift
@@ -1,15 +1,28 @@
 import CGtk
 
 extension ListBox {
+    /// Appends a widget to the end of the list box.
     public func append(_ child: Widget) {
         gtk_list_box_append(opaquePointer, child.widgetPointer)
     }
 
+    /// Removes all rows in the list box.
     public func removeAll() {
-        while let row = gtk_list_box_get_row_at_index(opaquePointer, 0) {
-            gtk_list_box_row_set_child(row, nil)
-            gtk_list_box_remove(opaquePointer, row.cast())
+        gtk_list_box_remove_all(opaquePointer)
+    }
+
+    /// Removes the row at the given index.
+    /// - Returns: `false` if the index is out of bounds, and `true` otherwise
+    ///   (indicating that a row was removed).
+    @discardableResult
+    public func removeRow(at index: Int) -> Bool {
+        guard let row = gtk_list_box_get_row_at_index(opaquePointer, gint(index)) else {
+            return false
         }
+
+        gtk_list_box_row_set_child(row, nil)
+        gtk_list_box_remove(opaquePointer, row.cast())
+        return true
     }
 
     /// Returns `true` on success.

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -724,10 +724,26 @@ public final class GtkBackend:
         to items: [Widget],
         withRowHeights rowHeights: [Int]
     ) {
+        // NOTE: This implementation works under the same assumptions as
+        //   AppKitBackend's implementation. Read the comment in
+        //   AppKitBackend.setItems for more details. In short, we assume
+        //   that modifications made to `items` between `setItems` calls
+        //   are either all pops, or all appends (not a mix).
+
         let listView = listView as! CustomListBox
-        listView.removeAll()
-        for item in items {
-            listView.append(item)
+
+        let previousRowCount = listView.cachedRowCount
+        listView.cachedRowCount = items.count
+
+        if items.count > previousRowCount {
+            for item in items[previousRowCount...] {
+                print("Appending item")
+                listView.append(item)
+            }
+        } else if items.count < previousRowCount {
+            for _ in 0..<(previousRowCount - items.count) {
+                listView.removeRow(at: items.count)
+            }
         }
     }
 
@@ -750,15 +766,13 @@ public final class GtkBackend:
     }
 
     public func setSelectedItem(ofSelectableListView listView: Widget, toItemAt index: Int?) {
-        let listView = listView as! ListBox
-        let handler = listView.rowSelected
-        listView.rowSelected = nil
+        let listView = listView as! CustomListBox
+        listView.cachedSelection = index
         if let index {
             listView.selectRow(at: index)
         } else {
             listView.unselectAll()
         }
-        listView.rowSelected = handler
     }
 
     public func createTooltipContainer(wrapping child: Widget) -> Widget {
@@ -814,7 +828,7 @@ public final class GtkBackend:
         let ellipsize: EllipsizeMode
         if let widget = widget as? CustomLabel {
             ellipsize = widget.ellipsize
-        } else if let widget = widget as? TextView {
+        } else if widget as? TextView != nil {
             // We don't ellipsize multi-line text editors
             ellipsize = .none
         } else {
@@ -2026,6 +2040,7 @@ extension UnsafeMutablePointer {
 
 class CustomListBox: ListBox {
     var cachedSelection: Int? = nil
+    var cachedRowCount = 0
 }
 
 /// A custom label subclass that supports ellipsizing multi-line text. Regular

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -737,7 +737,6 @@ public final class GtkBackend:
 
         if items.count > previousRowCount {
             for item in items[previousRowCount...] {
-                print("Appending item")
                 listView.append(item)
             }
         } else if items.count < previousRowCount {


### PR DESCRIPTION
This PR fixes #391. The underlying issue was similar to that of #276, but both issues had separate solutions because they were both in the underlying backend implementations rather than the shared SwiftCrossUI `List` view implementation.

I've used the same assumption as in #653 while addressing the underlying the backend issue.

I also cleaned up GtkBackend's row selection handler suppression so that we don't occasionally suppress legitimate row selections as we were before this PR. Sometimes when a list view was programmatically updated, GtkBackend's `cachedSelection` would get out of sync with the actual selection. Now we just pre-emptively update the `cachedSelection` when programmatically setting the selected index, and we never remove the handler.