### PR TITLE
Redraw UIKitBackend draw-based gradients on bounds change

### DIFF
--- a/Sources/UIKitBackend/UIKitBackend+Gradient.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Gradient.swift
@@ -104,6 +104,7 @@ final class LinearGradientView: BaseViewWidget {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         self.layer.drawsAsynchronously = true
+        self.contentMode = .redraw
     }
 }
 
@@ -158,6 +159,7 @@ final class RadialGradientView: BaseViewWidget {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         self.layer.drawsAsynchronously = true
+        self.contentMode = .redraw
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #576.

Set `contentMode = .redraw` on the two draw-based UIKit gradient views so they repaint on a bounds change instead of stretching a cached bitmap after device rotation.

## Background

`RadialGradientView` and `LinearGradientView` in the UIKit backend render their gradient inside `draw(_:)`, which UIKit caches into a bitmap. Because their content mode is the default `.scaleToFill`, a bounds change on device rotation stretches that cached bitmap to the new size instead of repainting. The gradient stays distorted until some later event (for example switching to another tab and back) forces `draw(_:)` to run again, which is exactly the behavior reported in the issue.

## Changes

Set `contentMode = .redraw` on both draw-based gradient views inside their existing `didMoveToWindow()` overrides. With `.redraw`, any bounds or size change invalidates the view and forces `draw(_:)` to re-run at the new size, so the gradient repaints correctly on rotation without needing a tab switch.

The angular `GradientView` is unaffected: it is backed by a `CAGradientLayer`, which resizes with its layer automatically, so no change is needed there.

## Testing

Verified against GradientsExample: rotating the simulator while a radial or linear gradient is on screen now repaints the gradient at the new orientation immediately, and the angular gradient continues to render correctly. UIKit backend rendering is exercised on device/simulator; the repository has no UIKit rendering unit-test harness.
