### PR TITLE
GtkBackend: stop scroll views propagating content natural width

### DIFF
--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -676,6 +676,13 @@ public final class GtkBackend:
 
     public func createScrollContainer(for child: Widget) -> Widget {
         let scrollView = ScrolledWindow()
+        // Never propagate the content's natural width. Wrapped text reports
+        // its unwrapped one-line width as its natural width, which inflates
+        // every ancestor's natural width until a container that honors
+        // naturals allocates the scroll view wider than the window — and the
+        // overflow clips content off the window's trailing edge. The scroll
+        // view's own size comes from the layout, not from its content.
+        gtk_scrolled_window_set_propagate_natural_width(scrollView.opaquePointer, 0)
         scrollView.setChild(child)
         return scrollView
     }


### PR DESCRIPTION
## Problem

Wrapped text reports its *unwrapped* one-line width as its natural width. With `propagate-natural-width` on (the `GtkScrolledWindow` default), that natural width bubbles up through every ancestor's natural size, and any container that honors naturals — split panes, fixed-position containers — ends up allocating the scroll view **wider than the window**. The overflow then clips content off the window's trailing edge: long lines render past the visible area instead of wrapping at the viewport width.

In SwiftCrossUI this bites any app with long text inside a ScrollView beside other content (rail + detail layouts): the detail pane can end up laid out wider than the window itself.

## Change

Disable natural-width propagation in `createScrollContainer`. The layout system already decides scroll view sizes itself — propagating the content's natural width can only inflate them.

## Evidence

Measured on a rail+detail GTK4 workspace: the detail pane's natural width reached ~2700px from unwrapped label widths and the split paned allocated it past the window edge, right-clipping transcript lines. With propagation off, content wraps at the viewport width and nothing crosses the window edge (verified pixel-precisely).
