### PR TITLE
WinUIBackend: Implement sheet support

### DIFF
--- a/Examples/Sources/WindowingExample/WindowingApp.swift
+++ b/Examples/Sources/WindowingExample/WindowingApp.swift
@@ -111,6 +111,7 @@ struct SheetDemo: View {
                 Text("Root sheet")
                 Button("Present a nested sheet") {
                     isNestedSheetPresented = true
+                    print("Presented a nested sheet")
                 }
                 Button("Dismiss") {
                     dismiss()

--- a/Package.swift
+++ b/Package.swift
@@ -306,6 +306,8 @@ let package = Package(
                 "SwiftCrossUI",
                 "WinUIInterop",
                 .product(name: "WinUI", package: "swift-winui"),
+                .product(name: "UWP", package: "swift-winui"),
+                .product(name: "CWinRT", package: "swift-winui"),
                 .product(name: "WinAppSDK", package: "swift-winui"),
                 .product(name: "WindowsFoundation", package: "swift-winui"),
                 .product(name: "Mutex", package: "swift-mutex"),

--- a/Sources/WinUIBackend/WinUIBackend+Sheets.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Sheets.swift
@@ -1,0 +1,116 @@
+import SwiftCrossUI
+import UWP
+import WinUI
+import WindowsFoundation
+import CWinRT
+import WinSDK
+
+// swiftlint:disable force_try
+
+extension WinUIBackend: BackendFeatures.Sheets {
+    public class Sheet: ContentDialog {
+        var dismissHandler: (() -> Void)?
+    }
+
+    public func createSheet(content: Widget) -> Sheet {
+        let sheet = Sheet()
+        sheet.content = content
+
+        // When all buttons are unlabelled, WinUI hides the actions section of
+        // the dialog automatically.
+        sheet.primaryButtonText = ""
+        sheet.secondaryButtonText = ""
+        sheet.closeButtonText = ""
+
+        // Sometimes the sheet will have its own default escape key handling,
+        // and sometimes it won't. This accelerator is for the cases where it
+        // doesn't. It's not exactly clear what determines whether this
+        // accelerator is required, but from some testing it seems that sheets
+        // without interactive content don't have escape key handling by default
+        // (e.g. sheets with only text).
+        let accelerator = WinUI.KeyboardAccelerator()
+        accelerator.key = .escape
+        accelerator.invoked.addHandler { [weak sheet] _, _ in
+            guard let sheet else { return }
+            try! sheet.hide()
+            sheet.dismissHandler?()
+        }
+        sheet.keyboardAccelerators.append(accelerator)
+        sheet.keyboardAcceleratorPlacementMode = .hidden
+
+        // The top portion of a ContentDialog (the dialog portion) is an
+        // overlay with its own background color. We hide the action portion
+        // of the dialog to use it as a sheet, so we remove the overlay
+        // background and simply use the dialog's background property to
+        // control the background color of the sheet.
+        _ = sheet.resources.insert("ContentDialogTopOverlay", nil)
+        _ = sheet.resources.insert("ContentDialogSeparatorBorderBrush", nil)
+        _ = sheet.resources.insert("ContentDialogMaxWidth", 1000000 as Double)
+        _ = sheet.resources.insert("ContentDialogMinWidth", 0 as Double)
+        _ = sheet.resources.insert("ContentDialogMaxHeight", 1000000 as Double)
+        _ = sheet.resources.insert("ContentDialogMinHeight", 0 as Double)
+
+        return sheet
+    }
+
+    public func updateSheet(
+        _ sheet: Sheet,
+        window: Window,
+        environment: EnvironmentValues,
+        size: SIMD2<Int>,
+        onDismiss: @escaping () -> Void,
+        cornerRadius: Double?,
+        detents _: [PresentationDetent],
+        dragIndicatorVisibility _: SwiftCrossUI.Visibility,
+        backgroundColor: SwiftCrossUI.Color.Resolved?,
+        interactiveDismissDisabled: Bool
+    ) {
+        sheet.width = Double(size.x)
+        sheet.height = Double(size.y)
+        sheet.dismissHandler = onDismiss
+
+        if let backgroundColor {
+            sheet.background = WinUI.SolidColorBrush(backgroundColor.uwpColor)
+        } else {
+            try! sheet.clearValue(Sheet.backgroundProperty)
+        }
+
+        sheet.requestedTheme = switch environment.colorScheme {
+            case .light: .light
+            case .dark: .dark
+        }
+    }
+
+    public func presentSheet(
+        _ sheet: Sheet,
+        window: Window,
+        parentSheet: Sheet?
+    ) {
+        sheet.xamlRoot = window.content.xamlRoot
+        do {
+            let promise = try sheet.showAsync()!
+            promise.completed = { [weak sheet] _, status in
+                guard let sheet, status == .completed else {
+                    return
+                }
+
+                sheet.dismissHandler?()
+            }
+        } catch {
+            // Force tries don't print properly in some Windows environments, and this
+            // is a particularly useful error to have access to, because there are legitimate
+            // edge cases under which this could be triggered
+            print("Error: \(error)")
+            fatalError("\(error)")
+        }
+    }
+
+    public func dismissSheet(_ sheet: Sheet, window: Window, parentSheet: Sheet?) {
+        print("Dismissing sheet programmatically")
+        try! sheet.hide()
+    }
+
+    public func size(ofSheet sheet: Sheet) -> SIMD2<Int> {
+        .zero
+    }
+}

--- a/Sources/WinUIInterop/dummy.cpp
+++ b/Sources/WinUIInterop/dummy.cpp
@@ -1,3 +1,6 @@
+// Without these, imports, WinUIBackend's SwiftIInitializeWithWindow
+// wrapper class fails to compile.
+
 #include "WinUIInterop.h"
 #include <ShObjIdl.h>
 #include <Windows.h>


### PR DESCRIPTION
This PR introduces sheet support for WinUIBackend.

This implementation has two known issues;

1. It doesn't support nested sheets (due to WinUI limitations), and
2. The sheets have 24 pixels of additional padding around their content

In future, we could implement a workaround for the first issue by hiding the previous sheet before we show the nested sheet, and then re-showing the previous sheet when the nested sheet gets dismissed.

In theory, it should be simple to work around the second issue (by setting the ContentDialogPadding theme resource to `0, 0, 0, 0`). Unfortunately, swift-winui has some deficiencies around passing value types to WinRT APIs. It supports all of the basic value types supported by IPropertyValue, but not arbitrary value types. I've spent many many hours trying to pass a `Thickness` value to the `ResourceDictionary.insert(_:_:)` API, but have so far come up empty handed. I've pushed my latest attempt to the `stackotter/remove_winui_sheet_padding` branch. Those changes rely on some WinUI changes that are sitting on my laptop for now (because they don't work).