### PR TITLE
Add public accessor for getting ResolvedMenu from View

### DIFF
--- a/Sources/Gtk/GObject.swift
+++ b/Sources/Gtk/GObject.swift
@@ -23,7 +23,7 @@ open class GObject: GObjectRepresentable {
         for (id, _) in signals {
             g_signal_handler_disconnect(gobjectPointer, id)
         }
-  
+
         g_object_unref(gobjectPointer)
     }
 

--- a/Sources/Gtk3/GObject.swift
+++ b/Sources/Gtk3/GObject.swift
@@ -29,7 +29,7 @@ open class GObject: GObjectRepresentable {
 
             disconnectSignal(gobjectPointer, handlerId: handlerId)
         }
-      
+
         g_object_unref(gobjectPointer)
     }
 

--- a/Sources/Gtk3/Widgets/Widget.swift
+++ b/Sources/Gtk3/Widgets/Widget.swift
@@ -108,7 +108,7 @@ open class Widget: GObject {
             self.styleUpdated?()
         }
     }
-  
+
     public func queueDraw() {
         gtk_widget_queue_draw(widgetPointer)
     }

--- a/Sources/SwiftCrossUI/Views/View.swift
+++ b/Sources/SwiftCrossUI/Views/View.swift
@@ -245,4 +245,13 @@ extension View {
     }
 
     public var _asMenuItems: [MenuItem] { body._asMenuItems }
+
+    /// Resolves this view's menu content to the representation used by backends.
+    ///
+    /// This is the same resolution applied to ``Menu`` content and scene ``Commands``.
+    /// - Returns: The resolved menu.
+    @MainActor
+    public func _resolvedMenuContent() -> ResolvedMenu {
+        Menu.resolve(items: _asMenuItems)
+    }
 }

--- a/Sources/SwiftCrossUI/Views/View.swift
+++ b/Sources/SwiftCrossUI/Views/View.swift
@@ -251,7 +251,7 @@ extension View {
     /// This is the same resolution applied to ``Menu`` content and scene ``Commands``.
     /// - Returns: The resolved menu.
     @MainActor
-    public func _resolvedMenuContent() -> ResolvedMenu {
+    @_spi(Backends) public func resolvedMenuContent() -> ResolvedMenu {
         Menu.resolve(items: _asMenuItems)
     }
 }


### PR DESCRIPTION
All this does is simply add a public way to get ResolvedMenu from a view.

i specifically needed it for something i was working on, but couldnt find a way to do it "correctly"

I was unsure whether it was best to make the current resolve func public, or add a new one prefixed with _ to signal it isnt a "normal feature everyone will use" - so please tell me if it should be put somewhere else / if its completely out of scope :3

(The other files changed were just formatting from swiftformat)

I'd be surprised if this would break anything, but i tested anyways uwu

Tested on:
Arch Linux x64 (7.0.3-zen)
macOS 27.0 arn64 (m2)
Winslop 11 25H2 (26200)