### PR TITLE
WinUIBackend: Block in openExternalURL until completed

### DIFF
--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -349,7 +349,15 @@ public final class WinUIBackend:
     }
 
     public func openExternalURL(_ url: URL) throws {
-        _ = UWP.Launcher.launchUriAsync(WindowsFoundation.Uri(url.absoluteString))
+        let promise = UWP.Launcher.launchUriAsync(WindowsFoundation.Uri(url.absoluteString))!
+        let semaphore = DispatchSemaphore(value: 0)
+        promise.completed = { _, status in
+            semaphore.signal()
+            if status != .completed {
+                logger.warning("Failed to open external URL \(url)")
+            }
+        }
+        semaphore.wait()
     }
 
     public func runInMainThread(action: @escaping @MainActor () -> Void) {


### PR DESCRIPTION
We previously didn't wait until UWP actually opened URLs. This led to URLs never getting opened if you immediately exited after calling `openURL`. We now block until the 'async' LaunchUriAsync call completes (by using semaphore). I considered making the `openExternalURL` backend method `async`, but that would've required making the `openURL` environment action asynchronous as well, which would be a rather large breaking change, and doesn't appear to be necessary.

```swift
@Environment(\.openURL) var openURL

// ...

    Button("Open and quit") {
        openURL(URL(string: "...")!)
        Foundation.exit(0)
    }
```