### PR TITLE
Add `textCase(_:)` modifier

### DIFF
--- a/Examples/Sources/FontsExample/FontsApp.swift
+++ b/Examples/Sources/FontsExample/FontsApp.swift
@@ -6,7 +6,7 @@ struct FontsApp: App {
     @State var isEmphasized = false
     @State var isMonospaced = false
     @State var isItalics = false
-    @State var textCase: Text.Case? = nil
+    @State var textCase: OptionalTextCase? = .unset
 
     let fonts: [Font] = [
         .largeTitle,
@@ -28,7 +28,10 @@ struct FontsApp: App {
                 Toggle("Emphasize text", isOn: $isEmphasized)
                 Toggle("Monospaced text", isOn: $isMonospaced)
                 Toggle("Italics", isOn: $isItalics)
-                Picker(of: [Text.Case.uppercase, .lowercase], selection: $textCase)
+                HStack {
+                    Text("Text case:")
+                    Picker(of: OptionalTextCase.allCases, selection: $textCase)
+                }
 
                 ForEach(fonts, id: \.self) { font in
                     Text("The quick brown fox jumps over the lazy dog.")
@@ -38,10 +41,33 @@ struct FontsApp: App {
                                 .monospaced(isMonospaced)
                                 .italic(isItalics)
                         )
-                        .textCase(textCase)
+                        .textCase(textCase?.textCase)
                 }
             }
             .toggleStyle(.checkbox)
+        }
+    }
+}
+
+// TODO(kaleb): Remove this hacky enum once we can apply arbitrary labels to picker options.
+enum OptionalTextCase: CaseIterable, CustomStringConvertible {
+    case uppercase
+    case lowercase
+    case unset
+
+    var textCase: Text.Case? {
+        switch self {
+            case .uppercase: .uppercase
+            case .lowercase: .lowercase
+            case .unset: nil
+        }
+    }
+
+    var description: String {
+        switch self {
+            case .uppercase: "Uppercase"
+            case .lowercase: "Lowercase"
+            case .unset: "Unset"
         }
     }
 }

--- a/Examples/Sources/FontsExample/FontsApp.swift
+++ b/Examples/Sources/FontsExample/FontsApp.swift
@@ -6,6 +6,7 @@ struct FontsApp: App {
     @State var isEmphasized = false
     @State var isMonospaced = false
     @State var isItalics = false
+    @State var textCase: Text.Case? = nil
 
     let fonts: [Font] = [
         .largeTitle,
@@ -27,6 +28,7 @@ struct FontsApp: App {
                 Toggle("Emphasize text", isOn: $isEmphasized)
                 Toggle("Monospaced text", isOn: $isMonospaced)
                 Toggle("Italics", isOn: $isItalics)
+                Picker(of: [Text.Case.uppercase, .lowercase], selection: $textCase)
 
                 ForEach(fonts, id: \.self) { font in
                     Text("The quick brown fox jumps over the lazy dog.")
@@ -36,6 +38,7 @@ struct FontsApp: App {
                                 .monospaced(isMonospaced)
                                 .italic(isItalics)
                         )
+                        .textCase(textCase)
                 }
             }
             .toggleStyle(.checkbox)

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -269,6 +269,11 @@ extension EnvironmentValues {
     /// How lines should be aligned relative to each other when line wrapped.
     @Entry public var multilineTextAlignment: HorizontalAlignment = .leading
 
+    /// Whether to override the case of displayed ``Text`` views.
+    ///
+    /// `nil` displays the text without any case changes.
+    @Entry public var textCase: Text.Case?
+
     /// The current color scheme of the current view scope.
     @Entry public var colorScheme: ColorScheme = .light
 
@@ -423,6 +428,9 @@ extension EnvironmentValues {
     /// The current time zone that views should use when handling dates.
     @Entry public var timeZone: TimeZone = .current
 
+    /// The current locale.
+    @Entry public var locale: Locale = .current
+
     /// The display style used by ``Picker``.
     @Entry public var pickerStyle: any PickerStyle = .automatic
 
@@ -449,6 +457,21 @@ extension EnvironmentValues {
     @MainActor
     public var deviceClass: DeviceClass { backend.deviceClass }
 }
+
+extension EnvironmentValues {
+    func applyingTextTransforms(to string: String) -> String {
+        var string = string
+
+        switch textCase {
+            case .lowercase: string = string.lowercased(with: locale)
+            case .uppercase: string = string.uppercased(with: locale)
+            case nil: break
+        }
+
+        return string
+    }
+}
+
 
 /// A key that can be used to extend the environment with new properties.
 public protocol EnvironmentKey<Value> {

--- a/Sources/SwiftCrossUI/Values/TextCase.swift
+++ b/Sources/SwiftCrossUI/Values/TextCase.swift
@@ -1,0 +1,9 @@
+extension Text {
+    /// How to transform the capitalization of text.
+    public enum Case: Hashable, Sendable {
+        /// Makes text all lowercase.
+        case lowercase
+        /// Makes text all uppercase.
+        case uppercase
+    }
+}

--- a/Sources/SwiftCrossUI/Views/Modifiers/Style/TextCaseModifier.swift
+++ b/Sources/SwiftCrossUI/Views/Modifiers/Style/TextCaseModifier.swift
@@ -1,0 +1,8 @@
+extension View {
+    /// Transforms the case of ``Text`` views.
+    ///
+    /// - Parameter textCase: The new text case.
+    public func textCase(_ textCase: Text.Case?) -> some View {
+        environment(\.textCase, textCase)
+    }
+}

--- a/Sources/SwiftCrossUI/Views/Text.swift
+++ b/Sources/SwiftCrossUI/Views/Text.swift
@@ -75,11 +75,14 @@ extension Text: ElementaryView {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
+        let transformedString = environment.applyingTextTransforms(to: string)
+
         // TODO: Avoid this. Move it to commit once we figure out a solution for Gtk.
         // Even in dry runs we must update the underlying text view widget
         // because GtkBackend currently relies on querying the widget for text
         // properties and such (via Pango).
-        backend.updateTextView(widget, content: string, environment: environment)
+        backend
+            .updateTextView(widget, content: transformedString, environment: environment)
 
         // UI frameworks often handle the zero proposal specially. We want to
         // have standard text sizing behaviour so it's better for us to never
@@ -96,7 +99,7 @@ extension Text: ElementaryView {
         // A zero height proposal should result in the text using at least one
         // line of height (if non-empty).
         var size = backend.size(
-            of: string,
+            of: transformedString,
             whenDisplayedIn: widget,
             proposedWidth: proposedSize.width.flatMap {
                 // For text, an infinite proposal is the same as an unspecified


### PR DESCRIPTION
Currently it only applies to `Text` views; we'll probably want to respect the modifier in other views too.