### PR TITLE
GtkBackend: skip no-op resize operations

### DIFF
--- a/Sources/Gtk/Widgets/Fixed.swift
+++ b/Sources/Gtk/Widgets/Fixed.swift
@@ -39,6 +39,9 @@ import CGtk
 /// widget. But you should be aware of the tradeoffs.
 open class Fixed: Widget {
     public var children: [Widget] = []
+    /// Last layout position per child, so backends can skip no-op
+    /// `gtk_fixed_move` calls (each one queues a resize).
+    public var lastPositions: [ObjectIdentifier: SIMD2<Int>] = [:]
 
     /// Creates a new `GtkFixed`.
     public init() {
@@ -65,6 +68,7 @@ open class Fixed: Widget {
         if let index = children.firstIndex(where: { $0 === child }) {
             gtk_fixed_remove(castedPointer(), child.widgetPointer)
             children.remove(at: index)
+            lastPositions[ObjectIdentifier(child)] = nil
             child.parentWidget = nil
         }
     }
@@ -75,5 +79,6 @@ open class Fixed: Widget {
             child.parentWidget = nil
         }
         children = []
+        lastPositions = [:]
     }
 }

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -583,7 +583,16 @@ public final class GtkBackend:
 
     public func setPosition(ofChildAt index: Int, in container: Widget, to position: SIMD2<Int>) {
         let container = container as! Fixed
-        container.move(container.children[index], x: Double(position.x), y: Double(position.y))
+        let child = container.children[index]
+        // gtk_fixed_move calls gtk_widget_queue_resize, and during
+        // size_allocate that re-triggers allocation — an infinite loop when
+        // a layout oscillates by a pixel. Skip no-op and sub-pixel moves.
+        let key = ObjectIdentifier(child)
+        if let last = container.lastPositions[key], abs(last.x - position.x) <= 1, abs(last.y - position.y) <= 1 {
+            return
+        }
+        container.lastPositions[key] = position
+        container.move(child, x: Double(position.x), y: Double(position.y))
     }
 
     public func remove(childAt index: Int, from container: Widget) {
@@ -630,6 +639,12 @@ public final class GtkBackend:
     }
 
     public func setSize(of widget: Widget, to size: SIMD2<Int>) {
+        // gtk_widget_set_size_request calls gtk_widget_queue_resize
+        // unconditionally, so re-applying the same size every layout pass
+        // re-triggers allocation forever (GTK warns "queue_resize() during
+        // size_allocate()" and the main thread pins). Skip no-op sets.
+        let current = widget.getSizeRequest()
+        guard current.width != size.x || current.height != size.y else { return }
         widget.setSizeRequest(width: size.x, height: size.y)
     }
 


### PR DESCRIPTION
## Problem

`gtk_widget_set_size_request` and `gtk_fixed_move` both call `gtk_widget_queue_resize()` unconditionally. On dense views the layout engine re-applies *identical* sizes and positions every pass, so GTK re-runs allocation continuously — the log fills with `queue_resize() during size_allocate()` warnings and the main thread pins at 100%.

## Changes

- **`setSize(of:to:)`** — skip when the size request is unchanged.
- **`setPosition(ofChildAt:in:to:)`** — track last-applied positions on `Fixed` and skip no-op and sub-pixel moves (≤1px). Besides avoiding the redundant queue_resize storm, this breaks the oscillating resize → allocate → resize loop that happens when a layout jitters by a single pixel (a real livelock observed in practice).

No layout outcome changes — identical requests are simply not re-issued.

## Evidence

Dogfooded on a dense GTK4 workspace (rail + transcript + panes): before, the app burned a core while idle on a connected session; after, it idles.
