### PR TITLE
ForEach: Add back old menu item inits as deprecated

### DIFF
--- a/Sources/SwiftCrossUI/Views/ForEach.swift
+++ b/Sources/SwiftCrossUI/Views/ForEach.swift
@@ -432,7 +432,73 @@ extension ForEach where Items.Element: Identifiable, ID == Items.Element.ID {
     /// Creates a view that creates child views on demand based on a collection of identifiable data.
     public init(
         _ elements: Items,
-        child: @escaping (Items.Element) -> Child
+        @ViewBuilder _ child: @escaping (Items.Element) -> Child
+    ) {
+        self.elements = elements
+        self.child = child
+        self.idKeyPath = \.id
+    }
+}
+
+// MARK: Deprecated MenuItem-based inits
+
+extension ForEach where ID == Int {
+    /// Creates a view that creates child views on demand based on a collection of data.
+    @available(
+        *,
+        deprecated,
+        message: """
+            ForEach requires an explicit 'id' parameter for non-Identifiable \
+            elements to correctly persist state across view updates
+            """
+    )
+    @_disfavoredOverload
+    public init(
+        menuItems elements: Items,
+        @ViewBuilder _ child: @escaping (Items.Element) -> Child
+    ) {
+        self.elements = elements
+        self.child = child
+        self.idKeyPath = nil
+    }
+}
+
+extension ForEach {
+    /// Creates a view that creates child views on demand based on a collection of data.
+    @available(
+        *,
+        deprecated,
+        renamed: "init(_:id:_:)",
+        message: """
+            Special treatment of menu item ForEach blocks is no longer necessary. \
+            Remove the menuItems parameter label.
+            """
+    )
+    public init(
+        menuItems elements: Items,
+        id keyPath: KeyPath<Items.Element, ID>,
+        @ViewBuilder _ child: @escaping (Items.Element) -> Child
+    ) {
+        self.elements = elements
+        self.child = child
+        self.idKeyPath = keyPath
+    }
+}
+
+extension ForEach where Items.Element: Identifiable, ID == Items.Element.ID {
+    /// Creates a view that creates child views on demand based on a collection of data.
+    @available(
+        *,
+        deprecated,
+        renamed: "init(_:_:)",
+        message: """
+            Special treatment of menu item ForEach blocks is no longer necessary. \
+            Remove the menuItems parameter label.
+            """
+    )
+    public init(
+        menuItems elements: Items,
+        @ViewBuilder _ child: @escaping (Items.Element) -> Child
     ) {
         self.elements = elements
         self.child = child

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -353,10 +353,13 @@ public final class WinUIBackend:
         let semaphore = DispatchSemaphore(value: 0)
         promise.completed = { _, status in
             semaphore.signal()
+
             if status != .completed {
                 logger.warning("Failed to open external URL \(url)")
             }
         }
+
+        // Block until the URL has been launched
         semaphore.wait()
     }
 


### PR DESCRIPTION
This PR adds back the old `init(menuItems:_:)` family of inits that were removed in #629. I've added them back as deprecated inits to provide a smoother update path for existing apps using the now-obselete `menuItems` based inits.

I also added a missing a `@ViewBuilder` annotation that was missing from one of the regular inits.