### PR TITLE
Android date pickers

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/FlyingFox",
       "state" : {
-        "revision" : "de38230104cf63ef4843cb569ba11c13f8165685",
-        "version" : "0.26.2"
+        "revision" : "d06fd45653bcab9803af31d66440f552c9dd9c93",
+        "version" : "0.27.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates",
       "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
       }
     },
     {
@@ -275,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
-        "version" : "2.101.0"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {
@@ -347,8 +347,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
-        "version" : "1.6.5"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {
@@ -392,8 +392,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/TOMLKit",
       "state" : {
-        "revision" : "fc32cb1b94aa2f8721c1585341ef723a0b4a6ab8",
-        "version" : "0.7.0"
+        "revision" : "6206c73fc5adb16b0f75665a1c5fcf1f7da4be1b",
+        "version" : "0.7.1"
       }
     },
     {

--- a/Examples/Sources/ControlsExample/ControlsApp.swift
+++ b/Examples/Sources/ControlsExample/ControlsApp.swift
@@ -162,7 +162,7 @@ struct ControlsApp: App {
                                 Text("You chose: \(flavor ?? "Nothing yet!")")
                             }
 
-                            #if !os(tvOS) && !canImport(AndroidBackend)
+                            #if !os(tvOS)
                                 VStack {
                                     Text("Selected date: \(date)")
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a9dfa341acb293bdcb1f600fefe94ce02ae96b209d8daf249f85f203568d1a05",
+  "originHash" : "e1d47171a0f09d7abb802e04c331d0a0a5062a8b24a023170a5295c7a5107321",
   "pins" : [
     {
       "identity" : "androidkit",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
-        "version" : "1.6.5"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -402,6 +402,7 @@ if androidBackendSupported {
             dependencies: [
                 "SwiftCrossUI",
                 "AndroidBackendShim",
+                .product(name: "Mutex", package: "swift-mutex"),
 
                 // These two dependencies have to be marked as only included on Android
                 // (even though this target is only used on Android) because SwiftPM requires

--- a/Sources/AndroidBackend/AndroidBackend+DatePickers.swift
+++ b/Sources/AndroidBackend/AndroidBackend+DatePickers.swift
@@ -1,0 +1,126 @@
+import SwiftCrossUI
+import AndroidKit
+import SwiftJava
+import Foundation
+import JavaTime
+
+// swiftlint:disable force_try
+extension AndroidBackend: BackendFeatures.DatePickers {
+    public func createDatePicker() -> Widget {
+        AndroidKit.FrameLayout(Self.activity, environment: Self.env)
+    }
+
+    private static func getLocalDateTime(
+        date: Foundation.Date,
+        timeZone: Foundation.TimeZone
+    ) -> LocalDateTime {
+        var calendar = Foundation.Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        let components = calendar.dateComponents(
+            [.era, .year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+
+        // era 0 = BC, 1 = AD
+        let year = Int32(components.era == 0 ? 1 - components.year! : components.year!)
+
+        return try! JavaClass<LocalDateTime>().of(
+            year,
+            Int32(components.month!),
+            Int32(components.day!),
+            Int32(components.hour!),
+            Int32(components.minute!),
+            Int32(components.second!)
+        )!
+    }
+
+    private static func getFoundationDate(
+        localDateTime: LocalDateTime,
+        timeZone: Foundation.TimeZone
+    ) -> Foundation.Date {
+        var calendar = Foundation.Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        let year = localDateTime.getYear()
+
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: timeZone,
+            era: year <= 0 ? 0 : 1,
+            year: Int(year <= 0 ? 1 - year : year),
+            month: Int(localDateTime.getMonthValue()),
+            day: Int(localDateTime.getDayOfMonth()),
+            hour: Int(localDateTime.getHour()),
+            minute: Int(localDateTime.getMinute()),
+            second: Int(localDateTime.getSecond())
+        )
+
+        return calendar.date(from: components)!
+    }
+
+    public func updateDatePicker(
+        _ datePicker: Widget,
+        environment: EnvironmentValues,
+        date: Foundation.Date,
+        range: ClosedRange<Foundation.Date>,
+        components: DatePickerComponents,
+        onChange: @escaping (Foundation.Date) -> Void
+    ) {
+        let frame = datePicker.as(AndroidKit.FrameLayout.self)!
+        var datePicker = frame.getChildAt(0)?.as(AbstractDatePicker.self)
+
+        switch environment.datePickerStyle {
+            case .automatic, .compact:
+                var compactDatePicker = datePicker?.as(CompactDatePicker.self)
+
+                if compactDatePicker == nil {
+                    frame.removeAllViews()
+                    compactDatePicker = CompactDatePicker(
+                        Self.activity.as(FragmentActivity.self)!,
+                        environment: Self.env
+                    )
+                    datePicker = compactDatePicker
+                    frame.addView(compactDatePicker!)
+                }
+
+                compactDatePicker!
+                    .setForegroundColor(
+                        environment.suggestedForegroundColor.resolve(in: environment).asColorInt()
+                    )
+            case .graphical:
+                if datePicker?.is(GraphicalDatePicker.self) != true {
+                    frame.removeAllViews()
+                    datePicker = GraphicalDatePicker(
+                        Self.activity,
+                        environment: Self.env
+                    )
+                    frame.addView(datePicker!)
+                }
+            case .wheel:
+                // TODO(bbrk24): Once swift-bundler supports XML resources in libraries, implement
+                //   the wheel style
+                fatalError("The .wheel style is not currently supported on Android")
+        }
+
+        guard let datePicker else {
+            preconditionFailure("datePicker must be set by switch above, but was not")
+        }
+
+        datePicker.setComponents(Int32(components.rawValue))
+        datePicker.setRange(
+            min: Self.getLocalDateTime(date: range.lowerBound, timeZone: environment.timeZone),
+            max: Self.getLocalDateTime(date: range.upperBound, timeZone: environment.timeZone)
+        )
+        datePicker.setValue(Self.getLocalDateTime(date: date, timeZone: environment.timeZone))
+        datePicker.setEnabled(environment.isEnabled)
+
+        datePicker.setAction(SwiftAction(environment: Self.env) {
+            let date = Self.getFoundationDate(
+                localDateTime: datePicker.getValue()!,
+                timeZone: environment.timeZone
+            )
+            onChange(date)
+        })
+    }
+}

--- a/Sources/AndroidBackend/AndroidBackend+DatePickers.swift
+++ b/Sources/AndroidBackend/AndroidBackend+DatePickers.swift
@@ -7,6 +7,8 @@ import JavaTime
 // swiftlint:disable force_try
 extension AndroidBackend: BackendFeatures.DatePickers {
     public func createDatePicker() -> Widget {
+        // TODO(bbrk24): Once DatePickerStyle is more like PickerStyle, the FrameLayout wrapper will
+        //   be unnecessary
         AndroidKit.FrameLayout(Self.activity, environment: Self.env)
     }
 

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -4,6 +4,7 @@ import SwiftCrossUI
 import AndroidKit
 import AndroidGraphics
 import AndroidBackendShim
+import Mutex
 
 // Many force tries are required for the Android backend but we don't really want them
 // anywhere else so just disable the lint rule at a file level.
@@ -88,15 +89,10 @@ public final class AndroidBackend: BaseAppBackend {
     static let stdoutPipe = Pipe()
     static let stderrPipe = Pipe()
 
-    // Thread-safety note: `_supportedDatePickerStyles` is only set in `computeRootEnvironment`;
-    // `supportedDatePickerStyles` must be `nonisolated` to satisfy the DatePickers protocol.
-    private nonisolated(unsafe) var _supportedDatePickerStyles: [DatePickerStyle] = [
-        .automatic,
-        .compact
-    ]
+    private let _supportedDatePickerStyles = Mutex<[DatePickerStyle]>([.automatic, .compact])
 
     public nonisolated var supportedDatePickerStyles: [DatePickerStyle] {
-        _supportedDatePickerStyles
+        _supportedDatePickerStyles.withLock { copy $0 }
     }
 
     // .phone is a placeholder value -- the real value is set in `computeRootEnvironment`.
@@ -321,24 +317,26 @@ public final class AndroidBackend: BaseAppBackend {
         // ~350dp wide each, so when stacked next to each other they don't fit on all tablets, and
         // even just one of them doesn't fit by itself on some phones. Watch renders them a bit
         // smaller so they almost fit, but again they don't both fit at the same time.
-        switch helpers.getDeviceClass(Self.activity) {
-            case 0:
-                deviceClass = .desktop
-                _supportedDatePickerStyles = [.automatic, .compact, .graphical]
-            case 1:
-                deviceClass = .phone
-                _supportedDatePickerStyles = [.automatic, .compact]
-            case 2:
-                deviceClass = .tablet
-                _supportedDatePickerStyles = [.automatic, .compact]
-            case 3:
-                deviceClass = .tv
-                _supportedDatePickerStyles = [.automatic, .compact, .graphical]
-            case 4:
-                deviceClass = .watch
-                _supportedDatePickerStyles = [.automatic, .compact]
-            case let x:
-                fatalError("helpers.getDeviceClass returned unexpected value \(x)")
+        _supportedDatePickerStyles.withLock { supportedDatePickerStyles in
+            switch helpers.getDeviceClass(Self.activity) {
+                case 0:
+                    deviceClass = .desktop
+                    supportedDatePickerStyles = [.automatic, .compact, .graphical]
+                case 1:
+                    deviceClass = .phone
+                    supportedDatePickerStyles = [.automatic, .compact]
+                case 2:
+                    deviceClass = .tablet
+                    supportedDatePickerStyles = [.automatic, .compact]
+                case 3:
+                    deviceClass = .tv
+                    supportedDatePickerStyles = [.automatic, .compact, .graphical]
+                case 4:
+                    deviceClass = .watch
+                    supportedDatePickerStyles = [.automatic, .compact]
+                case let x:
+                    fatalError("helpers.getDeviceClass returned unexpected value \(x)")
+            }
         }
 
         return environment

--- a/Sources/AndroidBackend/AndroidBackend.swift
+++ b/Sources/AndroidBackend/AndroidBackend.swift
@@ -88,15 +88,19 @@ public final class AndroidBackend: BaseAppBackend {
     static let stdoutPipe = Pipe()
     static let stderrPipe = Pipe()
 
-    public lazy var deviceClass: DeviceClass =
-        switch helpers.getDeviceClass(Self.activity) {
-            case 0: .desktop
-            case 1: .phone
-            case 2: .tablet
-            case 3: .tv
-            case 4: .watch
-            case let x: fatalError("helpers.getDeviceClass returned unexpected value \(x)")
-        }
+    // Thread-safety note: `_supportedDatePickerStyles` is only set in `computeRootEnvironment`;
+    // `supportedDatePickerStyles` must be `nonisolated` to satisfy the DatePickers protocol.
+    private nonisolated(unsafe) var _supportedDatePickerStyles: [DatePickerStyle] = [
+        .automatic,
+        .compact
+    ]
+
+    public nonisolated var supportedDatePickerStyles: [DatePickerStyle] {
+        _supportedDatePickerStyles
+    }
+
+    // .phone is a placeholder value -- the real value is set in `computeRootEnvironment`.
+    public private(set) var deviceClass = DeviceClass.phone
 
     public let defaultPaddingAmount = 10
     public let supportsMultipleWindows = false
@@ -312,6 +316,30 @@ public final class AndroidBackend: BaseAppBackend {
 
         environment
             .appStorageProvider = SharedPreferencesAppStorageProvider(activity: Self.activity)
+
+        // The graphical DatePicker style is ginormous -- the clock and calendar individually are
+        // ~350dp wide each, so when stacked next to each other they don't fit on all tablets, and
+        // even just one of them doesn't fit by itself on some phones. Watch renders them a bit
+        // smaller so they almost fit, but again they don't both fit at the same time.
+        switch helpers.getDeviceClass(Self.activity) {
+            case 0:
+                deviceClass = .desktop
+                _supportedDatePickerStyles = [.automatic, .compact, .graphical]
+            case 1:
+                deviceClass = .phone
+                _supportedDatePickerStyles = [.automatic, .compact]
+            case 2:
+                deviceClass = .tablet
+                _supportedDatePickerStyles = [.automatic, .compact]
+            case 3:
+                deviceClass = .tv
+                _supportedDatePickerStyles = [.automatic, .compact, .graphical]
+            case 4:
+                deviceClass = .watch
+                _supportedDatePickerStyles = [.automatic, .compact]
+            case let x:
+                fatalError("helpers.getDeviceClass returned unexpected value \(x)")
+        }
 
         return environment
     }

--- a/Sources/AndroidBackend/DatePickers.swift
+++ b/Sources/AndroidBackend/DatePickers.swift
@@ -1,0 +1,51 @@
+import AndroidKit
+import SwiftJava
+import JavaTime
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.datepickers.AbstractDatePicker",
+    extends: AndroidKit.LinearLayout.self
+)
+class AbstractDatePicker: AndroidKit.LinearLayout {
+    @JavaMethod
+    func setAction(_ action: SwiftAction?)
+
+    @JavaMethod
+    func getValue() -> LocalDateTime!
+
+    @JavaMethod
+    func setValue(_ newValue: LocalDateTime!)
+
+    @JavaMethod
+    func setRange(min: LocalDateTime!, max: LocalDateTime!)
+
+    @JavaMethod
+    func setComponents(_ components: Int32)
+}
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.datepickers.CompactDatePicker",
+    extends: AbstractDatePicker.self
+)
+class CompactDatePicker: AbstractDatePicker {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ activity: FragmentActivity!,
+        environment: JNIEnvironment? = nil
+    )
+
+    @JavaMethod
+    func setForegroundColor(_ color: Int32)
+}
+
+@JavaClass(
+    "dev.swiftcrossui.androidbackend.datepickers.GraphicalDatePicker",
+    extends: AbstractDatePicker.self
+)
+class GraphicalDatePicker: AbstractDatePicker {
+    @JavaMethod
+    @_nonoverride convenience init(
+        _ context: AndroidKit.Context!,
+        environment: JNIEnvironment? = nil
+    )
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/AbstractDatePicker.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/AbstractDatePicker.kt
@@ -1,0 +1,59 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import android.content.Context
+import android.view.View
+import android.widget.LinearLayout
+import dev.swiftcrossui.androidbackend.SwiftAction
+import java.time.LocalDateTime
+
+abstract class AbstractDatePicker(context: Context) : LinearLayout(context) {
+    companion object {
+        const val COMPONENT_DATE = 0x1C
+        const val COMPONENT_HOUR_MINUTE = 0x60
+        const val COMPONENT_SECOND = 0x80
+        const val COMPONENT_TIME = COMPONENT_HOUR_MINUTE or COMPONENT_SECOND
+        const val COMPONENT_MASK = COMPONENT_DATE or COMPONENT_HOUR_MINUTE or COMPONENT_SECOND
+    }
+
+    var action: SwiftAction? = null
+
+    protected abstract val dateView: View
+    protected abstract val timeView: View
+
+    private var minDate = LocalDateTime.MIN
+    private var maxDate = LocalDateTime.MAX
+
+    protected abstract var currentValue: LocalDateTime
+
+    init {
+        orientation = LinearLayout.HORIZONTAL
+    }
+
+    protected abstract fun applyRange(min: LocalDateTime, max: LocalDateTime)
+
+    var value: LocalDateTime
+        get() = currentValue.coerceIn(minDate, maxDate)
+        set(newValue) {
+            currentValue = newValue.coerceIn(minDate, maxDate)
+        }
+
+    fun setRange(min: LocalDateTime, max: LocalDateTime) {
+        minDate = min
+        maxDate = max
+        applyRange(min, max)
+    }
+
+    fun setComponents(components: Int) {
+        require(components and COMPONENT_MASK == components)
+        require(components != 0)
+
+        dateView.visibility = if (components and COMPONENT_DATE != 0) View.VISIBLE else View.GONE
+        timeView.visibility = if (components and COMPONENT_TIME != 0) View.VISIBLE else View.GONE
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        dateView.isEnabled = enabled
+        timeView.isEnabled = enabled
+        super.setEnabled(enabled)
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/CompactDatePicker.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/CompactDatePicker.kt
@@ -1,0 +1,40 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import androidx.fragment.app.FragmentActivity
+import java.time.LocalDateTime
+
+class CompactDatePicker(activity: FragmentActivity) : AbstractDatePicker(activity) {
+    protected override val dateView = DateButton(activity)
+    protected override val timeView = TimeButton(activity)
+
+    init {
+        val childAction: () -> Unit = {
+            // Clamp to range before calling through to Swift
+            timeView.value = value.toLocalTime()
+            action?.call()
+        }
+
+        dateView.action = childAction
+        timeView.action = childAction
+
+        addView(dateView)
+        addView(timeView)
+    }
+
+    protected override var currentValue: LocalDateTime
+        get() = LocalDateTime.of(dateView.value, timeView.value)
+        set(newValue) {
+            dateView.value = newValue.toLocalDate()
+            timeView.value = newValue.toLocalTime()
+        }
+
+    protected override fun applyRange(min: LocalDateTime, max: LocalDateTime) {
+        dateView.setRange(min, max)
+        timeView.value = value.toLocalTime()
+    }
+
+    fun setForegroundColor(color: Int) {
+        dateView.setTextColor(color)
+        timeView.setTextColor(color)
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/Constants.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/Constants.kt
@@ -1,0 +1,22 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+object Constants {
+    val EPOCH = LocalDateTime.of(1970, 1, 1, 0, 0)
+    
+    val defaultMinDate =
+        try {
+            EPOCH.until(LocalDateTime.MIN, ChronoUnit.MILLIS)
+        } catch (_: ArithmeticException) {
+            Long.MIN_VALUE
+        }
+    
+    val defaultMaxDate =
+        try {
+            EPOCH.until(LocalDateTime.MAX, ChronoUnit.MILLIS)
+        } catch (_: ArithmeticException) {
+            Long.MAX_VALUE
+        }
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/Constants.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/Constants.kt
@@ -5,14 +5,14 @@ import java.time.temporal.ChronoUnit
 
 object Constants {
     val EPOCH = LocalDateTime.of(1970, 1, 1, 0, 0)
-    
+
     val defaultMinDate =
         try {
             EPOCH.until(LocalDateTime.MIN, ChronoUnit.MILLIS)
         } catch (_: ArithmeticException) {
             Long.MIN_VALUE
         }
-    
+
     val defaultMaxDate =
         try {
             EPOCH.until(LocalDateTime.MAX, ChronoUnit.MILLIS)

--- a/Sources/AndroidBackend/Kotlin/datepickers/DateButton.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/DateButton.kt
@@ -1,0 +1,102 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import android.app.DatePickerDialog
+import android.app.Dialog
+import android.icu.text.DateFormat
+import android.icu.util.GregorianCalendar
+import android.icu.util.ULocale
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.FragmentActivity
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class DateButton(private val activity: FragmentActivity) : Button(activity) {
+    private var minDate = Constants.defaultMinDate
+    private var maxDate = Constants.defaultMaxDate
+
+    private var _value = LocalDate.now()
+
+    var action: (() -> Unit)? = null
+
+    private val dialogFragment = DialogFragment()
+
+    var value: LocalDate
+        get() = _value
+        set(newValue) {
+            _value = newValue
+            dialogFragment.datePicker?.updateDate(
+                newValue.year,
+                newValue.monthValue - 1,
+                newValue.dayOfMonth,
+            )
+            updateText()
+        }
+
+    init {
+        dialogFragment.button = this
+
+        isAllCaps = false
+
+        setOnClickListener { _ ->
+            dialogFragment.show(activity.supportFragmentManager, DialogFragment.TAG)
+        }
+
+        updateText()
+    }
+
+    private fun updateText() {
+        val calendar = GregorianCalendar()
+        calendar.set(_value.year, _value.monthValue - 1, _value.dayOfMonth)
+
+        setText(
+            calendar
+                .getDateTimeFormat(DateFormat.LONG, DateFormat.NONE, ULocale.getDefault())
+                .format(calendar.time)
+        )
+    }
+
+    fun setRange(min: LocalDateTime, max: LocalDateTime) {
+        minDate = Constants.EPOCH.until(min, ChronoUnit.MILLIS)
+        maxDate = Constants.EPOCH.until(max, ChronoUnit.MILLIS)
+
+        dialogFragment.datePicker?.minDate = minDate
+        dialogFragment.datePicker?.maxDate = maxDate
+    }
+
+    class DialogFragment : AppCompatDialogFragment() {
+        companion object {
+            const val TAG = "DateButton.DialogFragment"
+        }
+
+        lateinit var button: DateButton
+
+        val datePicker
+            get() = (dialog as DatePickerDialog?)?.datePicker
+
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            val dialog =
+                DatePickerDialog(
+                    requireContext(),
+                    DatePickerDialog.OnDateSetListener { _, year, month, day ->
+                        val newValue = LocalDate.of(year, month + 1, day)
+                        if (newValue != button._value) {
+                            button._value = newValue
+                            button.updateText()
+                            button.action?.invoke()
+                        }
+                    },
+                    button._value.year,
+                    button._value.monthValue - 1,
+                    button._value.dayOfMonth,
+                )
+
+            dialog.datePicker.minDate = button.minDate
+            dialog.datePicker.maxDate = button.maxDate
+
+            return dialog
+        }
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/GraphicalDatePicker.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/GraphicalDatePicker.kt
@@ -1,0 +1,50 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import android.content.Context
+import android.text.format.DateFormat
+import android.widget.DatePicker
+import android.widget.TimePicker
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class GraphicalDatePicker(context: Context) : AbstractDatePicker(context) {
+    protected override val dateView = DatePicker(context)
+    protected override val timeView = TimePicker(context)
+
+    protected override var currentValue = LocalDateTime.now()
+
+    init {
+        dateView.setOnDateChangedListener { _, year, month, day ->
+            currentValue = currentValue.withYear(year).withMonth(month + 1).withDayOfMonth(day)
+
+            adjustTimeForBounds()
+
+            action?.call()
+        }
+
+        timeView.setIs24HourView(DateFormat.is24HourFormat(context))
+        timeView.setOnTimeChangedListener { _, hour, minute ->
+            currentValue = currentValue.withHour(hour).withMinute(minute)
+
+            adjustTimeForBounds()
+
+            action?.call()
+        }
+
+        addView(dateView)
+        addView(timeView)
+    }
+
+    protected override fun applyRange(min: LocalDateTime, max: LocalDateTime) {
+        dateView.minDate = Constants.EPOCH.until(min, ChronoUnit.MILLIS)
+        dateView.maxDate = Constants.EPOCH.until(max, ChronoUnit.MILLIS)
+
+        adjustTimeForBounds()
+    }
+
+    private fun adjustTimeForBounds() {
+        val time = value
+        timeView.hour = time.hour
+        timeView.minute = time.minute
+    }
+}

--- a/Sources/AndroidBackend/Kotlin/datepickers/TimeButton.kt
+++ b/Sources/AndroidBackend/Kotlin/datepickers/TimeButton.kt
@@ -1,0 +1,91 @@
+package dev.swiftcrossui.androidbackend.datepickers
+
+import android.app.Dialog
+import android.app.TimePickerDialog
+import android.icu.util.Calendar
+import android.icu.util.GregorianCalendar
+import android.icu.util.ULocale
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.FragmentActivity
+import java.time.LocalTime
+
+class TimeButton(private val activity: FragmentActivity) : Button(activity) {
+    private var _value = LocalTime.now()
+
+    var action: (() -> Unit)? = null
+
+    private val dialogFragment = DialogFragment()
+
+    var value: LocalTime
+        get() = _value
+        set(newValue) {
+            if (newValue != _value) {
+                _value = newValue
+                (dialogFragment.dialog as TimePickerDialog?)?.updateTime(
+                    newValue.hour,
+                    newValue.minute,
+                )
+                updateText()
+            }
+        }
+
+    init {
+        dialogFragment.button = this
+
+        isAllCaps = false
+
+        setOnClickListener { _ ->
+            dialogFragment.show(activity.supportFragmentManager, DialogFragment.TAG)
+        }
+
+        updateText()
+    }
+
+    private fun updateText() {
+        val calendar = GregorianCalendar()
+        calendar[Calendar.HOUR_OF_DAY] = _value.hour
+        calendar[Calendar.MINUTE] = _value.minute
+
+        setText(
+            calendar
+                .getDateTimeFormat(
+                    android.icu.text.DateFormat.NONE,
+                    android.icu.text.DateFormat.SHORT,
+                    ULocale.getDefault(),
+                )
+                .format(calendar.time)
+        )
+    }
+
+    class DialogFragment : AppCompatDialogFragment() {
+        companion object {
+            val TAG = "TimeButton.DialogFragment"
+        }
+
+        lateinit var button: TimeButton
+
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            val context = requireContext()
+
+            val dialog =
+                TimePickerDialog(
+                    context,
+                    TimePickerDialog.OnTimeSetListener { _, hour, minute ->
+                        val newValue = LocalTime.of(hour, minute)
+                        if (newValue != button._value) {
+                            button._value = newValue
+                            button.updateText()
+                            button.action?.invoke()
+                        }
+                    },
+                    button._value.hour,
+                    button._value.minute,
+                    android.text.format.DateFormat.is24HourFormat(context),
+                )
+
+            return dialog
+        }
+    }
+}


### PR DESCRIPTION
This PR implements preliminary DatePickers on Android. Currently, only the `.compact` style is universally available -- `.graphical` is too big for many devices, and `.wheel` requires XML. Currently, the date picker widget is a FrameLayout that contains an instance of AbstractDatePicker (whose concrete subclasses include GraphicalDatePicker and CompactDatePicker); when #491 is resolved, the FrameLayout can be removed, but for now a single widget needs to be able to handle changing its style on the fly.

Since neither TimePicker nor TimePickerDialog can set a finer resolution than minutes, the "second" bit of DatePickerComponents is currently ignored.