### PR TITLE
WinUIBackend: Support displaying multiple alerts at once

### DIFF
--- a/Sources/WinUIBackend/WinUIBackend+Alerts.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Alerts.swift
@@ -1,0 +1,112 @@
+@_spi(Backends) import SwiftCrossUI
+import WinUI
+
+// swiftlint:disable force_try
+
+extension WinUIBackend: BackendFeatures.Alerts {
+    public class Alert: ContentDialog {
+        var window: Window?
+        var parentAlert: Alert?
+        var handleResponse: ((Int) -> Void)?
+        var ignoreNextDismissal = false
+
+        /// Shows an alert that has already been attached to a window (via xamlRoot),
+        /// and attached to the alert stack (via parentAlert and updating
+        /// window.currentAlert)
+        func showAttached() {
+            let promise = try! showAsync()!
+            promise.completed = { [weak self] operation, status in
+                guard
+                    let self,
+                    status == .completed,
+                    let operation,
+                    let result = try? operation.getResults()
+                else {
+                    return
+                }
+
+                if !self.ignoreNextDismissal {
+                    // If the alert was shown over the top of another alert, show
+                    // the parent alert
+                    self.window?.currentAlert = self.parentAlert
+                    self.parentAlert?.showAttached()
+
+                    let index =
+                        switch result {
+                            case .primary: 0
+                            case .secondary: 1
+                            case .none: 2
+                            default:
+                                fatalError("WinUIBackend: Invalid dialog response")
+                        }
+                    self.handleResponse?(index)
+                } else {
+                    self.ignoreNextDismissal = false
+                }
+            }
+        }
+    }
+
+    public func createAlert() -> Alert {
+        Alert()
+    }
+
+    public func updateAlert(
+        _ alert: Alert,
+        title: String,
+        actionLabels: [String],
+        environment: EnvironmentValues
+    ) {
+        alert.title = title
+        if actionLabels.count >= 1 {
+            alert.primaryButtonText = actionLabels[0]
+        }
+        if actionLabels.count >= 2 {
+            alert.secondaryButtonText = actionLabels[1]
+        }
+        if actionLabels.count >= 3 {
+            alert.closeButtonText = actionLabels[2]
+        }
+
+        switch environment.colorScheme {
+            case .light:
+                alert.requestedTheme = .light
+            case .dark:
+                alert.requestedTheme = .dark
+        }
+    }
+
+    public func showAlert(
+        _ alert: Alert,
+        window: Window?,
+        responseHandler handleResponse: @escaping (Int) -> Void
+    ) {
+        // WinUI only allows one dialog at a time so we limit ourselves using
+        // a semaphore.
+        guard let window = window ?? windows.first else {
+            logger.warning("WinUI can't show alert without window")
+            return
+        }
+
+        alert.xamlRoot = window.content.xamlRoot
+        alert.window = window
+
+        // WinUI only allows one dialog at a time (subsequent dialogs throw
+        // exceptions), so we hide any existing alert before showing the new one
+        if let currentAlert = window.currentAlert {
+            currentAlert.ignoreNextDismissal = true
+            try! currentAlert.hide()
+            alert.parentAlert = currentAlert
+        }
+
+        window.currentAlert = alert
+        alert.handleResponse = handleResponse
+        alert.showAttached()
+    }
+
+    public func dismissAlert(_ alert: Alert, window: Window?) {
+        try! alert.hide()
+        alert.window?.currentAlert = alert.parentAlert
+        alert.parentAlert?.showAttached()
+    }
+}

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -41,7 +41,6 @@ public final class WinUIBackend:
     BackendFeatures.ExternalURLs,
     BackendFeatures.IncomingURLs,
     BackendFeatures.FileDialogs,
-    BackendFeatures.Alerts,
     BackendFeatures.CornerRadius,
     BackendFeatures.Gestures,
     BackendFeatures.AttachedMenus,
@@ -79,7 +78,6 @@ public final class WinUIBackend:
     public typealias Window = CustomWindow
     public typealias Widget = WinUI.FrameworkElement
     public typealias Menu = WinUI.MenuFlyout
-    public typealias Alert = WinUI.ContentDialog
     public typealias Path = GeometryGroupHolder
 
     public let defaultTableRowContentHeight = 20
@@ -115,11 +113,8 @@ public final class WinUIBackend:
 
     var internalState: InternalState
     nonisolated(unsafe) private var dispatcherQueue: WinAppSDK.DispatcherQueue?
-    /// WinUI only allows one dialog at a time (subsequent dialogs throw
-    /// exceptions), so we limit ourselves.
-    private var dialogSemaphore = DispatchSemaphore(value: 1)
 
-    private var windows: [Window] = []
+    var windows: [Window] = []
 
     private var measurementTextBlock: TextBlock!
 
@@ -1507,75 +1502,6 @@ public final class WinUIBackend:
         }
     }
 
-    public func createAlert() -> Alert {
-        ContentDialog()
-    }
-
-    public func updateAlert(
-        _ alert: Alert,
-        title: String,
-        actionLabels: [String],
-        environment: EnvironmentValues
-    ) {
-        alert.title = title
-        if actionLabels.count >= 1 {
-            alert.primaryButtonText = actionLabels[0]
-        }
-        if actionLabels.count >= 2 {
-            alert.secondaryButtonText = actionLabels[1]
-        }
-        if actionLabels.count >= 3 {
-            alert.closeButtonText = actionLabels[2]
-        }
-
-        switch environment.colorScheme {
-            case .light:
-                alert.requestedTheme = .light
-            case .dark:
-                alert.requestedTheme = .dark
-        }
-    }
-
-    public func showAlert(
-        _ alert: Alert,
-        window: Window?,
-        responseHandler handleResponse: @escaping (Int) -> Void
-    ) {
-        // WinUI only allows one dialog at a time so we limit ourselves using
-        // a semaphore.
-        guard let window = window ?? windows.first else {
-            logger.warning("WinUI can't show alert without window")
-            return
-        }
-
-        alert.xamlRoot = window.content.xamlRoot
-        dialogSemaphore.wait()
-        let promise = try! alert.showAsync()!
-        promise.completed = { operation, status in
-            self.dialogSemaphore.signal()
-            guard
-                status == .completed,
-                let operation,
-                let result = try? operation.getResults()
-            else {
-                return
-            }
-            let index =
-                switch result {
-                    case .primary: 0
-                    case .secondary: 1
-                    case .none: 2
-                    default:
-                        fatalError("WinUIBackend: Invalid dialog response")
-                }
-            handleResponse(index)
-        }
-    }
-
-    public func dismissAlert(_ alert: Alert, window: Window?) {
-        try! alert.hide()
-    }
-
     public func showOpenDialog(
         fileDialogOptions: FileDialogOptions,
         openDialogOptions: OpenDialogOptions,
@@ -2291,6 +2217,7 @@ public class CustomWindow: WinUI.Window {
     var grid: WinUI.Grid
     var cachedAppWindow: WinAppSDK.AppWindow!
     var isActive = false
+    var currentAlert: WinUIBackend.Alert?
 
     private(set) var menuBarIsVisible = false
 


### PR DESCRIPTION
WinUI doesn't support displaying multiple alerts at once, so we were using a semaphore to make sure only one alert can be shown at a time, but that actually just replaces an internal WinUI crash with a deadlock of our own creation.

This PR refactors the WinUI alert system so that displaying an alert while another alert is already visible hides the existing alert to be shown again later when the new alert gets dismissed.