### PR TITLE
Set participateInStackLayoutsWhenEmpty to false for EmptyView

### DIFF
--- a/Sources/SwiftCrossUI/Views/EmptyView.swift
+++ b/Sources/SwiftCrossUI/Views/EmptyView.swift
@@ -51,7 +51,7 @@ public struct EmptyView: View, Sendable {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        ViewLayoutResult.leafView(size: .zero)
+        ViewLayoutResult(size: .zero, childResults: [], participateInStackLayoutsWhenEmpty: false)
     }
 
     public func commit<Backend: BaseAppBackend>(

--- a/Sources/SwiftCrossUI/Views/OptionalView.swift
+++ b/Sources/SwiftCrossUI/Views/OptionalView.swift
@@ -76,7 +76,11 @@ extension OptionalView: TypeSafeView {
         } else {
             hasToggled = children.node != nil
             children.node = nil
-            result = ViewLayoutResult.leafView(size: .zero)
+            result = ViewLayoutResult(
+                size: .zero,
+                childResults: [],
+                participateInStackLayoutsWhenEmpty: false
+            )
         }
         children.hasToggled = children.hasToggled || hasToggled
 


### PR DESCRIPTION
Fixes #416 

Turns out EmptyView and empty OptionalView set `participateInStackLayoutsWhenEmpty` to true. Setting this to false removes the extra padding observed in #416 and #656.

For the record, I tested empty ForEach as well, and that seems to already work correctly.