### PR TITLE
WinUIBackend: filter backdrop console noise (#204)

### DIFF
--- a/Sources/WinUIBackend/Console.swift
+++ b/Sources/WinUIBackend/Console.swift
@@ -1,6 +1,10 @@
 import Foundation
 import WinSDK
 
+#if canImport(CRT)
+    import CRT
+#endif
+
 extension WinUIBackend {
     /// Attaches the app's standard IO streams to the parent's console.
     ///
@@ -25,7 +29,7 @@ extension WinUIBackend {
         guard
             freopen_s(&fp, "NUL:", "r", stdin) == 0,
             freopen_s(&fp, "NUL:", "w", stdout) == 0,
-            freopen_s(&fp, "NUL:", "w", stdout) == 0,
+            freopen_s(&fp, "NUL:", "w", stderr) == 0,
             FreeConsole()
         else {
             throw Error(message: "Failed to release existing console")
@@ -37,11 +41,107 @@ extension WinUIBackend {
         var fp = UnsafeMutablePointer<FILE>?.none
         guard
             freopen_s(&fp, "CONIN$", "r", stdin) == 0,
-            freopen_s(&fp, "CONOUT$", "w", stdout) == 0,
             freopen_s(&fp, "CONOUT$", "w", stderr) == 0
         else {
             throw Error(message: "Failed to redirect console IO")
         }
+        try redirectFilteredStandardOutput()
+    }
+
+    /// Redirects stdout into a pipe drained by a background thread that
+    /// filters out noise before writing to the console.
+    ///
+    /// Microsoft.UI.Xaml.dll from WindowsAppSDK 1.5 preview prints backdrop
+    /// debugging messages (BVI-*, rcBackdropLocal=, and bare matrix/rect
+    /// value lines) straight to stdout whenever an acrylic backdrop
+    /// re-renders, and apps have no switch to turn them off. stderr is left
+    /// attached directly to the console so that crash output can't get lost
+    /// in the pipe. Remove this filter once we're on a stable WindowsAppSDK
+    /// (#204).
+    private static func redirectFilteredStandardOutput() throws {
+        var pipeEnds = [CInt](repeating: 0, count: 2)
+        guard _pipe(&pipeEnds, 65536, _O_BINARY) == 0 else {
+            throw Error(message: "Failed to create console filter pipe")
+        }
+        let readEnd = pipeEnds[0]
+        let writeEnd = pipeEnds[1]
+
+        guard _dup2(writeEnd, _fileno(stdout)) == 0 else {
+            throw Error(message: "Failed to redirect stdout to console filter pipe")
+        }
+        // The pipe isn't a console, so the CRT switches stdout to full
+        // buffering; disable buffering so output flows through immediately.
+        setvbuf(stdout, nil, _IONBF, 0)
+
+        // Cover code that writes directly to GetStdHandle(STD_OUTPUT_HANDLE)
+        // as well.
+        SetStdHandle(
+            STD_OUTPUT_HANDLE,
+            UnsafeMutableRawPointer(bitPattern: _get_osfhandle(writeEnd))
+        )
+
+        var consoleFile = UnsafeMutablePointer<FILE>?.none
+        guard fopen_s(&consoleFile, "CONOUT$", "w") == 0, let console = consoleFile else {
+            throw Error(message: "Failed to open console for filtered output")
+        }
+        let consoleAddress = UInt(bitPattern: console)
+
+        Thread.detachNewThread {
+            let console = UnsafeMutablePointer<FILE>(bitPattern: consoleAddress)!
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var pending = ""
+            var lastLineWasNoise = false
+            while true {
+                let count = _read(readEnd, &buffer, UInt32(buffer.count))
+                guard count > 0 else { break }
+                pending += String(decoding: buffer[0..<Int(count)], as: UTF8.self)
+                while let newlineIndex = pending.firstIndex(of: "\n") {
+                    var line = String(pending[..<newlineIndex])
+                    pending = String(pending[pending.index(after: newlineIndex)...])
+                    if line.hasSuffix("\r") {
+                        line.removeLast()
+                    }
+                    if isBackdropDebugNoise(line, afterNoiseLine: lastLineWasNoise) {
+                        lastLineWasNoise = true
+                        continue
+                    }
+                    lastLineWasNoise = false
+                    fputs(line + "\n", console)
+                    fflush(console)
+                }
+            }
+
+            if !pending.isEmpty {
+                if pending.hasSuffix("\r") {
+                    pending.removeLast()
+                }
+                if !isBackdropDebugNoise(pending, afterNoiseLine: lastLineWasNoise) {
+                    fputs(pending, console)
+                    fflush(console)
+                }
+            }
+        }
+    }
+
+    /// Decides whether a single output line is WinUI backdrop debugging noise.
+    private nonisolated static func isBackdropDebugNoise(
+        _ line: String,
+        afterNoiseLine: Bool
+    ) -> Bool {
+        // The noise blocks are interleaved with blank lines; drop blank lines
+        // that directly follow a noise line.
+        if line.isEmpty {
+            return afterNoiseLine
+        }
+        if line.hasPrefix("BVI-") || line.hasPrefix("rcBackdropLocal=") {
+            return true
+        }
+        // Bare matrix/rect value lines contain only digits and light
+        // punctuation, e.g. "(1.25, 0.00, 0.00, 0.00), ..." or
+        // "0.00, 0.00, 12.00, 339.20 (12.00 x 339.20)". Only filter them
+        // after an explicit backdrop noise prefix so normal numeric stdout
+        // such as "12345" still reaches the console.
+        return afterNoiseLine && line.allSatisfy { "0123456789.,-() x".contains($0) }
     }
 
     /// Adjusts the size of the app's console output buffer.


### PR DESCRIPTION
Temp fixes for WinSDK1.5 console noise issue.
It might not be necessary for WinSDK2.
