### PR TITLE
WinUIBackend: Apply stdout fix before App.init

### DIFF
--- a/Sources/SwiftCrossUI/App.swift
+++ b/Sources/SwiftCrossUI/App.swift
@@ -140,6 +140,8 @@ extension App {
 
     /// Runs the application.
     public static func main() {
+        Backend.earlySetup()
+
         extractMetadataAndInitializeLogging()
         let app = Self()
         let backend = app.backend

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Core.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Core/Core.swift
@@ -22,6 +22,17 @@ extension BackendFeatures {
         /// This is used to determine text sizing and other adaptive properties.
         var deviceClass: DeviceClass { get }
 
+        /// Performs early backend setup before a backend is created.
+        ///
+        /// This is useful for backends that want to perform certain setup actions
+        /// before the user's `App.init` implementation runs, such as WinUIBackend
+        /// which has to perform setup in order for `print` to work sensibly for
+        /// GUI apps on Windows.
+        ///
+        /// This is guaranteed to be the first code that runs in SwiftCrossUI's
+        /// default `App.main` implementation.
+        static func earlySetup()
+
         /// Runs the backend's main run loop.
         ///
         /// The app will exit when this method returns. This will always be the
@@ -80,5 +91,13 @@ extension BackendFeatures {
         ///
         /// - Parameter action: The root environment change handler.
         func setRootEnvironmentChangeHandler(to action: @escaping @Sendable @MainActor () -> Void)
+    }
+}
+
+// MARK: Default implementations
+
+extension BackendFeatures.Core {
+    public static func earlySetup() {
+        // Most backends don't have to do any early setup
     }
 }

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -135,6 +135,22 @@ public final class WinUIBackend:
         }
     }
 
+    public static func earlySetup() {
+        do {
+            try Self.attachToParentConsole()
+        } catch {
+            // We essentially just ignore if this fails because it's just a QoL
+            // debugging feature, and if it fails then any warning we print likely
+            // won't get seen anyway. But I don't trust my Windows knowledge enough
+            // to assert that it's impossible to view logs on failure, so let's
+            // print a warning anyway.
+            logger.warning(
+                "failed to attach to parent console",
+                metadata: ["error": "\(error)"]
+            )
+        }
+    }
+
     public func runMainLoop(_ callback: @escaping @MainActor () -> Void) {
         do {
             try Self.attachToParentConsole()


### PR DESCRIPTION
WinUIBackend applies a fix to wire up stdout/stderr to the parent process's console, which allows applications to print debug info to the console etc. That fix is required for any Windows applications that are compiled as GUI apps (which don't get consoles by default).

Before this PR, that fix was only applied once WinUIBackend.runMainLoop got called by SwiftCrossUI, which meant that early print statements in App.init didn't get routed to the console, which made debugging issues during the early phases of startup tricky.

This PR adds a static `earlySetup` requirement to `BackendFeatures.Core` that backends can use to run early setup code before the app's `init` gets invoked. It also adds a WinUIBackend implementation of that method, with the console fix code that previously lived in `runMainLoop`.