### PR TITLE
GtkBackend: opt-in bottom anchoring for ScrollView

### DIFF
--- a/Sources/Gtk/Widgets/ScrolledWindow.swift
+++ b/Sources/Gtk/Widgets/ScrolledWindow.swift
@@ -3,6 +3,55 @@ import CGtk
 public class ScrolledWindow: Widget {
     var child: Widget?
 
+    /// Stick-to-bottom anchoring for streaming content. While enabled, the
+    /// view stays pinned to the newest content as it grows when the scrollbar
+    /// was within range of the bottom before the growth; scrolling up
+    /// releases the pin, and scrolling back near the bottom re-engages it on
+    /// the next growth. Off by default; opt in per scroll view via the
+    /// `scrollAnchorsToBottom` environment value.
+    public var anchorsToBottom = false {
+        didSet { installBottomAnchor() }
+    }
+    /// The adjustment's `upper` as of the last change; compared against the
+    /// pre-change scroll geometry to decide whether the user was at the
+    /// bottom when new content arrived.
+    private var lastUpper = 0.0
+    private var bottomAnchorInstalled = false
+
+    private func installBottomAnchor() {
+        guard !bottomAnchorInstalled, let adjustment = gtk_scrolled_window_get_vadjustment(opaquePointer)
+        else { return }
+        bottomAnchorInstalled = true
+        let onChanged: @convention(c) (OpaquePointer?, UnsafeMutableRawPointer?) -> Void = { _, data in
+            guard let data else { return }
+            let owner = Unmanaged<ScrolledWindow>.fromOpaque(data).takeUnretainedValue()
+            owner.snapToBottomIfAnchored()
+        }
+        // Retained: one box per scroll container, outlives the signals.
+        let box = Unmanaged.passRetained(self).toOpaque()
+        g_signal_connect_data(adjustment, "changed", unsafeBitCast(onChanged, to: GCallback.self), box, nil, GConnectFlags(rawValue: 0))
+    }
+
+    /// Distance from the bottom that still counts as "at the bottom".
+    private static let bottomSlack = 120.0
+
+    private func snapToBottomIfAnchored() {
+        guard let adjustment = gtk_scrolled_window_get_vadjustment(opaquePointer) else { return }
+        let value = gtk_adjustment_get_value(adjustment)
+        let pageSize = gtk_adjustment_get_page_size(adjustment)
+        let upper = gtk_adjustment_get_upper(adjustment)
+        // Read the pre-change geometry before updating lastUpper: when GTK
+        // coalesces two growths into one signal, writing first would make a
+        // scrolled-up user look "at bottom" and get yanked down.
+        let wasAtBottom = value + pageSize >= lastUpper - Self.bottomSlack
+        lastUpper = upper
+        guard anchorsToBottom, wasAtBottom, upper > pageSize else { return }
+        let target = upper - pageSize
+        if abs(gtk_adjustment_get_value(adjustment) - target) > 1 {
+            gtk_adjustment_set_value(adjustment, target)
+        }
+    }
+
     public convenience init() {
         self.init(gtk_scrolled_window_new())
     }

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -689,6 +689,7 @@ public final class GtkBackend:
         hasVerticalScrollBar: Bool
     ) {
         let scrollView = scrollView as! ScrolledWindow
+        scrollView.anchorsToBottom = environment.scrollAnchorsToBottom
         scrollView.setScrollBarPresence(
             hasVerticalScrollBar: hasVerticalScrollBar,
             hasHorizontalScrollBar: hasHorizontalScrollBar

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -437,6 +437,11 @@ extension EnvironmentValues {
     /// The number of lines text can occupy and whether to reserve that space.
     @Entry public var lineLimitSettings: LineLimit?
 
+    /// Whether a scroll view pins itself to the bottom as content grows
+    /// (transcript-style), releasing when the user scrolls up and
+    /// re-engaging when they scroll back near the bottom. Off by default.
+    @Entry public var scrollAnchorsToBottom: Bool = false
+
     /// The maximum number of lines that text can occupy in a view.
     public var lineLimit: Int? {
         lineLimitSettings?.limit


### PR DESCRIPTION
## Problem

Chat/log-style views have no way to stay pinned to the newest content: the vertical adjustment's `value` stays at an absolute offset while `upper` grows, so a streaming transcript visibly jumps as entries arrive. There is no scroll API in the framework at all today (the ScrollView docs acknowledge it).

## What this adds

- `ScrolledWindow.anchorsToBottom` (GTK backend), off by default.
- A `scrollAnchorsToBottom` environment value so individual scroll views opt in — the rail/lists keep their normal behavior.

On each adjustment `changed` signal, the anchor snaps `value = upper - pageSize`, **but only when the pre-growth geometry was within 120pt of the bottom**:

| Situation | Behavior |
|---|---|
| Content opens taller than the viewport | Lands on the newest entries |
| Growth while at bottom | Follows every delta |
| Growth while scrolled up | Stays put — no fighting the user |
| Back within 120pt of the bottom | Re-engages on the next growth |

The geometry is read **before** updating `lastUpper`: GTK coalesces multiple growths into one `changed` signal, so writing first would make a scrolled-up user look at-bottom and get yanked down (caught by the included reasoning in tests downstream).

## Notes

- 120pt slack reads well at default body sizes; easy to expose later if wanted.
- No behavior change for existing users — the anchor installs only when the environment flag is set.

Dogfooded in a transcript-heavy GTK4 app (streaming sessions over a websocket): pinned open, follow-stream, and release-without-drift all verified.